### PR TITLE
Export Phase B role + tenant settings to config/sync (closes #30)

### DIFF
--- a/config/sync/aabenforms_tenant.settings.yml
+++ b/config/sync/aabenforms_tenant.settings.yml
@@ -1,0 +1,4 @@
+employee_provisioning:
+  employee_claim_field: ''
+  employee_claim_match: equals
+  employee_claim_value: ''

--- a/config/sync/user.role.aabenforms_employee.yml
+++ b/config/sync/user.role.aabenforms_employee.yml
@@ -1,0 +1,12 @@
+uuid: 869c3378-d168-4683-87e5-fd05259705fd
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_core
+id: aabenforms_employee
+label: 'AabenForms Employee'
+weight: 5
+is_admin: false
+permissions:
+  - 'access employee webform api'


### PR DESCRIPTION
## Summary

Phase B's \`aabenforms_employee\` role and \`aabenforms_tenant.settings\` were only shipped in the module's \`config/install/\` directory. Fresh installs worked; \`drush cim\` on existing sites would have deleted them. Production survived only because nobody ran a cim deploy after Phase B landed.

This adds both to \`config/sync\`. \`drush cim -n\` now reports "no changes to import" cleanly.

## Test plan
- [x] \`drush cim -y\` creates the role + settings without error.
- [x] After import, \`drush cim -n\` reports no pending changes.
- [x] \`config/sync/user.role.aabenforms_employee.yml\` and \`config/sync/aabenforms_tenant.settings.yml\` present.
- [ ] After merge: production deploy that runs \`drush cim\` no longer threatens to delete the role.