### PR TITLE
Harden ApprovalTokenService::validateToken (closes #17)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
@@ -86,18 +86,47 @@ class ApprovalTokenService {
    */
   public function validateToken(int $submission_id, int $parent_number, string $token): bool {
     try {
+      // Strict decode: rejects whitespace and non-base64 characters that
+      // would otherwise round-trip silently.
       $decoded = base64_decode($token, TRUE);
-      if (!$decoded) {
+      if ($decoded === FALSE || $decoded === '') {
         $this->logger->warning('Invalid token format for submission @sid', [
           '@sid' => $submission_id,
         ]);
         return FALSE;
       }
 
-      [$hash, $timestamp] = explode(':', $decoded, 2);
+      // Guard the destructure: a token without ':' would PHP-fatal on
+      // unconditional list-assignment, and an empty $timestamp would
+      // coerce to (int) 0 which is "valid in 1970".
+      $parts = explode(':', $decoded, 2);
+      if (count($parts) !== 2) {
+        $this->logger->warning('Malformed token (no separator) for submission @sid', [
+          '@sid' => $submission_id,
+        ]);
+        return FALSE;
+      }
+      [$hash, $timestamp_raw] = $parts;
+
+      // Range-check the timestamp: must be numeric, positive, and not
+      // implausibly far in the future. One hour of clock-drift slack.
+      if (!is_numeric($timestamp_raw)) {
+        $this->logger->warning('Non-numeric timestamp in token for submission @sid', [
+          '@sid' => $submission_id,
+        ]);
+        return FALSE;
+      }
+      $timestamp = (int) $timestamp_raw;
+      $now = time();
+      if ($timestamp <= 0 || $timestamp > $now + 3600) {
+        $this->logger->warning('Out-of-range timestamp in token for submission @sid', [
+          '@sid' => $submission_id,
+        ]);
+        return FALSE;
+      }
 
       // Check expiration.
-      if (time() - $timestamp > self::TOKEN_EXPIRATION) {
+      if ($now - $timestamp > self::TOKEN_EXPIRATION) {
         $this->logger->info('Expired token for submission @sid, parent @parent', [
           '@sid' => $submission_id,
           '@parent' => $parent_number,
@@ -124,7 +153,7 @@ class ApprovalTokenService {
 
       return TRUE;
     }
-    catch (\Exception $e) {
+    catch (\Throwable $e) {
       $this->logger->error('Token validation error: @message', [
         '@message' => $e->getMessage(),
       ]);
@@ -158,13 +187,21 @@ class ApprovalTokenService {
   public function getTokenTimestamp(string $token): ?int {
     try {
       $decoded = base64_decode($token, TRUE);
-      if (!$decoded) {
+      if ($decoded === FALSE || $decoded === '') {
         return NULL;
       }
-      [$hash, $timestamp] = explode(':', $decoded, 2);
-      return (int) $timestamp;
+      $parts = explode(':', $decoded, 2);
+      if (count($parts) !== 2) {
+        return NULL;
+      }
+      [, $timestamp_raw] = $parts;
+      if (!is_numeric($timestamp_raw)) {
+        return NULL;
+      }
+      $timestamp = (int) $timestamp_raw;
+      return $timestamp > 0 ? $timestamp : NULL;
     }
-    catch (\Exception $e) {
+    catch (\Throwable $e) {
       return NULL;
     }
   }

--- a/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
@@ -111,9 +111,10 @@ class ApprovalTokenService {
         return FALSE;
       }
 
-      // Guard the destructure: a token without ':' would PHP-fatal on
-      // unconditional list-assignment, and an empty $timestamp would
-      // coerce to (int) 0 which is "valid in 1970".
+      // Guard the destructure: a token without ':' would raise undefined
+      // array key/offset warnings on unconditional list-assignment, and a
+      // missing or empty timestamp could end up coercing to (int) 0
+      // ("valid in 1970") if not rejected first.
       $parts = explode(':', $decoded, 2);
       if (count($parts) !== 2) {
         $this->logger->notice('Malformed token (no separator) for submission @sid', [

--- a/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
@@ -19,6 +19,15 @@ class ApprovalTokenService {
   const TOKEN_EXPIRATION = 604800;
 
   /**
+   * Allowed clock skew when validating a token timestamp (1 hour).
+   *
+   * A future timestamp is rejected as out-of-range, but we allow a small
+   * grace window so a slightly fast client clock or a token minted on a
+   * peer node with a tiny NTP drift still validates.
+   */
+  const MAX_CLOCK_SKEW = 3600;
+
+  /**
    * The private key service.
    *
    * @var \Drupal\Core\PrivateKey
@@ -88,9 +97,15 @@ class ApprovalTokenService {
     try {
       // Strict decode: rejects whitespace and non-base64 characters that
       // would otherwise round-trip silently.
+      //
+      // Format-failure logs below are notice-level: they fire on any
+      // garbage URL hit (typo, mangled email link, scanner). The
+      // ParentApprovalController already logs a single warning per
+      // failed validation with the request context attached, so
+      // doubling up at warning would just spam the channel.
       $decoded = base64_decode($token, TRUE);
       if ($decoded === FALSE || $decoded === '') {
-        $this->logger->warning('Invalid token format for submission @sid', [
+        $this->logger->notice('Invalid token format for submission @sid', [
           '@sid' => $submission_id,
         ]);
         return FALSE;
@@ -101,7 +116,7 @@ class ApprovalTokenService {
       // coerce to (int) 0 which is "valid in 1970".
       $parts = explode(':', $decoded, 2);
       if (count($parts) !== 2) {
-        $this->logger->warning('Malformed token (no separator) for submission @sid', [
+        $this->logger->notice('Malformed token (no separator) for submission @sid', [
           '@sid' => $submission_id,
         ]);
         return FALSE;
@@ -109,17 +124,17 @@ class ApprovalTokenService {
       [$hash, $timestamp_raw] = $parts;
 
       // Range-check the timestamp: must be numeric, positive, and not
-      // implausibly far in the future. One hour of clock-drift slack.
+      // implausibly far in the future. MAX_CLOCK_SKEW of slack.
       if (!is_numeric($timestamp_raw)) {
-        $this->logger->warning('Non-numeric timestamp in token for submission @sid', [
+        $this->logger->notice('Non-numeric timestamp in token for submission @sid', [
           '@sid' => $submission_id,
         ]);
         return FALSE;
       }
       $timestamp = (int) $timestamp_raw;
       $now = time();
-      if ($timestamp <= 0 || $timestamp > $now + 3600) {
-        $this->logger->warning('Out-of-range timestamp in token for submission @sid', [
+      if ($timestamp <= 0 || $timestamp > $now + self::MAX_CLOCK_SKEW) {
+        $this->logger->notice('Out-of-range timestamp in token for submission @sid', [
           '@sid' => $submission_id,
         ]);
         return FALSE;

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\PrivateKey;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the ApprovalTokenService.
+ *
+ * Locks in the validateToken hardening: explicit base64 guard, count()
+ * guard on the explode destructure, and is_numeric + range check on the
+ * decoded timestamp. Each guard closes a specific path that the
+ * pre-hardening code accepted - see issue #17 for the bypass details.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\ApprovalTokenService
+ * @group aabenforms_workflows
+ */
+class ApprovalTokenServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  protected ApprovalTokenService $service;
+
+  /**
+   * Fixed HMAC key the PrivateKey mock returns - lets us craft tampered tokens.
+   */
+  protected string $key = 'unit-test-key-not-secret';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $private_key = $this->createMock(PrivateKey::class);
+    $private_key->method('get')->willReturn($this->key);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $logger_factory->method('get')->willReturn($logger);
+
+    $this->service = new ApprovalTokenService($private_key, $logger_factory);
+  }
+
+  /**
+   * A freshly generated token validates against the same submission/parent.
+   */
+  public function testRoundTripValidates(): void {
+    $token = $this->service->generateToken(42, 1);
+    $this->assertTrue($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * Tampering with the wrong submission_id fails the HMAC check.
+   */
+  public function testTamperedSubmissionIdRejected(): void {
+    $token = $this->service->generateToken(42, 1);
+    $this->assertFalse($this->service->validateToken(99, 1, $token));
+  }
+
+  /**
+   * A token older than TOKEN_EXPIRATION fails the expiry check.
+   */
+  public function testExpiredTokenRejected(): void {
+    // 7 days + 1 second ago - past TOKEN_EXPIRATION (604800).
+    $token = $this->service->generateToken(42, 1, time() - 604801);
+    $this->assertFalse($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * Garbage that isn't valid base64 gets rejected at the decode step.
+   */
+  public function testNonBase64TokenRejected(): void {
+    $this->assertFalse($this->service->validateToken(42, 1, '!!!not-base64!!!'));
+  }
+
+  /**
+   * Empty input is rejected.
+   *
+   * `base64_decode('') === ''` which the new `=== ''` guard catches;
+   * the old `if (!$decoded)` happened to do the same here, but the
+   * contract is now explicit.
+   */
+  public function testEmptyTokenRejected(): void {
+    $this->assertFalse($this->service->validateToken(42, 1, ''));
+  }
+
+  /**
+   * Base64 that decodes to a string with no ':' separator is rejected.
+   *
+   * This is the path that previously fataled or fell through with an
+   * empty $timestamp. The count(parts) !== 2 guard short-circuits it.
+   */
+  public function testTokenWithoutSeparatorRejected(): void {
+    $token = base64_encode('no-colon-here');
+    $this->assertFalse($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * A non-numeric timestamp fails is_numeric() before reaching the cast.
+   *
+   * Pre-hardening, (int) 'abc' resolved to 0 and the token tested as
+   * "valid in 1970". Now rejected explicitly.
+   */
+  public function testNonNumericTimestampRejected(): void {
+    $token = base64_encode('somehash:not-a-number');
+    $this->assertFalse($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * A timestamp of 0 is rejected by the positivity check.
+   */
+  public function testZeroTimestampRejected(): void {
+    $token = base64_encode('somehash:0');
+    $this->assertFalse($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * A negative timestamp is rejected by the positivity check.
+   */
+  public function testNegativeTimestampRejected(): void {
+    $token = base64_encode('somehash:-12345');
+    $this->assertFalse($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * A far-future timestamp is rejected by the range check.
+   *
+   * One hour of clock-drift slack is allowed; anything beyond that fails.
+   */
+  public function testFarFutureTimestampRejected(): void {
+    $future = time() + 86400;
+    $token = base64_encode('somehash:' . $future);
+    $this->assertFalse($this->service->validateToken(42, 1, $token));
+  }
+
+  /**
+   * GetTokenTimestamp returns NULL for malformed input rather than 0.
+   */
+  public function testGetTokenTimestampReturnsNullForMalformed(): void {
+    $this->assertNull($this->service->getTokenTimestamp(''));
+    $this->assertNull($this->service->getTokenTimestamp('!!!not-base64!!!'));
+    $this->assertNull($this->service->getTokenTimestamp(base64_encode('no-colon')));
+    $this->assertNull($this->service->getTokenTimestamp(base64_encode('hash:not-numeric')));
+    $this->assertNull($this->service->getTokenTimestamp(base64_encode('hash:0')));
+  }
+
+  /**
+   * GetTokenTimestamp extracts the timestamp from a well-formed token.
+   */
+  public function testGetTokenTimestampExtractsValidValue(): void {
+    $now = time();
+    $token = $this->service->generateToken(42, 1, $now);
+    $this->assertSame($now, $this->service->getTokenTimestamp($token));
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -95,8 +95,9 @@ class ApprovalTokenServiceTest extends UnitTestCase {
   /**
    * Base64 that decodes to a string with no ':' separator is rejected.
    *
-   * This is the path that previously fataled or fell through with an
-   * empty $timestamp. The count(parts) !== 2 guard short-circuits it.
+   * This is the path that previously caused a fatal error or fell
+   * through with an empty $timestamp. The count(parts) !== 2 guard
+   * short-circuits it.
    */
   public function testTokenWithoutSeparatorRejected(): void {
     $token = base64_encode('no-colon-here');

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -137,7 +137,7 @@ class ApprovalTokenServiceTest extends UnitTestCase {
    * One hour of clock-drift slack is allowed; anything beyond that fails.
    */
   public function testFarFutureTimestampRejected(): void {
-    $future = time() + 86400;
+    $future = time() + ApprovalTokenService::MAX_CLOCK_SKEW + 1;
     $token = base64_encode('somehash:' . $future);
     $this->assertFalse($this->service->validateToken(42, 1, $token));
   }


### PR DESCRIPTION
## Summary

Closes the type-coercion bypass flagged in #17 with three explicit guards in `validateToken()`:

1. `base64_decode` failures rejected via `=== FALSE` / `=== ''` (no more `if (!$decoded)` conflation).
2. `count(\$parts) !== 2` guard before destructuring the colon split, so a malformed token without `:` no longer reaches the timestamp comparison.
3. `is_numeric` + positive + `<= now + 3600s` clock-drift range check on the decoded timestamp, so `(int) '' === 0` → "valid in 1970" can no longer pass.

Also widens the catch to `\Throwable` and applies the same guards to `getTokenTimestamp()` (returns NULL for malformed input instead of `(int)` cast garbage).

## Tests

`ApprovalTokenServiceTest` covers:

- round-trip validation + tampered submission_id rejection
- expired / non-base64 / empty / no-separator / non-numeric / zero / negative / far-future timestamp rejections
- `getTokenTimestamp` NULL paths

Result: 12 tests, 16 assertions, all green.

## Test plan
- [x] phpcs Drupal standard clean.
- [x] `phpunit ApprovalTokenServiceTest` 12/12 green.
- [ ] After merge: confirm the existing parent-approval flow on `/parent-approval/{token}` still validates legitimate tokens (regression smoke).