### PR TITLE
Defensive cleanup: \Throwable + DI tidy + @api annotations (closes #18)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/src/Form/TemplateSelectForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/TemplateSelectForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_workflows\Form;
 
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\aabenforms_workflows\Service\BpmnTemplateManager;
@@ -28,13 +29,23 @@ class TemplateSelectForm extends FormBase {
   protected BpmnTemplateManager $templateManager;
 
   /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected FileSystemInterface $fileSystem;
+
+  /**
    * Constructs a TemplateSelectForm object.
    *
    * @param \Drupal\aabenforms_workflows\Service\BpmnTemplateManager $template_manager
    *   The BPMN template manager service.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
    */
-  public function __construct(BpmnTemplateManager $template_manager) {
+  public function __construct(BpmnTemplateManager $template_manager, FileSystemInterface $file_system) {
     $this->templateManager = $template_manager;
+    $this->fileSystem = $file_system;
   }
 
   /**
@@ -42,7 +53,8 @@ class TemplateSelectForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('aabenforms_workflows.bpmn_template_manager')
+      $container->get('aabenforms_workflows.bpmn_template_manager'),
+      $container->get('file_system')
     );
   }
 
@@ -369,7 +381,7 @@ class TemplateSelectForm extends FormBase {
     $temp_path = NULL;
     try {
       $file->move('temporary://', $safe_name);
-      $temp_path = \Drupal::service('file_system')->realpath($destination);
+      $temp_path = $this->fileSystem->realpath($destination);
 
       if ($this->templateManager->importTemplate($temp_path, $template_id)) {
         $this->messenger()->addStatus(

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AabenFormsActionBase.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AabenFormsActionBase.php
@@ -72,12 +72,16 @@ abstract class AabenFormsActionBase extends ActionBase implements ContainerFacto
   /**
    * Handles action execution errors.
    *
-   * @param \Exception $e
-   *   The exception.
+   * Param is `\Throwable`, not `\Exception`, so a `\TypeError` or
+   * `\ParseError` propagating out of an action's execute() still hits
+   * the audit/logging path instead of escaping unobserved.
+   *
+   * @param \Throwable $e
+   *   The throwable that aborted the action.
    * @param string $context_message
    *   Context about what was being attempted.
    */
-  protected function handleError(\Exception $e, string $context_message = ''): void {
+  protected function handleError(\Throwable $e, string $context_message = ''): void {
     $this->log(
       'Action failed: {message}. Context: {context}',
       [

--- a/web/modules/custom/aabenforms_workflows/src/Service/BpmnTemplateManager.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/BpmnTemplateManager.php
@@ -70,6 +70,8 @@ class BpmnTemplateManager {
    *   - file: Absolute path to BPMN file.
    *   - description: Template description.
    *   - category: Template category (e.g., 'municipal', 'citizen_service').
+   *
+   * @api
    */
   public function getAvailableTemplates(): array {
     $templates = [];
@@ -82,15 +84,24 @@ class BpmnTemplateManager {
       return $templates;
     }
 
-    foreach (glob($template_dir . '/*.bpmn') as $file) {
-      $template_id = basename($file, '.bpmn');
-      $metadata = $this->extractTemplateMetadata($file);
+    // Routed through FileSystemInterface::scanDirectory so the call is
+    // mockable in unit tests and consistent with the rest of the module
+    // (no direct glob/scandir on the filesystem).
+    $found = $this->fileSystem->scanDirectory(
+      $template_dir,
+      '/\.bpmn$/',
+      ['recurse' => FALSE]
+    );
+
+    foreach ($found as $file_uri => $info) {
+      $template_id = $info->name;
+      $metadata = $this->extractTemplateMetadata($file_uri);
 
       if ($metadata) {
         $templates[$template_id] = [
           'id' => $template_id,
           'name' => $metadata['name'] ?? $template_id,
-          'file' => $file,
+          'file' => $file_uri,
           'description' => $metadata['description'] ?? '',
           'category' => $metadata['category'] ?? 'other',
         ];
@@ -110,6 +121,8 @@ class BpmnTemplateManager {
    *
    * @return \SimpleXMLElement|string|null
    *   The parsed BPMN XML or NULL if not found/invalid.
+   *
+   * @api
    */
   public function loadTemplate(string $template_id, bool $as_string = FALSE): \SimpleXMLElement|string|null {
     $file = $this->getTemplatePath($template_id);
@@ -153,6 +166,8 @@ class BpmnTemplateManager {
    *
    * @return bool
    *   TRUE if valid, FALSE otherwise.
+   *
+   * @api
    */
   public function validateTemplate(string $template_id_or_xml): bool {
     // Determine if input is XML or template ID.


### PR DESCRIPTION
## Summary

Three small Drupal-hygiene fixes flagged in PR #15 that did not land on main, scoped to a single PR per #18.

- **`AabenFormsActionBase::handleError()`** widened from `\Exception` → `\Throwable` so `\TypeError` / `\ParseError` propagating out of an action's `execute()` still hits the audit/logging path.
- **`TemplateSelectForm`** constructor-injects `FileSystemInterface`; removes the static `\Drupal::service('file_system')` call in `submitImport()`. Matches the project's `drupal-expert` skill rule.
- **`BpmnTemplateManager`** replaces `glob()` in `getAvailableTemplates()` with the already-injected `FileSystemInterface::scanDirectory()` so the call is mockable in tests and consistent with the rest of the module. Adds `@api` to `getAvailableTemplates()`, `loadTemplate()`, and `validateTemplate()` so the contract is documented.

## Test plan

- [x] phpcs Drupal standard clean across all three files.
- [x] No new test failures vs main on `BpmnTemplateManagerTest` (the 4 pre-existing failures track 1:1 to main).
- [ ] After merge: open `/admin/aabenforms/workflows/templates`, confirm template browser still lists templates and the import upload still works.