### PR TITLE
Make README coverage + tests badges dynamic

### DIFF
--- a/.github/badges/tests.json
+++ b/.github/badges/tests.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "tests", "message": "pending CI run", "color": "lightgrey"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,19 @@ jobs:
 
       - name: Run PHPUnit with Coverage
         run: |
+          # Tee the output so the test/assertion summary line is parseable
+          # later. --log-junit gives us a machine-readable count too.
+          # The aabenforms_workflows exclusion is tracked as a follow-up
+          # (see the README) - those tests have rotted and need a real
+          # fix rather than masking inside the badge number.
+          set -o pipefail
           XDEBUG_MODE=coverage vendor/bin/phpunit \
             --coverage-text \
             --coverage-cobertura=coverage/cobertura.xml \
             --coverage-html=coverage/html \
+            --log-junit=phpunit-junit.xml \
             --exclude-group aabenforms_workflows \
-            --testdox
+            --testdox 2>&1 | tee phpunit-output.log
         env:
           SIMPLETEST_DB: mysql://root:root@127.0.0.1/drupal_test
           SIMPLETEST_BASE_URL: http://localhost
@@ -175,29 +182,56 @@ jobs:
           path: coverage/html
           retention-days: 30
 
-      - name: Coverage Badge
+      - name: Coverage + Tests badges
         run: |
           mkdir -p .github/badges
+
+          # Coverage badge.
           COVERAGE=${{ steps.coverage.outputs.percentage }}
-          COLOR="red"
+          COVERAGE_COLOR="red"
           if (( $(echo "$COVERAGE >= 80" | bc -l) )); then
-            COLOR="brightgreen"
+            COVERAGE_COLOR="brightgreen"
           elif (( $(echo "$COVERAGE >= 60" | bc -l) )); then
-            COLOR="yellow"
+            COVERAGE_COLOR="yellow"
           elif (( $(echo "$COVERAGE >= 40" | bc -l) )); then
-            COLOR="orange"
+            COVERAGE_COLOR="orange"
           fi
+          echo "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"${COVERAGE}%\", \"color\": \"${COVERAGE_COLOR}\"}" > .github/badges/coverage.json
 
-          # Create badge JSON for shields.io
-          echo "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"${COVERAGE}%\", \"color\": \"${COLOR}\"}" > .github/badges/coverage.json
+          # Tests badge - parse the test count + failure count from the
+          # JUnit log written by phpunit. Source of truth, not the human-
+          # readable "Tests: N" line which can be missing on early exit.
+          cat > parse_tests.php << 'PHPEOF'
+          <?php
+          $xml = simplexml_load_file('phpunit-junit.xml');
+          $attrs = $xml->testsuite[0]->attributes();
+          $total = (int) $attrs['tests'];
+          $failures = (int) $attrs['failures'] + (int) $attrs['errors'];
+          $passing = $total - $failures;
+          echo $passing . ',' . $total . ',' . $failures;
+          PHPEOF
 
-      - name: Commit Coverage Badge
+          IFS=',' read -r PASSING TOTAL FAILURES <<< "$(php parse_tests.php)"
+          rm parse_tests.php
+          if [ "$FAILURES" -gt 0 ]; then
+            TESTS_MSG="${PASSING}/${TOTAL} passing"
+            TESTS_COLOR="red"
+          else
+            TESTS_MSG="${TOTAL} passing"
+            TESTS_COLOR="brightgreen"
+          fi
+          echo "{\"schemaVersion\": 1, \"label\": \"tests\", \"message\": \"${TESTS_MSG}\", \"color\": \"${TESTS_COLOR}\"}" > .github/badges/tests.json
+
+          # Surface in the run summary too.
+          echo "🧪 **Tests:** ${TESTS_MSG}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Commit badges
         if: github.ref == 'refs/heads/main'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add .github/badges/coverage.json || true
-          git diff --staged --quiet || git commit -m "Update coverage badge [skip ci]"
+          git add .github/badges/coverage.json .github/badges/tests.json || true
+          git diff --staged --quiet || git commit -m "Update coverage + tests badges [skip ci]"
           git push
 
   summary:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 [![CI](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml/badge.svg)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
 [![Coding Standards](https://github.com/madsnorgaard/aabenforms/actions/workflows/coding-standards.yml/badge.svg)](https://github.com/madsnorgaard/aabenforms/actions/workflows/coding-standards.yml)
-[![Coverage](https://img.shields.io/badge/coverage-45%25-yellow)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-156%20passing-brightgreen)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/madsnorgaard/aabenforms/main/.github/badges/coverage.json)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/madsnorgaard/aabenforms/main/.github/badges/tests.json)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

The README badges were lying. README line 11 hardcoded \`coverage-45%-yellow\`, while \`.github/badges/coverage.json\` (committed by CI on every main push) actually reported **8.68% red**. Line 12 hardcoded \`tests-156 passing\`, frozen since Phase 2. This PR replaces both with shields.io endpoint badges that read live JSON from \`.github/badges/\` and teaches CI to write the second file.

### Changes

- README \`Coverage\` + \`Tests\` badges → shields.io endpoint URLs pointing at \`.github/badges/coverage.json\` and \`.github/badges/tests.json\`.
- CI's PHPUnit step now writes \`phpunit-junit.xml\` and tees stdout into \`phpunit-output.log\` so test counts are parseable.
- New CI step generates \`tests.json\` from the JUnit log: \`{passing}/{total} passing\` red on any failure, \`{total} passing\` brightgreen otherwise. Surfaced in the run summary too.
- Old "Coverage Badge" + "Commit Coverage Badge" steps consolidated and renamed to handle both files.
- \`.github/badges/tests.json\` seeded with a "pending CI run" placeholder so the README endpoint resolves on day one.

### Not in this PR

The \`--exclude-group aabenforms_workflows\` from commit \`f7c4d68\` (Feb 1) is still in place. The original 3 failing tests it was meant to skip have grown to 87 tests with 56 errors and 5 failures locally on current main. That deserves its own focused fix - see follow-up issue. This PR's scope is just "stop the badge from lying".

## Test plan

- [x] phpcs not relevant (yml + markdown only).
- [ ] After merge: first CI run on main writes both \`coverage.json\` (overwritten) and \`tests.json\` (created). README shields.io endpoints render the live numbers.
- [ ] Bonus: paste the README into a markdown previewer and confirm both badges resolve.