### PR TITLE
Add Digital Post DTO + value-object unit tests (closes #19)

### DIFF
--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Audit/NullAuditEmitterTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Audit/NullAuditEmitterTest.php
@@ -33,11 +33,14 @@ class NullAuditEmitterTest extends UnitTestCase {
    * Emit() returns void and does not throw, regardless of inputs.
    */
   public function testEmitIsSilentNoOp(): void {
+    // PHPUnit's first-class way to mark "this test deliberately makes no
+    // assertions" - keeps the test out of the risky-test bucket without
+    // a meaningless assertTrue(TRUE) placeholder.
+    $this->expectNotToPerformAssertions();
     $e = new NullAuditEmitter();
     $e->emit('digital_post.send', 'tx-1', 'sent', 'success');
     $e->emit('digital_post.send', 'tx-2', 'failed', 'failure', ['reason' => 'X']);
     $e->emit('', '', '', '', []);
-    $this->assertTrue(TRUE);
   }
 
 }

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Audit/NullAuditEmitterTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Audit/NullAuditEmitterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\Audit;
+
+use Drupal\aabenforms_digital_post\Audit\AuditEmitterInterface;
+use Drupal\aabenforms_digital_post\Audit\NullAuditEmitter;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests NullAuditEmitter is a side-effect-free no-op.
+ *
+ * Sites without aabenforms_core get this implementation; the contract is
+ * "calling emit() must not throw and must not have observable side
+ * effects". A test feels paranoid for a no-op, but it locks the contract
+ * so a future "let's at least log to syslog" change has to break this
+ * test deliberately rather than silently.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\Audit\NullAuditEmitter
+ * @group aabenforms_digital_post
+ */
+class NullAuditEmitterTest extends UnitTestCase {
+
+  /**
+   * Implements the interface.
+   */
+  public function testImplementsInterface(): void {
+    $this->assertInstanceOf(AuditEmitterInterface::class, new NullAuditEmitter());
+  }
+
+  /**
+   * Emit() returns void and does not throw, regardless of inputs.
+   */
+  public function testEmitIsSilentNoOp(): void {
+    $e = new NullAuditEmitter();
+    $e->emit('digital_post.send', 'tx-1', 'sent', 'success');
+    $e->emit('digital_post.send', 'tx-2', 'failed', 'failure', ['reason' => 'X']);
+    $e->emit('', '', '', '', []);
+    $this->assertTrue(TRUE);
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Certificate/FileCertificateLocatorTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Certificate/FileCertificateLocatorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\Certificate;
+
+use Drupal\aabenforms_digital_post\Certificate\FileCertificateLocator;
+use Drupal\aabenforms_digital_post\Exception\CertificateException;
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests FileCertificateLocator config-driven cert resolution.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\Certificate\FileCertificateLocator
+ * @group aabenforms_digital_post
+ */
+class FileCertificateLocatorTest extends UnitTestCase {
+
+  /**
+   * Builds a locator with a Config mock returning the given key/value map.
+   */
+  protected function locatorWithConfig(array $configValues): FileCertificateLocator {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(
+      static fn (string $key) => $configValues[$key] ?? NULL
+    );
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')
+      ->with('aabenforms_digital_post.settings')
+      ->willReturn($config);
+    return new FileCertificateLocator($factory);
+  }
+
+  /**
+   * Empty cert_path config throws CertificateException.
+   */
+  public function testEmptyCertPathThrows(): void {
+    $locator = $this->locatorWithConfig(['cert_path' => '']);
+    $this->expectException(CertificateException::class);
+    $this->expectExceptionMessage('cert_path');
+    $locator->locate();
+  }
+
+  /**
+   * Missing cert file throws CertificateException with the path in the message.
+   */
+  public function testMissingCertFileThrows(): void {
+    $missing = '/nonexistent/' . uniqid('cert-', TRUE) . '.pem';
+    $locator = $this->locatorWithConfig(['cert_path' => $missing]);
+    $this->expectException(CertificateException::class);
+    $this->expectExceptionMessage($missing);
+    $locator->locate();
+  }
+
+  /**
+   * Valid cert path + env-var passphrase resolve into a Certificate.
+   */
+  public function testValidPathReturnsCertificateWithPassphrase(): void {
+    $tmp = tempnam(sys_get_temp_dir(), 'af-cert-');
+    file_put_contents($tmp, "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n");
+    $envVar = 'AF_TEST_CERT_PASS_' . bin2hex(random_bytes(4));
+    putenv($envVar . '=hunter2');
+    try {
+      $locator = $this->locatorWithConfig([
+        'cert_path' => $tmp,
+        'cert_passphrase_state' => $envVar,
+      ]);
+      $cert = $locator->locate();
+      $this->assertSame($tmp, $cert->path);
+      $this->assertSame('hunter2', $cert->passphrase);
+      $this->assertSame('file', $cert->sourceLabel);
+    }
+    finally {
+      putenv($envVar);
+      @unlink($tmp);
+    }
+  }
+
+  /**
+   * Valid cert path with no passphrase env-var yields NULL passphrase.
+   */
+  public function testValidPathNoPassphraseEnv(): void {
+    $tmp = tempnam(sys_get_temp_dir(), 'af-cert-');
+    file_put_contents($tmp, "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n");
+    try {
+      $locator = $this->locatorWithConfig([
+        'cert_path' => $tmp,
+        'cert_passphrase_state' => '',
+      ]);
+      $cert = $locator->locate();
+      $this->assertNull($cert->passphrase);
+    }
+    finally {
+      @unlink($tmp);
+    }
+  }
+
+  /**
+   * Locator advertises supportsRenewal() as TRUE.
+   */
+  public function testSupportsRenewal(): void {
+    $locator = $this->locatorWithConfig(['cert_path' => '']);
+    $this->assertTrue($locator->supportsRenewal());
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/AttachmentTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/AttachmentTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\DigitalPost;
+
+use Drupal\aabenforms_digital_post\DigitalPost\Attachment;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the Attachment value object factories + constructor guards.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\DigitalPost\Attachment
+ * @group aabenforms_digital_post
+ */
+class AttachmentTest extends UnitTestCase {
+
+  /**
+   * FromBytes() captures filename, mime, and the byte length as size.
+   */
+  public function testFromBytesHappyPath(): void {
+    $a = Attachment::fromBytes('hello world', 'greeting.txt', 'text/plain');
+    $this->assertSame('greeting.txt', $a->filename);
+    $this->assertSame('text/plain', $a->mimeType);
+    $this->assertSame(11, $a->sizeBytes);
+    $this->assertNull($a->path);
+    $this->assertSame('hello world', $a->bytes());
+  }
+
+  /**
+   * FromFile() reads filename + size from the on-disk file.
+   */
+  public function testFromFileHappyPath(): void {
+    $tmp = tempnam(sys_get_temp_dir(), 'af-attach-');
+    file_put_contents($tmp, 'on-disk-payload');
+    try {
+      $a = Attachment::fromFile($tmp, 'doc.txt', 'text/plain');
+      $this->assertSame('doc.txt', $a->filename);
+      $this->assertSame('text/plain', $a->mimeType);
+      $this->assertSame($tmp, $a->path);
+      $this->assertSame(15, $a->sizeBytes);
+      $this->assertSame('on-disk-payload', $a->bytes());
+    }
+    finally {
+      @unlink($tmp);
+    }
+  }
+
+  /**
+   * FromFile() rejects a path that doesn't exist or isn't readable.
+   */
+  public function testFromFileMissingPathRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Attachment::fromFile('/nonexistent/' . uniqid('af-', TRUE));
+  }
+
+  /**
+   * Empty filename is rejected.
+   */
+  public function testEmptyFilenameRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Attachment::fromBytes('payload', '', 'text/plain');
+  }
+
+  /**
+   * Empty mime type is rejected.
+   */
+  public function testEmptyMimeRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Attachment::fromBytes('payload', 'a.txt', '');
+  }
+
+  /**
+   * Zero-byte payload is rejected (sizeBytes must be positive).
+   */
+  public function testZeroSizeRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Attachment::fromBytes('', 'a.txt', 'text/plain');
+  }
+
+  /**
+   * Attachment over the 10 MiB cap is rejected.
+   */
+  public function testOversizeRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Attachment::fromBytes(str_repeat('A', Attachment::DEFAULT_MAX_SIZE_BYTES + 1), 'big.bin', 'application/octet-stream');
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/DigitalPostTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/DigitalPostTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\DigitalPost;
+
+use Drupal\aabenforms_digital_post\DigitalPost\Attachment;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the DigitalPost DTO constructor guards + totalAttachmentBytes.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\DigitalPost\DigitalPost
+ * @group aabenforms_digital_post
+ */
+class DigitalPostTest extends UnitTestCase {
+
+  /**
+   * Builds a baseline valid DigitalPost - tweak via the args to test guards.
+   */
+  protected function build(
+    string $subject = 'Subject',
+    string $body = 'Body',
+    array $attachments = [],
+    string $type = DigitalPost::TYPE_DIGITAL_POST,
+  ): DigitalPost {
+    return new DigitalPost(
+      recipient: Recipient::cpr('0101900001'),
+      sender: new Sender('12345678'),
+      subject: $subject,
+      body: $body,
+      attachments: $attachments,
+      type: $type,
+    );
+  }
+
+  /**
+   * The happy path constructs without throwing.
+   */
+  public function testValidPostConstructs(): void {
+    $post = $this->build();
+    $this->assertSame('Subject', $post->subject);
+    $this->assertSame(DigitalPost::TYPE_DIGITAL_POST, $post->type);
+  }
+
+  /**
+   * Empty subject is rejected.
+   */
+  public function testEmptySubjectRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->build(subject: '');
+  }
+
+  /**
+   * Whitespace-only subject is rejected (trim guard).
+   */
+  public function testWhitespaceOnlySubjectRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->build(subject: "   \t\n  ");
+  }
+
+  /**
+   * Subject longer than 255 chars is rejected.
+   */
+  public function testOversizeSubjectRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->build(subject: str_repeat('a', 256));
+  }
+
+  /**
+   * Boundary case: 255-char subject is accepted as the upper limit.
+   */
+  public function testSubjectAtMaxBoundaryAccepted(): void {
+    $post = $this->build(subject: str_repeat('a', 255));
+    $this->assertSame(255, strlen($post->subject));
+  }
+
+  /**
+   * Empty body is rejected.
+   */
+  public function testEmptyBodyRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->build(body: '');
+  }
+
+  /**
+   * An invalid type string fails the in_array allowlist.
+   */
+  public function testInvalidTypeRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->build(type: 'NotARealType');
+  }
+
+  /**
+   * All four valid types construct without error.
+   */
+  public function testAllValidTypesAccepted(): void {
+    foreach (DigitalPost::VALID_TYPES as $type) {
+      $post = $this->build(type: $type);
+      $this->assertSame($type, $post->type);
+    }
+  }
+
+  /**
+   * A non-Attachment in the attachments array is rejected by index.
+   */
+  public function testNonAttachmentInArrayRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('attachments[1]');
+    $real = Attachment::fromBytes('payload', 'a.txt', 'text/plain');
+    $this->build(attachments: [$real, 'not-an-attachment']);
+  }
+
+  /**
+   * TotalAttachmentBytes() sums sizeBytes across all attachments.
+   */
+  public function testTotalAttachmentBytesSums(): void {
+    $a = Attachment::fromBytes(str_repeat('x', 10), 'a.txt', 'text/plain');
+    $b = Attachment::fromBytes(str_repeat('y', 25), 'b.txt', 'text/plain');
+    $post = $this->build(attachments: [$a, $b]);
+    $this->assertSame(35, $post->totalAttachmentBytes());
+  }
+
+  /**
+   * TotalAttachmentBytes() returns 0 with no attachments.
+   */
+  public function testTotalAttachmentBytesEmpty(): void {
+    $this->assertSame(0, $this->build()->totalAttachmentBytes());
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/DigitalPostTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/DigitalPostTest.php
@@ -28,7 +28,7 @@ class DigitalPostTest extends UnitTestCase {
     string $type = DigitalPost::TYPE_DIGITAL_POST,
   ): DigitalPost {
     return new DigitalPost(
-      recipient: Recipient::cpr('0101900001'),
+      recipient: Recipient::cpr('0000000001'),
       sender: new Sender('12345678'),
       subject: $subject,
       body: $body,

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/RecipientTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/RecipientTest.php
@@ -106,17 +106,16 @@ class RecipientTest extends UnitTestCase {
   }
 
   /**
-   * The hash never contains the raw identifier as a substring.
+   * The hash is a deterministic SHA-256 of the namespaced identifier.
    *
-   * The contract is "no leakage in logs" - this test fails loudly if a
-   * future refactor swaps SHA-256 for a reversible/format-preserving
-   * encoding.
+   * This guards against future refactors replacing hashing with some other
+   * encoding while avoiding probabilistic substring assertions.
    */
   public function testIdentifierHashDoesNotLeakRaw(): void {
     $cpr = '2506924015';
     $hash = Recipient::cpr($cpr)->identifierHash();
-    $this->assertStringNotContainsString($cpr, $hash);
-    $this->assertStringNotContainsString(substr($cpr, 0, 6), $hash);
+    $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    $this->assertSame(hash('sha256', Recipient::TYPE_CPR . ':' . $cpr), $hash);
   }
 
   /**

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/RecipientTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/RecipientTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\DigitalPost;
+
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the Recipient value object.
+ *
+ * The contract under test:
+ *   - cpr() / cvr() factories normalise digits (strip dashes/spaces) and
+ *     reject anything that isn't exactly the right length.
+ *   - identifierHash() never echoes the raw identifier in any form a
+ *     log-skimmer could match against.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\DigitalPost\Recipient
+ * @group aabenforms_digital_post
+ */
+class RecipientTest extends UnitTestCase {
+
+  /**
+   * Bare 10-digit CPR is accepted.
+   */
+  public function testCprAcceptsBareDigits(): void {
+    $r = Recipient::cpr('0101900001');
+    $this->assertSame(Recipient::TYPE_CPR, $r->type);
+    $this->assertSame('0101900001', $r->identifier);
+  }
+
+  /**
+   * Dashed CPR (DDMMYY-XXXX) is normalised to bare digits.
+   */
+  public function testCprAcceptsDashed(): void {
+    $r = Recipient::cpr('010190-0001');
+    $this->assertSame('0101900001', $r->identifier);
+  }
+
+  /**
+   * CPR with whitespace is normalised.
+   */
+  public function testCprAcceptsWhitespace(): void {
+    $r = Recipient::cpr(' 010190 0001 ');
+    $this->assertSame('0101900001', $r->identifier);
+  }
+
+  /**
+   * Too-short CPR is rejected.
+   */
+  public function testCprTooShortRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Recipient::cpr('0101900');
+  }
+
+  /**
+   * Too-long CPR is rejected.
+   */
+  public function testCprTooLongRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Recipient::cpr('010190000123');
+  }
+
+  /**
+   * Non-digit-only CPR after stripping is rejected by length.
+   */
+  public function testCprAllLettersRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Recipient::cpr('abcdefghij');
+  }
+
+  /**
+   * Bare 8-digit CVR is accepted.
+   */
+  public function testCvrAcceptsBareDigits(): void {
+    $r = Recipient::cvr('12345678');
+    $this->assertSame(Recipient::TYPE_CVR, $r->type);
+    $this->assertSame('12345678', $r->identifier);
+  }
+
+  /**
+   * Spaced CVR ("12 34 56 78") is normalised.
+   */
+  public function testCvrAcceptsSpaced(): void {
+    $r = Recipient::cvr('12 34 56 78');
+    $this->assertSame('12345678', $r->identifier);
+  }
+
+  /**
+   * Wrong-length CVR is rejected.
+   */
+  public function testCvrWrongLengthRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    Recipient::cvr('1234567');
+  }
+
+  /**
+   * IdentifierHash() returns a deterministic SHA-256.
+   */
+  public function testIdentifierHashIsStable(): void {
+    $a = Recipient::cpr('0101900001');
+    $b = Recipient::cpr('010190-0001');
+    $this->assertSame($a->identifierHash(), $b->identifierHash());
+    $this->assertSame(64, strlen($a->identifierHash()));
+  }
+
+  /**
+   * The hash never contains the raw identifier as a substring.
+   *
+   * The contract is "no leakage in logs" - this test fails loudly if a
+   * future refactor swaps SHA-256 for a reversible/format-preserving
+   * encoding.
+   */
+  public function testIdentifierHashDoesNotLeakRaw(): void {
+    $cpr = '2506924015';
+    $hash = Recipient::cpr($cpr)->identifierHash();
+    $this->assertStringNotContainsString($cpr, $hash);
+    $this->assertStringNotContainsString(substr($cpr, 0, 6), $hash);
+  }
+
+  /**
+   * CPR vs CVR with the same digit string hash to different values.
+   *
+   * The hash is namespaced by type, so a CPR "12345678..." won't collide
+   * with a CVR "12345678".
+   */
+  public function testCprAndCvrHashDifferently(): void {
+    $cpr = Recipient::cpr('1234567812');
+    $cvr = Recipient::cvr('12345678');
+    $this->assertNotSame($cpr->identifierHash(), $cvr->identifierHash());
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/RecipientTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/RecipientTest.php
@@ -25,25 +25,25 @@ class RecipientTest extends UnitTestCase {
    * Bare 10-digit CPR is accepted.
    */
   public function testCprAcceptsBareDigits(): void {
-    $r = Recipient::cpr('0101900001');
+    $r = Recipient::cpr('0000000001');
     $this->assertSame(Recipient::TYPE_CPR, $r->type);
-    $this->assertSame('0101900001', $r->identifier);
+    $this->assertSame('0000000001', $r->identifier);
   }
 
   /**
    * Dashed CPR (DDMMYY-XXXX) is normalised to bare digits.
    */
   public function testCprAcceptsDashed(): void {
-    $r = Recipient::cpr('010190-0001');
-    $this->assertSame('0101900001', $r->identifier);
+    $r = Recipient::cpr('000000-0001');
+    $this->assertSame('0000000001', $r->identifier);
   }
 
   /**
    * CPR with whitespace is normalised.
    */
   public function testCprAcceptsWhitespace(): void {
-    $r = Recipient::cpr(' 010190 0001 ');
-    $this->assertSame('0101900001', $r->identifier);
+    $r = Recipient::cpr(' 000000 0001 ');
+    $this->assertSame('0000000001', $r->identifier);
   }
 
   /**
@@ -99,8 +99,8 @@ class RecipientTest extends UnitTestCase {
    * IdentifierHash() returns a deterministic SHA-256.
    */
   public function testIdentifierHashIsStable(): void {
-    $a = Recipient::cpr('0101900001');
-    $b = Recipient::cpr('010190-0001');
+    $a = Recipient::cpr('0000000001');
+    $b = Recipient::cpr('000000-0001');
     $this->assertSame($a->identifierHash(), $b->identifierHash());
     $this->assertSame(64, strlen($a->identifierHash()));
   }
@@ -112,7 +112,7 @@ class RecipientTest extends UnitTestCase {
    * encoding while avoiding probabilistic substring assertions.
    */
   public function testIdentifierHashDoesNotLeakRaw(): void {
-    $cpr = '2506924015';
+    $cpr = '0000000002';
     $hash = Recipient::cpr($cpr)->identifierHash();
     $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
     $this->assertSame(hash('sha256', Recipient::TYPE_CPR . ':' . $cpr), $hash);
@@ -125,7 +125,7 @@ class RecipientTest extends UnitTestCase {
    * with a CVR "12345678".
    */
   public function testCprAndCvrHashDifferently(): void {
-    $cpr = Recipient::cpr('1234567812');
+    $cpr = Recipient::cpr('0000000012');
     $cvr = Recipient::cvr('12345678');
     $this->assertNotSame($cpr->identifierHash(), $cvr->identifierHash());
   }

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
@@ -77,7 +77,7 @@ class ResultTest extends UnitTestCase {
    * stay opt-in for callers; it never appears in audit logs.
    */
   public function testAuditContextExcludesRawResponse(): void {
-    $secret = 'CPR=0101900001 inside the MeMo envelope';
+    $secret = 'CPR=TEST-CPR-0000 inside the MeMo envelope';
     $r = Result::failure('tx-5', Result::REASON_VALIDATION, 'bad', $secret);
     $ctx = $r->auditContext();
     $this->assertArrayNotHasKey('rawResponse', $ctx);

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
@@ -56,10 +56,14 @@ class ResultTest extends UnitTestCase {
   public function testAuditContextShape(): void {
     $r = Result::failure('tx-4', Result::REASON_TRANSPORT, 'network fail', 'PII goes here');
     $ctx = $r->auditContext();
-    $this->assertSame(
-      ['status', 'transaction_id', 'reason_code', 'message'],
-      array_keys($ctx)
-    );
+    // Assert the key set, not the order. Insertion order is a PHP
+    // implementation detail and not part of the public contract.
+    $expected_keys = ['status', 'transaction_id', 'reason_code', 'message'];
+    $actual_keys = array_keys($ctx);
+    sort($expected_keys);
+    sort($actual_keys);
+    $this->assertCount(4, $ctx);
+    $this->assertSame($expected_keys, $actual_keys);
     $this->assertSame(Result::FAILURE, $ctx['status']);
     $this->assertSame('tx-4', $ctx['transaction_id']);
     $this->assertSame(Result::REASON_TRANSPORT, $ctx['reason_code']);

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
@@ -77,7 +77,7 @@ class ResultTest extends UnitTestCase {
    * stay opt-in for callers; it never appears in audit logs.
    */
   public function testAuditContextExcludesRawResponse(): void {
-    $secret = 'CPR=TEST-CPR-0000 inside the MeMo envelope';
+    $secret = 'CPR=0000000099 inside the MeMo envelope';
     $r = Result::failure('tx-5', Result::REASON_VALIDATION, 'bad', $secret);
     $ctx = $r->auditContext();
     $this->assertArrayNotHasKey('rawResponse', $ctx);

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\DigitalPost;
+
+use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the Result DTO factories + auditContext() PII guard.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\DigitalPost\Result
+ * @group aabenforms_digital_post
+ */
+class ResultTest extends UnitTestCase {
+
+  /**
+   * Success() builds a SUCCESS result with a NULL reason code.
+   */
+  public function testSuccessFactory(): void {
+    $r = Result::success('tx-1', 'OK', '<envelope>...</envelope>');
+    $this->assertTrue($r->isSuccess());
+    $this->assertSame(Result::SUCCESS, $r->status);
+    $this->assertSame('tx-1', $r->transactionId);
+    $this->assertNull($r->reasonCode);
+    $this->assertSame('OK', $r->message);
+    $this->assertSame('<envelope>...</envelope>', $r->rawResponse);
+  }
+
+  /**
+   * Success() defaults message + rawResponse.
+   */
+  public function testSuccessFactoryDefaults(): void {
+    $r = Result::success('tx-2');
+    $this->assertSame('', $r->message);
+    $this->assertNull($r->rawResponse);
+  }
+
+  /**
+   * Failure() builds a FAILURE result with the given reason code.
+   */
+  public function testFailureFactory(): void {
+    $r = Result::failure('tx-3', Result::REASON_QUOTA, 'over quota', '<fault/>');
+    $this->assertFalse($r->isSuccess());
+    $this->assertSame(Result::FAILURE, $r->status);
+    $this->assertSame('tx-3', $r->transactionId);
+    $this->assertSame(Result::REASON_QUOTA, $r->reasonCode);
+    $this->assertSame('over quota', $r->message);
+    $this->assertSame('<fault/>', $r->rawResponse);
+  }
+
+  /**
+   * AuditContext() exposes the four log-safe fields and nothing else.
+   */
+  public function testAuditContextShape(): void {
+    $r = Result::failure('tx-4', Result::REASON_TRANSPORT, 'network fail', 'PII goes here');
+    $ctx = $r->auditContext();
+    $this->assertSame(
+      ['status', 'transaction_id', 'reason_code', 'message'],
+      array_keys($ctx)
+    );
+    $this->assertSame(Result::FAILURE, $ctx['status']);
+    $this->assertSame('tx-4', $ctx['transaction_id']);
+    $this->assertSame(Result::REASON_TRANSPORT, $ctx['reason_code']);
+    $this->assertSame('network fail', $ctx['message']);
+  }
+
+  /**
+   * AuditContext() never leaks rawResponse.
+   *
+   * The rawResponse field can carry PII from the MeMo envelope and must
+   * stay opt-in for callers; it never appears in audit logs.
+   */
+  public function testAuditContextExcludesRawResponse(): void {
+    $secret = 'CPR=0101900001 inside the MeMo envelope';
+    $r = Result::failure('tx-5', Result::REASON_VALIDATION, 'bad', $secret);
+    $ctx = $r->auditContext();
+    $this->assertArrayNotHasKey('rawResponse', $ctx);
+    $this->assertArrayNotHasKey('raw_response', $ctx);
+    foreach ($ctx as $value) {
+      $this->assertStringNotContainsString($secret, (string) $value);
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/SenderTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/SenderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\DigitalPost;
+
+use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the Sender DTO + fromConfig factory.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\DigitalPost\Sender
+ * @group aabenforms_digital_post
+ */
+class SenderTest extends UnitTestCase {
+
+  /**
+   * Bare 8-digit CVR is accepted unchanged.
+   */
+  public function testBareCvrAccepted(): void {
+    $s = new Sender('12345678', 'Aarhus Kommune');
+    $this->assertSame('12345678', $s->cvr);
+    $this->assertSame('Aarhus Kommune', $s->name);
+    $this->assertNull($s->returnAddress);
+  }
+
+  /**
+   * Spaced CVR is normalised to 8 digits.
+   */
+  public function testSpacedCvrNormalised(): void {
+    $s = new Sender('12 34 56 78');
+    $this->assertSame('12345678', $s->cvr);
+  }
+
+  /**
+   * Wrong-length CVR is rejected.
+   */
+  public function testWrongLengthCvrRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    new Sender('1234567');
+  }
+
+  /**
+   * FromConfig() builds a Sender from the module's settings.
+   */
+  public function testFromConfigHappyPath(): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['sender_cvr', '12345678'],
+      ['sender_name', 'Test Kommune'],
+    ]);
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')
+      ->with('aabenforms_digital_post.settings')
+      ->willReturn($config);
+
+    $s = Sender::fromConfig($factory);
+    $this->assertSame('12345678', $s->cvr);
+    $this->assertSame('Test Kommune', $s->name);
+  }
+
+  /**
+   * FromConfig() with empty sender_cvr throws with a useful pointer.
+   */
+  public function testFromConfigEmptyCvrThrows(): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['sender_cvr', ''],
+      ['sender_name', ''],
+    ]);
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->willReturn($config);
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('aabenforms_digital_post.settings:sender_cvr');
+    Sender::fromConfig($factory);
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/TransactionIdGeneratorTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/TransactionIdGeneratorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\Service;
+
+use Drupal\aabenforms_digital_post\Service\TransactionIdGenerator;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests TransactionIdGenerator emits time-ordered RFC 4122 UUIDv7s.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\Service\TransactionIdGenerator
+ * @group aabenforms_digital_post
+ */
+class TransactionIdGeneratorTest extends UnitTestCase {
+
+  /**
+   * Generate() returns a string matching the RFC 4122 v7 layout.
+   *
+   * Pattern: 8-4-4-4-12 hex digits, version nibble = 7, variant nibble
+   * in {8, 9, a, b}.
+   */
+  public function testGenerateMatchesUuidV7Regex(): void {
+    $gen = new TransactionIdGenerator();
+    $id = $gen->generate();
+    $this->assertSame(36, strlen($id));
+    $this->assertMatchesRegularExpression(
+      '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+      $id
+    );
+  }
+
+  /**
+   * Two consecutive generate() calls produce distinct ids.
+   */
+  public function testGenerateProducesUniqueIds(): void {
+    $gen = new TransactionIdGenerator();
+    $a = $gen->generate();
+    $b = $gen->generate();
+    $this->assertNotSame($a, $b);
+  }
+
+  /**
+   * Sequential ids sort lexicographically (the v7 time-ordering guarantee).
+   */
+  public function testGenerateIsTimeOrdered(): void {
+    $gen = new TransactionIdGenerator();
+    $first = $gen->generate();
+    // Tiny sleep to guarantee a tick of the v7 millisecond clock so the
+    // ordering is observable; v7 has 48-bit ms precision.
+    usleep(2000);
+    $second = $gen->generate();
+    $this->assertLessThan(0, strcmp($first, $second));
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/TransactionIdGeneratorTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/TransactionIdGeneratorTest.php
@@ -43,15 +43,38 @@ class TransactionIdGeneratorTest extends UnitTestCase {
 
   /**
    * Sequential ids sort lexicographically (the v7 time-ordering guarantee).
+   *
+   * Polls the embedded 48-bit ms timestamp instead of trusting a wall-clock
+   * `usleep()` to land in a different ms. On heavy CI a single 2 ms sleep
+   * can stay inside the same millisecond bucket; the bounded retry loop
+   * stays robust without making the test slow in the common case.
    */
   public function testGenerateIsTimeOrdered(): void {
     $gen = new TransactionIdGenerator();
     $first = $gen->generate();
-    // Tiny sleep to guarantee a tick of the v7 millisecond clock so the
-    // ordering is observable; v7 has 48-bit ms precision.
-    usleep(2000);
-    $second = $gen->generate();
+    $firstTs = $this->extractUuidV7Timestamp($first);
+
+    $second = $first;
+    $secondTs = $firstTs;
+    for ($attempt = 0; $attempt < 10 && $secondTs <= $firstTs; $attempt++) {
+      usleep(1000);
+      $second = $gen->generate();
+      $secondTs = $this->extractUuidV7Timestamp($second);
+    }
+
+    $this->assertGreaterThan(
+      $firstTs,
+      $secondTs,
+      'Failed to observe a UUIDv7 timestamp increase within the retry budget.',
+    );
     $this->assertLessThan(0, strcmp($first, $second));
+  }
+
+  /**
+   * Extracts the 48-bit unix-epoch millisecond timestamp from a UUIDv7.
+   */
+  private function extractUuidV7Timestamp(string $uuid): int {
+    return (int) hexdec(substr(str_replace('-', '', $uuid), 0, 12));
   }
 
 }


### PR DESCRIPTION
## Summary

50 tests, 101 assertions, all green. Pure-add — no production code touched.

Locks in the contracts on the seven smallest building blocks of `aabenforms_digital_post`:

| File | What it covers |
|---|---|
| `DigitalPostTest` | Subject empty/whitespace/oversize/boundary; body empty; type allowlist; attachment-array typecheck per index; `totalAttachmentBytes()` |
| `RecipientTest` | `cpr` / `cvr` factories accept dashed + spaced; reject wrong-length; `identifierHash()` stable, length-64, type-namespaced, no leakage |
| `ResultTest` | `success` / `failure` factories, `isSuccess`, **`auditContext()` PII guard — never leaks `rawResponse`** |
| `AttachmentTest` | `fromBytes` / `fromFile`; rejects missing path / empty filename / empty mime / zero size / oversize |
| `SenderTest` | Bare + spaced CVR normalisation; `fromConfig` happy + empty-CVR error path |
| `TransactionIdGeneratorTest` | UUIDv7 RFC 4122 regex, uniqueness, time-ordered |
| `NullAuditEmitterTest` | Implements interface; `emit()` silent no-op for any input |

The security-meaningful tests are the `RecipientTest::testIdentifierHashDoesNotLeakRaw` (locks the "no raw CPR in logs" contract) and `ResultTest::testAuditContextExcludesRawResponse` (locks the "no MeMo envelope in audit" contract).

## Test plan
- [x] phpcs Drupal standard clean.
- [x] phpunit: 50/50 green, 101 assertions.