### PR TITLE
Add parent_approval_mitid route + handoff stub (closes #51)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
@@ -67,6 +67,15 @@ aabenforms_workflows.parent_approval:
     _permission: 'access content'
     parent_number: '1|2'
 
+aabenforms_workflows.parent_approval_mitid:
+  path: '/parent-approval/{parent_number}/{submission_id}/{token}/mitid'
+  defaults:
+    _controller: '\Drupal\aabenforms_workflows\Controller\ParentApprovalController::mitidLogin'
+    _title: 'Parent Approval - MitID Login'
+  requirements:
+    _permission: 'access content'
+    parent_number: '1|2'
+
 aabenforms_workflows.parent_approval_complete:
   path: '/parent-approval/complete/{action}'
   defaults:

--- a/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
 use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -263,6 +264,60 @@ class ParentApprovalController extends ControllerBase {
       return $text;
     }
     return mb_substr($text, 0, $length) . '...';
+  }
+
+  /**
+   * Handles the parent's MitID login handoff.
+   *
+   * Demo-mode behaviour: validates the token (same gating as
+   * approvalPage so a tampered/expired/malformed link can't bypass the
+   * MitID requirement by navigating directly to this route), flips the
+   * parent's session flag, then redirects back to the approval page
+   * which now renders the form instead of the login button.
+   *
+   * @todo Replace the session-flag flip with a real OIDC handoff via
+   *   aabenforms_mitid: send the parent through MitId\Service\MitIdOidcClient::getAuthorizationUrl()
+   *   with a return URL of /parent-approval/{p}/{sid}/{token}, and on
+   *   the OIDC callback verify the CPR matches the submission's
+   *   parent{N}_email tied to the consenting parent before flipping the
+   *   session. The current stub is sufficient for the citizen-flow
+   *   smoke; production needs the real handoff.
+   *
+   * @param int $parent_number
+   *   The parent number (1 or 2).
+   * @param int $submission_id
+   *   The webform submission ID.
+   * @param string $token
+   *   The security token.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect back to the approval page.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   */
+  public function mitidLogin(int $parent_number, int $submission_id, string $token, Request $request): RedirectResponse {
+    if (!$this->tokenService->validateToken($submission_id, $parent_number, $token)) {
+      $this->logger->warning('Invalid token at MitID handoff for submission @sid, parent @parent', [
+        '@sid' => $submission_id,
+        '@parent' => $parent_number,
+      ]);
+      throw new AccessDeniedHttpException('Invalid approval token.');
+    }
+
+    $request->getSession()->set("mitid_authenticated_parent{$parent_number}", TRUE);
+    $this->logger->info('Parent @parent MitID handoff complete for submission @sid (demo stub)', [
+      '@parent' => $parent_number,
+      '@sid' => $submission_id,
+    ]);
+
+    $url = Url::fromRoute('aabenforms_workflows.parent_approval', [
+      'parent_number' => $parent_number,
+      'submission_id' => $submission_id,
+      'token' => $token,
+    ])->toString();
+    return new RedirectResponse($url);
   }
 
   /**


### PR DESCRIPTION
## Summary

The \`ParentApprovalController\` referenced an \`aabenforms_workflows.parent_approval_mitid\` route that **never existed** in \`routing.yml\`. Every successful token-validated visit blew up with \`RouteNotFoundException\` at the URL build step, so the parent-approval flow was 100% broken end-to-end. Surfaced by aabenforms#42's drush mint bridge actually exercising the happy path; tracked as #51.

### Changes

1. **New route**: \`/parent-approval/{parent_number}/{submission_id}/{token}/mitid\` → `ParentApprovalController::mitidLogin()`.
2. **New controller method `mitidLogin()`**: validates the token (same gating as `approvalPage` so a bad link can't bypass MitID by navigating directly), flips the parent's session flag, redirects back.
3. **TODO** in the docblock: the current behaviour is a demo stub; production should redirect through the existing `aabenforms_mitid` OIDC client and verify the returned CPR matches the submission's `parent{N}_email`. The scaffold here is what the real integration plugs into.

### Verified end-to-end with cookies

```
1. Initial visit:  /parent-approval/1/{sid}/{token}    → 200, body has "MitID" button
2. MitID handoff:  /parent-approval/1/{sid}/{token}/mitid → 302 redirect
3. Re-visit:       /parent-approval/1/{sid}/{token}    → 200, body has Approve/Reject form
```

## Test plan

- [x] phpcs Drupal standard clean.
- [x] Three-step cookie flow above passes locally.
- [x] aabenforms-frontend's parent-approval E2E spec (8 tests, including #42's valid-token assertion) still passes.
- [ ] After merge: visually walk through a real parent-approval link end-to-end on prod.

Closes #51