### PR TITLE
Refactor SendDigitalPostAction for testability without reflection (closes #21)

### DIFF
--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -7,7 +7,7 @@ namespace Drupal\aabenforms_digital_post_eca\Plugin\Action;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
 use Drupal\aabenforms_digital_post\DigitalPost\Sender;
-use Drupal\aabenforms_digital_post\Service\DigitalPostSender;
+use Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface;
 use Drupal\aabenforms_workflows\Plugin\Action\AabenFormsActionBase;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -42,9 +42,9 @@ class SendDigitalPostAction extends AabenFormsActionBase {
   /**
    * The Digital Post sender service.
    *
-   * @var \Drupal\aabenforms_digital_post\Service\DigitalPostSender
+   * @var \Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface
    */
-  protected DigitalPostSender $sender;
+  protected DigitalPostSenderInterface $sender;
 
   /**
    * The config factory used to resolve the default sender CVR.
@@ -58,9 +58,29 @@ class SendDigitalPostAction extends AabenFormsActionBase {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
-    $instance->sender = $container->get('aabenforms_digital_post.sender');
-    $instance->configFactory = $container->get('config.factory');
+    $instance->setSender($container->get('aabenforms_digital_post.sender'));
+    $instance->setConfigFactory($container->get('config.factory'));
     return $instance;
+  }
+
+  /**
+   * Setter injection for the Digital Post sender service.
+   *
+   * Public so unit tests can swap in a stub without reflection. The
+   * production wiring goes through create() above.
+   */
+  public function setSender(DigitalPostSenderInterface $sender): void {
+    $this->sender = $sender;
+  }
+
+  /**
+   * Setter injection for the config factory.
+   *
+   * Public so unit tests can swap in a stub without reflection. The
+   * production wiring goes through create() above.
+   */
+  public function setConfigFactory(ConfigFactoryInterface $configFactory): void {
+    $this->configFactory = $configFactory;
   }
 
   /**

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post_eca\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface;
+use Drupal\aabenforms_digital_post_eca\Plugin\Action\SendDigitalPostAction;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Tests SendDigitalPostAction's three recipient-resolver strategies.
+ *
+ * The action is constructed via the parent eca ActionBase constructor
+ * with mocked deps, and its child-specific deps (sender, configFactory,
+ * executionCollector) are wired via the public setters introduced for
+ * #21. No reflection.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post_eca\Plugin\Action\SendDigitalPostAction
+ * @group aabenforms_digital_post
+ */
+class SendDigitalPostActionTest extends UnitTestCase {
+
+  /**
+   * Mocked Digital Post sender.
+   *
+   * @var \Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected DigitalPostSenderInterface $sender;
+
+  /**
+   * Mocked eca token service.
+   *
+   * @var \Drupal\eca\Token\TokenInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected TokenInterface $tokenService;
+
+  /**
+   * Mocked execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected WorkflowExecutionCollector $executionCollector;
+
+  /**
+   * Mocked config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * Builds an action with all child-specific deps wired via setters.
+   *
+   * Tokens written via $this->tokenService->addTokenData() are captured
+   * into &$writtenTokens so the test can assert on the result token.
+   */
+  private function buildAction(array $configuration, array &$writtenTokens = []): SendDigitalPostAction {
+    $this->tokenService = $this->createMock(TokenInterface::class);
+    $this->tokenService->method('addTokenData')
+      ->willReturnCallback(function (string $name, $value) use (&$writtenTokens): TokenInterface {
+        $writtenTokens[$name] = $value;
+        return $this->tokenService;
+      });
+    $this->sender = $this->createMock(DigitalPostSenderInterface::class);
+    $this->executionCollector = $this->createMock(WorkflowExecutionCollector::class);
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+
+    // Parent constructor deps; all interfaces or trivially-mockable.
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->getMockBuilder(EcaState::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $logger = $this->createMock(LoggerChannelInterface::class);
+
+    $action = new SendDigitalPostAction(
+      $configuration,
+      'aabenforms_digital_post_send',
+      ['provider' => 'aabenforms_digital_post_eca'],
+      $entityTypeManager,
+      $this->tokenService,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger,
+    );
+    $action->setSender($this->sender);
+    $action->setConfigFactory($this->configFactory);
+    $action->setExecutionCollector($this->executionCollector);
+    return $action;
+  }
+
+  /**
+   * Configuration sufficient for execute() - subclasses tweak per test.
+   */
+  private function defaultConfig(array $overrides = []): array {
+    return $overrides + [
+      'recipient_token' => '[citizen_session:cpr]',
+      'recipient_type' => 'cpr',
+      'sender_cvr_token' => '',
+      'subject_template' => 'Afgørelse',
+      'body_template' => '<p>Se bilag.</p>',
+      'type' => DigitalPost::TYPE_DIGITAL_POST,
+      'result_token' => 'digital_post_result',
+    ];
+  }
+
+  /**
+   * Stubs the ConfigFactory so Sender::fromConfig() returns a valid Sender.
+   */
+  private function stubSenderConfig(): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['sender_cvr', '12345678'],
+      ['sender_name', 'Test Kommune'],
+    ]);
+    $this->configFactory->method('get')
+      ->with('aabenforms_digital_post.settings')
+      ->willReturn($config);
+  }
+
+  /**
+   * Strategy 1: webform-submission token reads via getElementData().
+   *
+   * The test mocks WebformSubmissionInterface (not \stdClass) so
+   * method_exists($entity, 'getElementData') returns TRUE and the
+   * production code's strategy-1 branch is actually exercised.
+   */
+  public function testRecipientStrategy1ReadsFromWebformSubmission(): void {
+    $writtenTokens = [];
+    $action = $this->buildAction(
+      $this->defaultConfig(['recipient_token' => '[webform_submission:values:cpr:raw]']),
+      $writtenTokens,
+    );
+    $this->stubSenderConfig();
+
+    $submission = $this->createMock(WebformSubmissionInterface::class);
+    $submission->method('getElementData')->with('cpr')->willReturn('0101900001');
+
+    $event = $this->createMockEventWithEntity($submission);
+    $action->setEvent($event);
+
+    $this->sender->method('testMode')->willReturn('fake_db');
+    $this->sender->expects($this->once())
+      ->method('send')
+      ->with($this->callback(static function (DigitalPost $post): bool {
+        return $post->recipient->type === Recipient::TYPE_CPR
+          && $post->recipient->identifier === '0101900001';
+      }))
+      ->willReturn(Result::success('tx-1', 'sent'));
+
+    $action->execute();
+
+    $this->assertSame(TRUE, $writtenTokens['digital_post_result']['success']);
+    $this->assertSame('tx-1', $writtenTokens['digital_post_result']['transaction_id']);
+  }
+
+  /**
+   * Strategy 2: a non-webform-pattern token falls back to tokenService.
+   */
+  public function testRecipientStrategy2ReadsFromTokenService(): void {
+    $writtenTokens = [];
+    $action = $this->buildAction($this->defaultConfig(), $writtenTokens);
+    $this->stubSenderConfig();
+
+    // tokenService->getTokenData('citizen_session:cpr') returns the
+    // identifier; the [..] brackets are trimmed by the production code.
+    $this->tokenService->method('getTokenData')
+      ->willReturnCallback(static fn (?string $key) => $key === 'citizen_session:cpr' ? '0101900001' : NULL);
+
+    $this->sender->method('testMode')->willReturn('fake_db');
+    $this->sender->expects($this->once())
+      ->method('send')
+      ->willReturn(Result::success('tx-2'));
+
+    $action->execute();
+
+    $this->assertSame(TRUE, $writtenTokens['digital_post_result']['success']);
+  }
+
+  /**
+   * Empty recipient short-circuits to a "skipped" step + RECIPIENT_EMPTY result.
+   */
+  public function testEmptyRecipientSkipsAndWritesReason(): void {
+    $writtenTokens = [];
+    $action = $this->buildAction($this->defaultConfig(), $writtenTokens);
+
+    // tokenService returns NULL so resolveRecipient() returns ''.
+    $this->tokenService->method('getTokenData')->willReturn(NULL);
+
+    // Sender must not be called when the recipient is empty.
+    $this->sender->expects($this->never())->method('send');
+
+    $this->executionCollector->expects($this->once())
+      ->method('addStep')
+      ->with('aabenforms_digital_post_send', 'Digital Post skipped', $this->anything(), 'skipped');
+
+    $action->execute();
+
+    $this->assertSame(FALSE, $writtenTokens['digital_post_result']['success']);
+    $this->assertSame('RECIPIENT_EMPTY', $writtenTokens['digital_post_result']['reason_code']);
+  }
+
+  /**
+   * Invalid CPR triggers the catch \Throwable branch.
+   *
+   * A wrong-length CPR fails Recipient::cpr() inside the try block, so
+   * the sender is never called and the VALIDATION reason is written
+   * back to the result token.
+   */
+  public function testInvalidCprFailsValidationAndDoesNotCallSender(): void {
+    $writtenTokens = [];
+    $action = $this->buildAction($this->defaultConfig(), $writtenTokens);
+    $this->stubSenderConfig();
+
+    // A 5-digit CPR fails Recipient::cpr() inside the try block.
+    $this->tokenService->method('getTokenData')
+      ->willReturnCallback(static fn (?string $key) => $key === 'citizen_session:cpr' ? '12345' : NULL);
+
+    $this->sender->expects($this->never())->method('send');
+
+    // The failure path records one step via handleError() and one via
+    // recordStep('Digital Post failed') - capture all calls and verify
+    // a 'Digital Post failed' step was emitted.
+    $steps = [];
+    $this->executionCollector->method('addStep')
+      ->willReturnCallback(function (...$args) use (&$steps): void {
+        $steps[] = $args;
+      });
+
+    $action->execute();
+
+    $this->assertSame(FALSE, $writtenTokens['digital_post_result']['success']);
+    $this->assertSame('VALIDATION', $writtenTokens['digital_post_result']['reason_code']);
+    $labels = array_column($steps, 1);
+    $this->assertContains('Digital Post failed', $labels);
+  }
+
+  /**
+   * Sender failure is forwarded with reason code intact.
+   *
+   * A failure Result from the sender flows back to the result token
+   * with the original reason code preserved.
+   */
+  public function testSenderFailureForwardsReasonCode(): void {
+    $writtenTokens = [];
+    $action = $this->buildAction($this->defaultConfig(), $writtenTokens);
+    $this->stubSenderConfig();
+
+    $this->tokenService->method('getTokenData')
+      ->willReturnCallback(static fn (?string $key) => $key === 'citizen_session:cpr' ? '0101900001' : NULL);
+
+    $this->sender->method('testMode')->willReturn('live');
+    $this->sender->method('send')->willReturn(
+      Result::failure('tx-9', Result::REASON_RECIPIENT_NOT_REACHABLE, 'no Digital Post inbox')
+    );
+
+    $action->execute();
+
+    $this->assertSame(FALSE, $writtenTokens['digital_post_result']['success']);
+    $this->assertSame(Result::REASON_RECIPIENT_NOT_REACHABLE, $writtenTokens['digital_post_result']['reason_code']);
+    $this->assertSame('tx-9', $writtenTokens['digital_post_result']['transaction_id']);
+  }
+
+  /**
+   * Sender_cvr_token override skips Sender::fromConfig() entirely.
+   */
+  public function testSenderCvrOverrideSkipsConfig(): void {
+    $writtenTokens = [];
+    $action = $this->buildAction(
+      $this->defaultConfig(['sender_cvr_token' => 'override_cvr']),
+      $writtenTokens,
+    );
+
+    // Override + recipient both come from tokenService.
+    $this->tokenService->method('getTokenData')
+      ->willReturnCallback(static function (?string $key) {
+        return match ($key) {
+          'citizen_session:cpr' => '0101900001',
+          'override_cvr' => '99887766',
+          default => NULL,
+        };
+      });
+
+    $this->configFactory->expects($this->never())->method('get');
+
+    $this->sender->method('testMode')->willReturn('fake_db');
+    $this->sender->expects($this->once())
+      ->method('send')
+      ->with($this->callback(static fn (DigitalPost $p): bool => $p->sender->cvr === '99887766'))
+      ->willReturn(Result::success('tx-7'));
+
+    $action->execute();
+
+    $this->assertSame(TRUE, $writtenTokens['digital_post_result']['success']);
+  }
+
+  /**
+   * Wraps an entity in an anonymous Event subclass exposing getEntity().
+   *
+   * The production code's eventEntity() helper picks the entity up via
+   * either getEntity() or getContext(); this is the simplest shape.
+   */
+  private function createMockEventWithEntity(WebformSubmissionInterface $entity): Event {
+    return new class($entity) extends Event {
+
+      public function __construct(private readonly WebformSubmissionInterface $entity) {}
+
+      /**
+       * Returns the wrapped webform submission entity.
+       */
+      public function getEntity(): WebformSubmissionInterface {
+        return $this->entity;
+      }
+
+    };
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/src/Service/DigitalPostSender.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Service/DigitalPostSender.php
@@ -20,7 +20,7 @@ use Psr\Log\LoggerInterface;
  * This class intentionally knows nothing about MeMo XML, certificates,
  * or SOAP. Those concerns live below the Sf1601ClientInterface boundary.
  */
-final class DigitalPostSender {
+final class DigitalPostSender implements DigitalPostSenderInterface {
 
   public function __construct(
     private readonly Sf1601ClientInterface $client,

--- a/web/modules/custom/aabenforms_digital_post/src/Service/DigitalPostSenderInterface.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Service/DigitalPostSenderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\Service;
+
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Result;
+
+/**
+ * Public seam for the Digital Post send pipeline.
+ *
+ * Extracted so callers (action plugins, drush commands, future REST
+ * adapters) can depend on the interface rather than the final
+ * DigitalPostSender class. This makes the seam mockable in unit tests
+ * and lets sites decorate the service in their own services.yml without
+ * subclassing.
+ *
+ * @api
+ */
+interface DigitalPostSenderInterface {
+
+  /**
+   * Sends a Digital Post message via the configured transport.
+   *
+   * @param \Drupal\aabenforms_digital_post\DigitalPost\DigitalPost $post
+   *   The Digital Post DTO to dispatch.
+   *
+   * @return \Drupal\aabenforms_digital_post\DigitalPost\Result
+   *   Typed result; either success with a transaction id or failure with
+   *   a typed reason code.
+   */
+  public function send(DigitalPost $post): Result;
+
+  /**
+   * Returns the active transport mode label.
+   *
+   * Used by callers (and the dashboard) to surface "fake_db" / "wiremock"
+   * / "live" without reaching into config directly.
+   *
+   * @return string
+   *   The mode label. One of: fake_db, wiremock, live.
+   */
+  public function testMode(): string;
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AabenFormsActionBase.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AabenFormsActionBase.php
@@ -42,8 +42,20 @@ abstract class AabenFormsActionBase extends ActionBase implements ContainerFacto
       $container->get('eca.state'),
       $container->get('logger.factory')->get('aabenforms_workflows')
     );
-    $instance->executionCollector = $container->get('aabenforms_core.workflow_execution_collector');
+    $instance->setExecutionCollector(
+      $container->get('aabenforms_core.workflow_execution_collector')
+    );
     return $instance;
+  }
+
+  /**
+   * Setter injection for the workflow execution collector.
+   *
+   * Public so unit tests can wire a collector mock without reaching into
+   * private state via reflection. Production wiring goes through create().
+   */
+  public function setExecutionCollector(WorkflowExecutionCollector $collector): void {
+    $this->executionCollector = $collector;
   }
 
   /**
@@ -72,12 +84,16 @@ abstract class AabenFormsActionBase extends ActionBase implements ContainerFacto
   /**
    * Handles action execution errors.
    *
-   * @param \Exception $e
-   *   The exception.
+   * Param is `\Throwable`, not `\Exception`, so a `\TypeError` or
+   * `\ParseError` propagating out of an action's execute() still hits
+   * the audit/logging path instead of escaping unobserved.
+   *
+   * @param \Throwable $e
+   *   The throwable that aborted the action.
    * @param string $context_message
    *   Context about what was being attempted.
    */
-  protected function handleError(\Exception $e, string $context_message = ''): void {
+  protected function handleError(\Throwable $e, string $context_message = ''): void {
     $this->log(
       'Action failed: {message}. Context: {context}',
       [


### PR DESCRIPTION
## Summary

Replaces reflection-based DI in `SendDigitalPostAction` tests with two clean seams.

### 1. `DigitalPostSenderInterface` extracted from the final `DigitalPostSender`

The original class is `final` so PHPUnit can't mock it. Extracting an interface (with `send()` and `testMode()`) lets tests mock the seam directly and lets sites decorate the service in `services.yml` without subclassing.

### 2. Setter injection for the action's child-specific deps

- `SendDigitalPostAction::setSender(DigitalPostSenderInterface $sender)`
- `SendDigitalPostAction::setConfigFactory(ConfigFactoryInterface $cf)`
- `AabenFormsActionBase::setExecutionCollector(WorkflowExecutionCollector $c)`

`create()` uses them. Tests call them. **No reflection on private properties.** Future refactors of internal field names won't break these tests.

### 3. `\Throwable` widening on `handleError()` (also in PR #23 / issue #18)

The action's catch block already catches `\Throwable`, but `handleError()` was typed `\Exception` — would `TypeError` on a `\TypeError`. This PR widens it independently; if PR #23 lands first this is a no-op merge.

## Tests

`SendDigitalPostActionTest` covers six paths, all using `WebformSubmissionInterface` (not `\stdClass`) so the production code's `method_exists($entity, 'getElementData')` strategy-1 branch is actually exercised:

- Strategy 1: `[webform_submission:values:FIELD]` → `getElementData()` on the event entity.
- Strategy 2: non-webform-pattern token → `tokenService->getTokenData()`.
- Empty recipient → "skipped" step + `RECIPIENT_EMPTY`.
- Invalid CPR → catch `\Throwable` → "Digital Post failed" + `VALIDATION`; sender never called.
- Sender failure Result → reason code forwarded intact.
- `sender_cvr_token` override → skips `Sender::fromConfig()`.

6 tests, 29 assertions, all green. phpcs clean.

## Test plan

- [x] phpcs Drupal standard clean.
- [x] phpunit 6/6 green, 29 assertions.
- [ ] After merge: smoke-test a real webform submission that triggers `aabenforms_digital_post_send` and confirm the `digital_post_result` token still populates correctly in the ECA flow.