### PR TITLE
Fix invalid eca_base_cron plugin id in MED voting flow (closes #31)

### DIFF
--- a/config/sync/eca.eca.med_election_voting_flow.yml
+++ b/config/sync/eca.eca.med_election_voting_flow.yml
@@ -19,7 +19,7 @@ events:
         id: validate_voter_mitid
         condition: ''
   on_cron_tick:
-    plugin: eca_base_cron
+    plugin: 'eca_base:eca_cron'
     configuration:
       frequency: '+1 minute'
     successors:


### PR DESCRIPTION
## Summary

Phase C's \`med_election_voting_flow.yml\` referenced the eca event plugin \`eca_base_cron\`. That plugin id doesn't exist in the installed version - the correct form is \`eca_base:eca_cron\`. \`drush cim\` was failing with \`PluginNotFoundException\`, blocking deploy and local config parity (#27, #29, #30).

## Test plan
- [x] \`grep -rn 'plugin: eca_base_' config/sync/\` shows zero invalid uses after the fix.
- [x] \`drush cim -n\` accepts the file (was failing with PluginNotFoundException).
- [ ] After merge: production deploy that runs \`drush cim -y\` should now create the voting flow rather than fault.