### PR TITLE
Distinguish malformed vs expired tokens in parent-approval UX

### DIFF
--- a/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
@@ -87,7 +87,11 @@ class ParentApprovalController extends ControllerBase {
    * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
    */
   public function approvalPage(int $parent_number, int $submission_id, string $token, Request $request): array {
-    // Validate token.
+    // Validate token, then branch on outcome so the citizen sees an
+    // accurate message rather than a generic "denied". Three outcomes:
+    // expired (well-formed, past) → "ask for a new link"; malformed
+    // (URL corrupted) → "check the URL"; tampered (HMAC mismatch) →
+    // 403 (real security signal).
     if (!$this->tokenService->validateToken($submission_id, $parent_number, $token)) {
       $this->logger->warning('Invalid or expired token for submission @sid, parent @parent', [
         '@sid' => $submission_id,
@@ -102,6 +106,20 @@ class ParentApprovalController extends ControllerBase {
           ],
           '#status_headings' => [
             'error' => $this->t('Expired Link'),
+          ],
+        ];
+      }
+
+      if ($this->tokenService->isTokenMalformed($token)) {
+        return [
+          '#theme' => 'status_messages',
+          '#message_list' => [
+            'error' => [
+              $this->t('This approval link is invalid. The URL may have been truncated by your email client - please copy and paste the full link, or contact the case worker for a fresh one.'),
+            ],
+          ],
+          '#status_headings' => [
+            'error' => $this->t('Invalid Link'),
           ],
         ];
       }

--- a/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
@@ -223,20 +223,50 @@ class ApprovalTokenService {
   }
 
   /**
-   * Checks if token is expired.
+   * Checks if a token is genuinely expired.
+   *
+   * Returns TRUE only when the token's timestamp resolves AND is older
+   * than TOKEN_EXPIRATION. Malformed tokens (no timestamp at all) are
+   * NOT expired - they are malformed; isTokenMalformed() reports that
+   * separately so the controller can render different UX for each case.
    *
    * @param string $token
-   *   The token.
+   *   The token to inspect.
    *
    * @return bool
-   *   TRUE if expired, FALSE otherwise.
+   *   TRUE only if the token has a parseable, in-range timestamp that is
+   *   older than TOKEN_EXPIRATION seconds.
    */
   public function isTokenExpired(string $token): bool {
     $timestamp = $this->getTokenTimestamp($token);
     if ($timestamp === NULL) {
-      return TRUE;
+      return FALSE;
     }
     return (time() - $timestamp) > self::TOKEN_EXPIRATION;
+  }
+
+  /**
+   * Checks if a token is malformed (cannot be parsed).
+   *
+   * Returns TRUE when the token fails any of the structural checks:
+   * non-base64, no separator, non-numeric or out-of-range timestamp.
+   * This is distinct from "expired" (well-formed but past) and from
+   * "tampered" (well-formed, in-date, but HMAC mismatch).
+   *
+   * Lets the controller render a citizen-friendly "this link is invalid,
+   * check the URL or contact us" message instead of the misleading
+   * "expired link" UX, which suggests the citizen just needs a fresher
+   * link when in fact their URL is corrupted.
+   *
+   * @param string $token
+   *   The token to inspect.
+   *
+   * @return bool
+   *   TRUE if the token cannot be parsed into a (hash, timestamp) pair
+   *   with a sensible numeric timestamp.
+   */
+  public function isTokenMalformed(string $token): bool {
+    return $this->getTokenTimestamp($token) === NULL;
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -162,4 +162,48 @@ class ApprovalTokenServiceTest extends UnitTestCase {
     $this->assertSame($now, $this->service->getTokenTimestamp($token));
   }
 
+  /**
+   * IsTokenExpired only fires for well-formed tokens past the cutoff.
+   *
+   * Malformed tokens have no resolvable timestamp - they are NOT
+   * "expired", they are malformed. isTokenMalformed() reports that
+   * separately so the controller can render distinct UX for each.
+   */
+  public function testIsTokenExpiredSemantics(): void {
+    // Genuinely-past well-formed token → TRUE.
+    $past = $this->service->generateToken(42, 1, time() - 604801);
+    $this->assertTrue($this->service->isTokenExpired($past));
+
+    // Fresh well-formed token → FALSE.
+    $fresh = $this->service->generateToken(42, 1);
+    $this->assertFalse($this->service->isTokenExpired($fresh));
+
+    // Malformed tokens → FALSE (they're not expired, they're malformed).
+    $this->assertFalse($this->service->isTokenExpired(''));
+    $this->assertFalse($this->service->isTokenExpired('!!!not-base64!!!'));
+    $this->assertFalse($this->service->isTokenExpired(base64_encode('no-colon')));
+    $this->assertFalse($this->service->isTokenExpired(base64_encode('hash:not-numeric')));
+  }
+
+  /**
+   * IsTokenMalformed catches every structural failure mode.
+   */
+  public function testIsTokenMalformedSemantics(): void {
+    // Malformed inputs.
+    $this->assertTrue($this->service->isTokenMalformed(''));
+    $this->assertTrue($this->service->isTokenMalformed('!!!not-base64!!!'));
+    $this->assertTrue($this->service->isTokenMalformed(base64_encode('no-colon')));
+    $this->assertTrue($this->service->isTokenMalformed(base64_encode('hash:not-numeric')));
+    $this->assertTrue($this->service->isTokenMalformed(base64_encode('hash:0')));
+    $this->assertTrue($this->service->isTokenMalformed(base64_encode('hash:-12345')));
+
+    // Well-formed tokens (any timestamp) are NOT malformed - even if
+    // they will fail HMAC validation downstream.
+    $fresh = $this->service->generateToken(42, 1);
+    $this->assertFalse($this->service->isTokenMalformed($fresh));
+
+    $tampered = base64_encode('deadbeef:' . time());
+    $this->assertFalse($this->service->isTokenMalformed($tampered));
+  }
+
 }


### PR DESCRIPTION
## Summary

Closes one of the optional follow-ups from #68. The previous controller branched two ways: \`validateToken=FALSE && isTokenExpired=TRUE\` rendered "this link has expired - ask for a new one"; everything else 403'd. But \`isTokenExpired\` returned TRUE for any token with no resolvable timestamp (i.e. malformed shape), so a citizen pasting a truncated email link saw "expired" UX — confusing, since asking for a new link wouldn't help if the URL itself is corrupted.

### Three-way branching now

| Token state | UX | HTTP |
|---|---|---|
| Expired (well-formed, past) | "This approval link has expired. Please contact the case worker for a new link." | 200 |
| Malformed (URL corrupted) | "This approval link is invalid. The URL may have been truncated by your email client — please copy and paste the full link, or contact the case worker for a fresh one." | 200 (distinct copy) |
| Tampered (HMAC mismatch on a well-formed in-date token) | "Access denied" | 403 |

The 403 is now reserved for the only case where it's a meaningful security signal — HMAC tampering — instead of being conflated with "your email client mangled the URL".

### Service-level changes

- \`ApprovalTokenService::isTokenExpired\` now returns TRUE only when the token has a parseable, in-range timestamp older than \`TOKEN_EXPIRATION\`. Malformed tokens are no longer "expired".
- \`ApprovalTokenService::isTokenMalformed\` reports the malformed case explicitly: TRUE when \`getTokenTimestamp\` returns NULL.

## Tests

Added two new unit tests:
- \`testIsTokenExpiredSemantics\` — 4 assertions across genuinely-past, fresh, and 4 malformed shapes.
- \`testIsTokenMalformedSemantics\` — 8 assertions covering every malformed shape + verifying tampered-but-well-formed tokens are NOT marked malformed.

Total: 14 unit tests, 30 assertions, all green.

\`aabenforms-frontend\`'s parent-approval E2E spec still passes 7/7 against the new branching — the \`assertRejected\` helper accepts both "expired" and "invalid" UX copy via regex `/expired|invalid/i`. Verified locally.

## Test plan
- [x] phpcs Drupal standard clean.
- [x] phpunit ApprovalTokenServiceTest 14/14 green.
- [x] frontend parent-approval.spec.ts 7/7 green against the new controller.
- [ ] After merge: visually confirm the new "Invalid Link" copy renders for a malformed token at \`https://api.aabenforms.dk/parent-approval/1/1/!!!not-base64!!!\`.