### PR TITLE
Author 6 missing webforms + ECA flows (closes #43-#48)

### DIFF
--- a/config/sync/eca.eca.address_change_flow.yml
+++ b/config/sync/eca.eca.address_change_flow.yml
@@ -1,0 +1,56 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-addresschange1
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+id: address_change_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission address_change'
+    successors:
+      -
+        id: cpr_lookup
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  cpr_lookup:
+    label: 'CPR registry lookup'
+    plugin: aabenforms_cpr_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:cpr:raw]'
+      result_token: citizen_data
+      use_cache: true
+    successors:
+      -
+        id: log_received
+        condition: ''
+  log_received:
+    label: 'Log: address change received'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: address_change_submitted
+      additional_data_token: '[citizen_data:name]'
+      message_template: 'Address change submitted; CPR resolved against registry.'
+    successors:
+      -
+        id: send_confirmation
+        condition: ''
+  send_confirmation:
+    label: 'Send confirmation via Digital Post'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:cpr:raw]'
+      recipient_type: cpr
+      sender_cvr_token: ''
+      subject_template: 'Bekræftelse på adresseændring'
+      body_template: '<p>Vi har registreret din adresseændring. Den nye adresse er gældende fra den angivne dato.</p>'
+      type: 'Digital Post'
+      result_token: digital_post_result
+    successors: {  }

--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -1,0 +1,56 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-buildperm00001
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+id: building_permit_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission building_permit'
+    successors:
+      -
+        id: cpr_lookup
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  cpr_lookup:
+    label: 'CPR registry lookup'
+    plugin: aabenforms_cpr_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:cpr:raw]'
+      result_token: 'citizen_data'
+      use_cache: true
+    successors:
+      -
+        id: log_received
+        condition: ''
+  log_received:
+    label: 'Log: building_permit_submitted'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: 'building_permit_submitted'
+      additional_data_token: ''
+      message_template: 'Building permit application received; CPR resolved against registry.'
+    successors:
+      -
+        id: send_confirmation
+        condition: ''
+  send_confirmation:
+    label: 'Send confirmation via Digital Post'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:cpr:raw]'
+      recipient_type: 'cpr'
+      sender_cvr_token: ''
+      subject_template: 'Modtaget: ansøgning om byggetilladelse'
+      body_template: '<p>Vi har modtaget din ansøgning om byggetilladelse. En sagsbehandler tager kontakt.</p>'
+      type: 'Digital Post'
+      result_token: 'digital_post_result'
+    successors: {  }

--- a/config/sync/eca.eca.company_verification_flow.yml
+++ b/config/sync/eca.eca.company_verification_flow.yml
@@ -1,0 +1,56 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-companyver0001
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+id: company_verification_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission company_verification'
+    successors:
+      -
+        id: cvr_lookup
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  cvr_lookup:
+    label: 'CVR registry lookup'
+    plugin: aabenforms_cvr_lookup
+    configuration:
+      cvr_token: '[webform_submission:values:cvr:raw]'
+      result_token: 'company_data'
+      use_cache: true
+    successors:
+      -
+        id: log_received
+        condition: ''
+  log_received:
+    label: 'Log: company_verification_submitted'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: 'company_verification_submitted'
+      additional_data_token: ''
+      message_template: 'Company verification request received; CVR resolved.'
+    successors:
+      -
+        id: send_confirmation
+        condition: ''
+  send_confirmation:
+    label: 'Send confirmation via Digital Post'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:cvr:raw]'
+      recipient_type: 'cvr'
+      sender_cvr_token: ''
+      subject_template: 'Verifikationsresultat'
+      body_template: '<p>Resultatet af jeres CVR-verifikation er klar. Se vedlagte bilag.</p>'
+      type: 'Digital Post'
+      result_token: 'digital_post_result'
+    successors: {  }

--- a/config/sync/eca.eca.foi_request_flow.yml
+++ b/config/sync/eca.eca.foi_request_flow.yml
@@ -1,0 +1,30 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-foirequest0001
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+id: foi_request_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission foi_request'
+    successors:
+      -
+        id: log_received
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  log_received:
+    label: 'Log: foi_request_submitted'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: 'foi_request_submitted'
+      additional_data_token: ''
+      message_template: 'FOI request received; case worker will process within 7 working days.'
+    successors: {  }

--- a/config/sync/eca.eca.marriage_booking_flow.yml
+++ b/config/sync/eca.eca.marriage_booking_flow.yml
@@ -1,0 +1,67 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-marriage000001
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+id: marriage_booking_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission marriage_booking'
+    successors:
+      -
+        id: cpr_lookup_partner1
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  cpr_lookup_partner1:
+    label: 'CPR registry lookup (partner 1)'
+    plugin: aabenforms_cpr_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:partner1_cpr:raw]'
+      result_token: 'partner1_data'
+      use_cache: true
+    successors:
+      -
+        id: cpr_lookup_partner2
+        condition: ''
+  cpr_lookup_partner2:
+    label: 'CPR registry lookup (partner 2)'
+    plugin: aabenforms_cpr_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:partner2_cpr:raw]'
+      result_token: 'partner2_data'
+      use_cache: true
+    successors:
+      -
+        id: log_received
+        condition: ''
+  log_received:
+    label: 'Log: marriage_booking_submitted'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: 'marriage_booking_submitted'
+      additional_data_token: ''
+      message_template: 'Marriage booking received; both partners CPR-verified.'
+    successors:
+      -
+        id: send_confirmation
+        condition: ''
+  send_confirmation:
+    label: 'Send confirmation via Digital Post'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:partner1_cpr:raw]'
+      recipient_type: 'cpr'
+      sender_cvr_token: ''
+      subject_template: 'Bekræftelse af vielsesbooking'
+      body_template: '<p>Vi har modtaget jeres ansøgning om civil vielse. I modtager bekræftelse på dato i Digital Post.</p>'
+      type: 'Digital Post'
+      result_token: 'digital_post_result'
+    successors: {  }

--- a/config/sync/eca.eca.parking_permit_flow.yml
+++ b/config/sync/eca.eca.parking_permit_flow.yml
@@ -1,0 +1,56 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-parking0000001
+langcode: en
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+id: parking_permit_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission parking_permit'
+    successors:
+      -
+        id: cpr_lookup
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  cpr_lookup:
+    label: 'CPR registry lookup'
+    plugin: aabenforms_cpr_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:cpr:raw]'
+      result_token: 'citizen_data'
+      use_cache: true
+    successors:
+      -
+        id: log_received
+        condition: ''
+  log_received:
+    label: 'Log: parking_permit_submitted'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: 'parking_permit_submitted'
+      additional_data_token: ''
+      message_template: 'Parking permit application received; CPR resolved.'
+    successors:
+      -
+        id: send_confirmation
+        condition: ''
+  send_confirmation:
+    label: 'Send confirmation via Digital Post'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:cpr:raw]'
+      recipient_type: 'cpr'
+      sender_cvr_token: ''
+      subject_template: 'Behandling af parkeringstilladelse'
+      body_template: '<p>Vi har modtaget din ansøgning om parkeringstilladelse. Afgørelse leveres i Digital Post.</p>'
+      type: 'Digital Post'
+      result_token: 'digital_post_result'
+    successors: {  }

--- a/config/sync/webform.webform.address_change.yml
+++ b/config/sync/webform.webform.address_change.yml
@@ -1,0 +1,224 @@
+uuid: 8d3c4f1a-1234-4567-89ab-address0001
+langcode: en
+status: open
+dependencies: {  }
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: address_change
+title: 'Address Change'
+description: 'Notify the municipality of a registered address change.'
+categories: {  }
+elements: |
+  cpr:
+    '#type': textfield
+    '#title': 'CPR number (DDMMYY-XXXX)'
+    '#required': true
+    '#pattern': '\d{6}-?\d{4}'
+    '#placeholder': '0101900001'
+  old_address:
+    '#type': textfield
+    '#title': 'Current address'
+    '#required': true
+    '#placeholder': 'Lohgade 1, 2100 København Ø'
+  new_address:
+    '#type': textfield
+    '#title': 'New address'
+    '#required': true
+    '#placeholder': 'Vestergade 5, 8000 Aarhus C'
+  moving_date:
+    '#type': date
+    '#title': 'Moving date'
+    '#required': true
+  consent:
+    '#type': checkbox
+    '#title': 'I confirm the information above is accurate.'
+    '#required': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Address change registered. You will receive a confirmation in Digital Post.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.building_permit.yml
+++ b/config/sync/webform.webform.building_permit.yml
@@ -1,0 +1,219 @@
+uuid: 8d3c4f1a-1234-4567-89ab-buildperm0001
+langcode: en
+status: open
+dependencies: {  }
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: building_permit
+title: 'Building Permit Application'
+description: 'Apply for a residential building permit (extensions, garages, sheds).'
+categories: {  }
+elements: |
+    cpr:
+      '#type': textfield
+      '#title': 'CPR number (DDMMYY-XXXX)'
+      '#required': true
+      '#pattern': '\d{6}-?\d{4}'
+    applicant_name:
+      '#type': textfield
+      '#title': 'Applicant name'
+      '#required': true
+    property_address:
+      '#type': textfield
+      '#title': 'Property address'
+      '#required': true
+    project_description:
+      '#type': textarea
+      '#title': 'Project description'
+      '#required': true
+      '#rows': 4
+      '#description': 'Describe what you intend to build, the size in m², and proximity to property lines.'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Your building-permit application has been registered. The case worker will respond via Digital Post.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.company_verification.yml
+++ b/config/sync/webform.webform.company_verification.yml
@@ -1,0 +1,216 @@
+uuid: 8d3c4f1a-1234-4567-89ab-companyver001
+langcode: en
+status: open
+dependencies: {  }
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: company_verification
+title: 'Company Verification'
+description: 'B2B verification flow for supplier-onboarding due diligence.'
+categories: {  }
+elements: |
+    cvr:
+      '#type': textfield
+      '#title': 'Company CVR (8 digits)'
+      '#required': true
+      '#pattern': '\d{8}'
+    director_cpr:
+      '#type': textfield
+      '#title': 'Director CPR (DDMMYY-XXXX)'
+      '#required': true
+      '#pattern': '\d{6}-?\d{4}'
+    verification_purpose:
+      '#type': textarea
+      '#title': 'Verification purpose'
+      '#required': true
+      '#rows': 3
+      '#description': 'Why is the verification being requested? (Onboarding, audit, KYC, etc.)'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Verification request received. Result delivered via Digital Post to the company CVR.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.foi_request.yml
+++ b/config/sync/webform.webform.foi_request.yml
@@ -1,0 +1,214 @@
+uuid: 8d3c4f1a-1234-4567-89ab-foirequest001
+langcode: en
+status: open
+dependencies: {  }
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: foi_request
+title: 'Freedom of Information Request'
+description: 'Submit a request for access to municipal records under the Public Information Act.'
+categories: {  }
+elements: |
+    requester_name:
+      '#type': textfield
+      '#title': 'Your name'
+      '#required': true
+    requester_email:
+      '#type': email
+      '#title': 'Email address for response'
+      '#required': true
+    request_text:
+      '#type': textarea
+      '#title': 'What records do you want access to?'
+      '#required': true
+      '#rows': 6
+      '#description': 'Be as specific as possible (case numbers, date ranges, document types).'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Your FOI request has been logged. The municipality must respond within 7 working days.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.marriage_booking.yml
+++ b/config/sync/webform.webform.marriage_booking.yml
@@ -1,0 +1,230 @@
+uuid: 8d3c4f1a-1234-4567-89ab-marriage00001
+langcode: en
+status: open
+dependencies: {  }
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: marriage_booking
+title: 'Civil Marriage Booking'
+description: 'Book a civil marriage ceremony at the municipality.'
+categories: {  }
+elements: |
+    partner1_cpr:
+      '#type': textfield
+      '#title': 'Partner 1 CPR (DDMMYY-XXXX)'
+      '#required': true
+      '#pattern': '\d{6}-?\d{4}'
+    partner1_name:
+      '#type': textfield
+      '#title': 'Partner 1 full name'
+      '#required': true
+    partner2_cpr:
+      '#type': textfield
+      '#title': 'Partner 2 CPR (DDMMYY-XXXX)'
+      '#required': true
+      '#pattern': '\d{6}-?\d{4}'
+    partner2_name:
+      '#type': textfield
+      '#title': 'Partner 2 full name'
+      '#required': true
+    ceremony_date:
+      '#type': date
+      '#title': 'Preferred ceremony date'
+      '#required': true
+    witness1_name:
+      '#type': textfield
+      '#title': 'Witness 1 full name'
+      '#required': true
+    witness2_name:
+      '#type': textfield
+      '#title': 'Witness 2 full name'
+      '#required': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Booking received. Both partners will receive a confirmation in Digital Post once a date is allocated.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.parking_permit.yml
+++ b/config/sync/webform.webform.parking_permit.yml
@@ -1,0 +1,220 @@
+uuid: 8d3c4f1a-1234-4567-89ab-parking000001
+langcode: en
+status: open
+dependencies: {  }
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: parking_permit
+title: 'Resident Parking Permit'
+description: 'Apply for a resident-zone parking permit for your registered vehicle.'
+categories: {  }
+elements: |
+    cpr:
+      '#type': textfield
+      '#title': 'CPR number (DDMMYY-XXXX)'
+      '#required': true
+      '#pattern': '\d{6}-?\d{4}'
+    address:
+      '#type': textfield
+      '#title': 'Registered address'
+      '#required': true
+    vehicle_registration:
+      '#type': textfield
+      '#title': 'Vehicle registration plate'
+      '#required': true
+      '#pattern': '[A-Z0-9]{2,7}'
+    duration_months:
+      '#type': number
+      '#title': 'Duration (months)'
+      '#required': true
+      '#min': 1
+      '#max': 12
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Permit application registered. Decision sent via Digital Post within 5 working days.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }


### PR DESCRIPTION
## Summary

Ships the 12 config files (one \`webform.webform.X.yml\` + one \`eca.eca.X_flow.yml\` per form) for the 6 templates that had BPMN definitions on disk but no webform/flow wiring. Closes the 6 per-form issues from the #68 spin-off (#43, #44, #45, #46, #47, #48).

## Per-form (observed step counts after smoke)

| Form | Steps | ECA action chain |
|---|---|---|
| `address_change` | 3 | cpr_lookup → audit_log → digital_post_send |
| `building_permit` | 3 | cpr_lookup → audit_log → digital_post_send |
| `company_verification` | 2 | cvr_lookup* → audit_log → digital_post_send |
| `foi_request` | 1 | audit_log (anonymous-allowed, no CPR/Digital Post) |
| `marriage_booking` | 3 | 2x cpr_lookup* → audit_log → digital_post_send |
| `parking_permit` | 3 | cpr_lookup → audit_log → digital_post_send |

\* `CvrLookupAction` never calls `recordStep()`, and the second CPR lookup in marriage_booking similarly doesn't appear in `workflow.steps`. Both are pre-existing action-plugin bugs (the underlying lookups DO run; they just don't surface in the response). I'll file separately.

## Verified locally

- `drush cim -y` imports all 12 files cleanly on fresh local DDEV. No `PluginNotFoundException`, no missing-service errors.
- `POST /api/webform/<form_id>/submit` returns 201 + `workflow.steps` for each form.

## Test plan

- [x] phpcs Drupal standard clean (yaml).
- [x] `drush cim -y` clean on fresh local.
- [x] `POST /api/webform/<form_id>/submit` returns 201 with the expected step count for each form.
- [ ] After merge: matching frontend PR re-adds the 6 fixtures in `tests/fixtures/template-fixtures.ts` so `all-templates.spec.ts` covers 13/13 templates.

Closes #43 #44 #45 #46 #47 #48