### PR TITLE
Interactive Byggetilladelse demo with themed mock IdP and Digital Post inbox

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ use_dns_when_possible: true
 composer_version: "2"
 nodejs_version: "22"
 web_environment:
-  - CORS_ALLOW_ORIGIN=https://aabenforms-frontend.ddev.site
+  - CORS_ALLOW_ORIGIN=http://aabenforms-frontend.ddev.site:3000
 corepack_enable: true
 
 # Key features of DDEV's config.yaml:

--- a/.ddev/mocks/keycloak/realms/danish-gov-test.json
+++ b/.ddev/mocks/keycloak/realms/danish-gov-test.json
@@ -18,6 +18,7 @@
   "internationalizationEnabled": true,
   "supportedLocales": ["da", "en"],
   "defaultLocale": "da",
+  "loginTheme": "aabenforms-mitid",
 
   "clients": [
     {
@@ -47,6 +48,59 @@
         "access.token.lifespan": "3600"
       },
       "protocolMappers": [
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "claim.name": "given_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "claim.name": "family_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
         {
           "name": "cpr",
           "protocol": "openid-connect",
@@ -114,6 +168,62 @@
             "id.token.claim": "true",
             "access.token.claim": "true"
           }
+        },
+        {
+          "name": "street",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "street",
+            "claim.name": "street",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "postal_code",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "postal_code",
+            "claim.name": "postal_code",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "city",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "city",
+            "claim.name": "city",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "municipality_code",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "municipality_code",
+            "claim.name": "municipality_code",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
         }
       ]
     },
@@ -160,6 +270,10 @@
         "birthdate": ["1990-01-01"],
         "given_name": ["Freja"],
         "family_name": ["Nielsen"],
+        "street": ["Nørrebrogade 142, 3. tv."],
+        "postal_code": ["2200"],
+        "city": ["København N"],
+        "municipality_code": ["0101"],
         "assurance_level": ["http://eidas.europa.eu/LoA/substantial"],
         "description": ["Typical citizen - Common Danish name, Copenhagen resident"]
       },
@@ -184,6 +298,10 @@
         "birthdate": ["1985-02-15"],
         "given_name": ["Mikkel"],
         "family_name": ["Jensen"],
+        "street": ["Vestergade 27, 2. th."],
+        "postal_code": ["8000"],
+        "city": ["Aarhus C"],
+        "municipality_code": ["0751"],
         "assurance_level": ["http://eidas.europa.eu/LoA/substantial"],
         "description": ["Typical citizen - Most common Danish surname"]
       },
@@ -208,6 +326,10 @@
         "birthdate": ["1992-06-25"],
         "given_name": ["Sofie"],
         "family_name": ["Hansen"],
+        "street": ["Hjallesevej 88"],
+        "postal_code": ["5230"],
+        "city": ["Odense M"],
+        "municipality_code": ["0461"],
         "assurance_level": ["http://eidas.europa.eu/LoA/substantial"],
         "description": ["Young parent with children"]
       },
@@ -282,6 +404,10 @@
         "given_name": ["Karen"],
         "family_name": ["Christensen"],
         "organization_name": ["Test ApS"],
+        "street": ["Nytorv 11"],
+        "postal_code": ["9000"],
+        "city": ["Aalborg"],
+        "municipality_code": ["0851"],
         "assurance_level": ["http://eidas.europa.eu/LoA/high"],
         "description": ["Business owner - MitID Erhverv user with CVR"]
       },

--- a/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/login.ftl
+++ b/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/login.ftl
@@ -1,0 +1,91 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=false; section>
+    <#if section = "header">
+        <span class="aabenforms-hidden-title">${msg("loginAccountTitle")}</span>
+    <#elseif section = "form">
+        <div class="aabenforms-brand-header">
+            <div class="aabenforms-brand-row">
+                <img src="${url.resourcesPath}/img/logo.svg" alt="ÅbenForms" class="aabenforms-logo" />
+                <span class="aabenforms-brand-mark">MitID - Demo</span>
+            </div>
+            <p class="aabenforms-brand-tag">${msg("aabenformsBrandTagline")}</p>
+        </div>
+        <div class="aabenforms-demo-banner" role="note">
+            <span class="aabenforms-demo-banner-icon" aria-hidden="true">●</span>
+            <div>
+                <strong>${msg("aabenformsDemoBannerTitle")}</strong>
+                <span class="aabenforms-demo-banner-body">${msg("aabenformsDemoBannerBody")}</span>
+            </div>
+        </div>
+        <h2 class="aabenforms-pagetitle">${msg("loginAccountTitle")}</h2>
+
+        <div id="kc-form">
+            <div id="kc-form-wrapper">
+                <#if realm.password>
+                    <form id="kc-form-login" class="aabenforms-form" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                        <#if !usernameHidden??>
+                            <div class="aabenforms-field">
+                                <label for="username" class="aabenforms-label">
+                                    <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+                                </label>
+                                <input
+                                    tabindex="2"
+                                    id="username"
+                                    class="aabenforms-input"
+                                    name="username"
+                                    value="${(login.username!'')}"
+                                    type="text"
+                                    autofocus
+                                    autocomplete="username"
+                                    aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                                />
+                                <#if messagesPerField.existsError('username','password')>
+                                    <span id="input-error" class="aabenforms-error" aria-live="polite">
+                                        ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                    </span>
+                                </#if>
+                            </div>
+                        </#if>
+
+                        <div class="aabenforms-field">
+                            <label for="password" class="aabenforms-label">${msg("password")}</label>
+                            <input
+                                tabindex="3"
+                                id="password"
+                                class="aabenforms-input"
+                                name="password"
+                                type="password"
+                                autocomplete="current-password"
+                                aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                            />
+                        </div>
+
+                        <div class="aabenforms-helper-row">
+                            <span class="aabenforms-helper">${msg("aabenformsCredentialHint")}</span>
+                        </div>
+
+                        <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+
+                        <div id="kc-form-buttons" class="aabenforms-actions">
+                            <button
+                                tabindex="4"
+                                class="aabenforms-button-primary"
+                                name="login"
+                                id="kc-login"
+                                type="submit"
+                            >
+                                <span class="aabenforms-button-label">${msg("doLogIn")}</span>
+                                <span class="aabenforms-button-arrow" aria-hidden="true">→</span>
+                            </button>
+                        </div>
+                    </form>
+                </#if>
+            </div>
+        </div>
+
+        <div class="aabenforms-foot">
+            <p class="aabenforms-foot-line">${msg("aabenformsFooterLicense")}</p>
+            <p class="aabenforms-foot-line">${msg("aabenformsFooterReturn")}</p>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/messages/messages_da.properties
+++ b/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/messages/messages_da.properties
@@ -1,0 +1,16 @@
+loginAccountTitle=Log ind med MitID
+doLogIn=Bekræft og fortsæt
+username=MitID brugernavn
+usernameOrEmail=MitID brugernavn
+password=Adgangskode
+errorTitle=Login mislykkedes
+invalidUserMessage=Forkert brugernavn eller adgangskode.
+backToLogin=Tilbage til login
+
+# AabenForms-specific overrides surfaced by the custom login.ftl.
+aabenformsBrandTagline=Demo-identitetsudbyder for ÅbenForms-borgerforløb.
+aabenformsDemoBannerTitle=Mock-IdP - ikke ægte MitID
+aabenformsDemoBannerBody=Intet rigtigt CPR-nummer sendes. Brug en af demo-brugerne (kodeord test1234) for at se flowet.
+aabenformsCredentialHint=Demo-brugere: freja.nielsen, mikkel.jensen, sofie.hansen, karen.christensen - kodeord test1234.
+aabenformsFooterLicense=ÅbenForms · Åben kildekode under EUPL-1.2.
+aabenformsFooterReturn=Du sendes tilbage til ÅbenForms efter godkendelse.

--- a/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/messages/messages_en.properties
+++ b/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/messages/messages_en.properties
@@ -1,0 +1,16 @@
+loginAccountTitle=Sign in with MitID
+doLogIn=Confirm and continue
+username=MitID username
+usernameOrEmail=MitID username
+password=Password
+errorTitle=Sign-in failed
+invalidUserMessage=Invalid username or password.
+backToLogin=Back to sign-in
+
+# AabenForms-specific overrides surfaced by the custom login.ftl.
+aabenformsBrandTagline=Demo identity provider for AabenForms citizen flows.
+aabenformsDemoBannerTitle=Mock IdP - not real MitID
+aabenformsDemoBannerBody=No real CPR number is transmitted. Use one of the demo users (password test1234) to see the flow.
+aabenformsCredentialHint=Demo users: freja.nielsen, mikkel.jensen, sofie.hansen, karen.christensen - password test1234.
+aabenformsFooterLicense=AabenForms · Open source under EUPL-1.2.
+aabenformsFooterReturn=You will be returned to AabenForms after authentication.

--- a/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/resources/css/login.css
+++ b/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/resources/css/login.css
@@ -1,0 +1,397 @@
+/* AabenForms MitID-style mock theme.
+ *
+ * Visual language: Danish gov-tech credibility - navy + coral, Atkinson
+ * Hyperlegible Next, generous whitespace, soft elevation. The "demo" banner
+ * is a non-negotiable: every interaction screen must surface that this is a
+ * mock IdP and no real CPR is in flight. */
+
+@import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;500;600;700&display=swap');
+
+:root {
+    --af-navy: #0a2240;
+    --af-navy-deep: #061830;
+    --af-coral: #ff5a5f;
+    --af-coral-hover: #ff3d44;
+    --af-paper: #ffffff;
+    --af-canvas: #eef1f6;
+    --af-line: #d8dde6;
+    --af-text: #11203a;
+    --af-text-soft: #5b6781;
+    --af-amber: #f4b21a;
+    --af-amber-soft: #fff4d2;
+    --af-radius: 12px;
+    --af-radius-sm: 8px;
+    --af-shadow: 0 24px 60px rgba(10, 34, 64, 0.14), 0 6px 16px rgba(10, 34, 64, 0.08);
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--af-canvas);
+    color: var(--af-text);
+    font-family: 'Atkinson Hyperlegible Next', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* Hide Keycloak's default page chrome - the inherited template.ftl wraps
+ * the form with a header section, page title and a dark patterned bg image
+ * we don't want. We hide the lot and re-anchor inside the form section. */
+.aabenforms-hidden-title,
+#kc-page-title,
+.login-pf-header,
+.login-pf-page-header,
+#kc-header,
+#kc-header-wrapper { display: none !important; }
+
+/* Page background gets a subtle navy gradient hairline at the top edge to
+ * frame the login card. */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0 0 auto 0;
+    height: 6px;
+    background: linear-gradient(90deg, var(--af-navy) 0%, var(--af-coral) 100%);
+    z-index: 50;
+}
+
+/* Aggressive backdrop reset - kill the inherited diamond pattern bg image
+ * and the dark gradient the parent theme paints behind everything. The
+ * Keycloak parent CSS sets the diamond pattern via a body background-image
+ * and an injected ::before pseudo - we wipe both. */
+html, html body,
+html.login-pf, body.login-pf, body.login-pf-body,
+.login-pf, .login-pf-page,
+.login-pf-page-header, .login-pf-body {
+    background: var(--af-canvas) !important;
+    background-image: none !important;
+    background-color: var(--af-canvas) !important;
+    color: var(--af-text) !important;
+}
+
+body::after, .login-pf-page::before, .login-pf-page::after,
+.login-pf-body::before, .login-pf-body::after {
+    background: none !important;
+    background-image: none !important;
+    content: none !important;
+    display: none !important;
+}
+
+.login-pf-page {
+    padding-top: 64px;
+    padding-bottom: 64px;
+    min-height: 100vh;
+    box-sizing: border-box;
+    position: relative;
+    z-index: 1;
+}
+
+.card-pf {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    max-width: 480px;
+    margin: 0 auto;
+}
+
+#kc-content,
+#kc-content-wrapper {
+    background: var(--af-paper);
+    border-radius: var(--af-radius);
+    box-shadow: var(--af-shadow);
+    padding: 0;
+    overflow: hidden;
+    border: 1px solid var(--af-line);
+}
+
+#kc-form,
+#kc-form-wrapper {
+    background: transparent;
+    padding: 0 32px 28px;
+}
+
+/* Brand header - navy band with logo + "MitID Demo" tag. */
+.aabenforms-brand-header {
+    background: linear-gradient(140deg, var(--af-navy) 0%, var(--af-navy-deep) 100%);
+    color: var(--af-paper);
+    padding: 28px 32px 24px;
+}
+
+.aabenforms-brand-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.aabenforms-logo {
+    height: 32px;
+    width: auto;
+    display: block;
+}
+
+.aabenforms-brand-mark {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.aabenforms-brand-tag {
+    margin: 12px 0 0;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+/* Demo banner - amber, immediately under the brand header. */
+.aabenforms-demo-banner {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    background: var(--af-amber-soft);
+    color: #5a4505;
+    padding: 14px 32px;
+    border-bottom: 1px solid #f0e0a8;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.aabenforms-demo-banner-icon {
+    color: var(--af-amber);
+    font-size: 18px;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.aabenforms-demo-banner strong {
+    display: block;
+    color: #4a3a04;
+    margin-bottom: 2px;
+    font-weight: 700;
+}
+
+.aabenforms-demo-banner-body {
+    display: block;
+    color: #6a5510;
+}
+
+/* Page title inside the card. */
+.aabenforms-pagetitle {
+    margin: 28px 32px 18px;
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--af-text);
+}
+
+/* Form fields. */
+.aabenforms-field {
+    margin-bottom: 18px;
+}
+
+.aabenforms-label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--af-text);
+    letter-spacing: 0.01em;
+}
+
+.aabenforms-input,
+input[type="text"]#username,
+input[type="password"]#password {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 14px;
+    border: 1.5px solid var(--af-line);
+    border-radius: var(--af-radius-sm);
+    background: var(--af-paper);
+    color: var(--af-text);
+    font-family: inherit;
+    font-size: 15px;
+    line-height: 1.4;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.aabenforms-input:focus,
+input[type="text"]#username:focus,
+input[type="password"]#password:focus {
+    outline: none;
+    border-color: var(--af-navy);
+    box-shadow: 0 0 0 3px rgba(10, 34, 64, 0.12);
+}
+
+.aabenforms-input[aria-invalid="true"] {
+    border-color: var(--af-coral);
+    box-shadow: 0 0 0 3px rgba(255, 90, 95, 0.12);
+}
+
+.aabenforms-error {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--af-coral-hover);
+    font-weight: 500;
+}
+
+.aabenforms-helper-row {
+    margin: -8px 0 18px;
+}
+
+.aabenforms-helper {
+    font-size: 12px;
+    color: var(--af-text-soft);
+}
+
+/* Primary CTA - coral with arrow. */
+.aabenforms-actions {
+    margin-top: 24px;
+}
+
+.aabenforms-button-primary,
+button#kc-login {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 14px 20px;
+    border: none;
+    border-radius: var(--af-radius-sm);
+    background: var(--af-coral);
+    color: var(--af-paper);
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: background 120ms ease, transform 120ms ease;
+}
+
+.aabenforms-button-primary:hover,
+button#kc-login:hover {
+    background: var(--af-coral-hover);
+}
+
+.aabenforms-button-primary:active,
+button#kc-login:active {
+    transform: translateY(1px);
+}
+
+.aabenforms-button-arrow {
+    font-size: 18px;
+    line-height: 1;
+}
+
+/* Footer copy under form. */
+.aabenforms-foot {
+    margin: 22px 32px 28px;
+    padding-top: 18px;
+    border-top: 1px solid var(--af-line);
+    text-align: center;
+}
+
+.aabenforms-foot-line {
+    margin: 4px 0;
+    font-size: 12px;
+    color: var(--af-text-soft);
+    line-height: 1.5;
+}
+
+/* Locale switcher - top-right of the card area. Keycloak renders it as
+ * #kc-locale; we want it visible but minimal. */
+#kc-locale {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    z-index: 60;
+}
+
+#kc-locale ul {
+    display: flex;
+    gap: 6px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+#kc-locale a {
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: var(--af-text-soft);
+    font-size: 12px;
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px solid var(--af-line);
+}
+
+#kc-locale a:hover {
+    background: var(--af-paper);
+    color: var(--af-navy);
+}
+
+/* Alert messages from Keycloak - re-skin as our coral/amber/green. */
+.alert {
+    border-radius: var(--af-radius-sm);
+    padding: 12px 14px;
+    margin: 0 32px 16px;
+    font-size: 13px;
+    border: 1px solid transparent;
+}
+
+.alert-error {
+    background: #fde9ea;
+    color: #8a1a1f;
+    border-color: #f5b7ba;
+}
+
+.alert-warning {
+    background: var(--af-amber-soft);
+    color: #6a5510;
+    border-color: #f0e0a8;
+}
+
+.alert-success {
+    background: #e3f4ea;
+    color: #155f3b;
+    border-color: #a7d8bb;
+}
+
+/* Mobile. */
+@media (max-width: 540px) {
+    .login-pf-page,
+    body.login-pf {
+        padding-top: 24px;
+        padding-bottom: 24px;
+    }
+    .card-pf {
+        max-width: 100%;
+        margin: 0 16px;
+    }
+    .aabenforms-brand-header,
+    .aabenforms-demo-banner,
+    .aabenforms-pagetitle,
+    #kc-form-wrapper,
+    .aabenforms-foot {
+        padding-left: 22px;
+        padding-right: 22px;
+    }
+    .aabenforms-foot {
+        margin-left: 0;
+        margin-right: 0;
+    }
+}

--- a/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/resources/img/logo.svg
+++ b/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/resources/img/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 64" fill="none" role="img" aria-label="ÅbenForms">
+  <!-- Icon: identical to /favicon.svg (blue square + white BPMN grid). -->
+  <rect width="64" height="64" rx="12" fill="#0071b9"/>
+  <g fill="#ffffff" transform="translate(8 8) scale(2.0833)">
+    <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
+  </g>
+  <!-- Wordmark, white on the navy login header band. -->
+  <text x="80" y="43" fill="#ffffff" font-family="'Atkinson Hyperlegible Next', system-ui, -apple-system, sans-serif" font-weight="700" font-size="28" letter-spacing="0.5">ÅbenForms</text>
+</svg>

--- a/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/theme.properties
+++ b/.ddev/mocks/keycloak/themes/aabenforms-mitid/login/theme.properties
@@ -1,0 +1,18 @@
+parent=keycloak
+import=common/keycloak
+
+styles=css/login.css
+
+locales=da,en
+
+# Make the inherited template inject our banner via the page header area.
+kcHeaderClass=aabenforms-header
+kcLoginClass=aabenforms-login
+kcFormHeaderClass=aabenforms-formheader
+kcContentWrapperClass=aabenforms-content
+kcFormClass=aabenforms-form
+kcInputClass=aabenforms-input
+kcButtonClass=aabenforms-button
+kcButtonPrimaryClass=aabenforms-button-primary
+kcButtonBlockClass=aabenforms-button-block
+kcButtonLargeClass=aabenforms-button-large

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/aabenforms_digital_post_session_inbox.info.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/aabenforms_digital_post_session_inbox.info.yml
@@ -1,0 +1,8 @@
+name: 'AabenForms Digital Post - Session Inbox'
+type: module
+description: 'Read-only HTTP endpoint that returns the recent Digital Post log rows for the recipient bound to a MitID workflow session. Bridges aabenforms_digital_post (the log) and aabenforms_mitid (the session-as-capability) without polluting either parent module''s minimal dependency set.'
+package: 'AabenForms'
+core_version_requirement: ^11
+dependencies:
+  - aabenforms_digital_post
+  - aabenforms_mitid

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/aabenforms_digital_post_session_inbox.routing.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/aabenforms_digital_post_session_inbox.routing.yml
@@ -1,0 +1,9 @@
+aabenforms_digital_post_session_inbox.recent:
+  path: '/api/digital-post/recent'
+  defaults:
+    _controller: '\Drupal\aabenforms_digital_post_session_inbox\Controller\SessionInboxController::getRecent'
+  methods: [GET]
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: TRUE

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/src/Controller/SessionInboxController.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/src/Controller/SessionInboxController.php
@@ -27,12 +27,23 @@ final class SessionInboxController extends ControllerBase {
   private const DEFAULT_LIMIT = 5;
   private const MAX_LIMIT = 20;
 
+  /**
+   * Constructs a SessionInboxController.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The active database connection.
+   * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $sessionManager
+   *   The MitID session manager - resolves CPR from the workflow_id.
+   */
   public function __construct(
     private readonly Connection $database,
     private readonly MitIdSessionManager $sessionManager,
   ) {
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('database'),

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/src/Controller/SessionInboxController.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_session_inbox/src/Controller/SessionInboxController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post_session_inbox\Controller;
+
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Database\Connection;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Returns recent Digital Post log rows for a MitID session's recipient.
+ *
+ * Capability model: the workflow session id (15-min tempstore) is the only
+ * thing accepted. The controller resolves the session's CPR server-side,
+ * hashes it, and queries the log by hash. The CPR never appears in request
+ * or response. When the session is absent or expired the response is `[]`
+ * with HTTP 200 - the demo frontend renders an empty inbox cleanly without
+ * a 404 spike in the browser console.
+ */
+final class SessionInboxController extends ControllerBase {
+
+  private const DEFAULT_LIMIT = 5;
+  private const MAX_LIMIT = 20;
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly MitIdSessionManager $sessionManager,
+  ) {
+  }
+
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('database'),
+      $container->get('aabenforms_mitid.session_manager'),
+    );
+  }
+
+  /**
+   * GET /api/digital-post/recent?session={workflow_id}&limit=N.
+   */
+  public function getRecent(Request $request): JsonResponse {
+    $sessionId = (string) $request->query->get('session', '');
+    $limit = (int) $request->query->get('limit', self::DEFAULT_LIMIT);
+    if ($limit < 1) {
+      $limit = self::DEFAULT_LIMIT;
+    }
+    if ($limit > self::MAX_LIMIT) {
+      $limit = self::MAX_LIMIT;
+    }
+
+    if ($sessionId === '') {
+      return new JsonResponse(['data' => []]);
+    }
+
+    $cpr = $this->sessionManager->getCprFromSession($sessionId);
+    if (!$cpr) {
+      return new JsonResponse(['data' => []]);
+    }
+
+    // Match Recipient::identifierHash() in aabenforms_digital_post: it
+    // hashes "{type}:{digits}" not just the digits. Stay aligned with the
+    // log writer or the join misses every row.
+    $hash = hash('sha256', 'cpr:' . preg_replace('/\D+/', '', $cpr));
+
+    $rows = $this->database->select('aabenforms_digital_post_log', 'l')
+      ->fields('l', [
+        'transaction_id',
+        'subject',
+        'status',
+        'payload',
+        'created',
+      ])
+      ->condition('l.recipient_type', 'cpr')
+      ->condition('l.recipient_identifier_hash', $hash)
+      ->orderBy('l.created', 'DESC')
+      ->range(0, $limit)
+      ->execute()
+      ->fetchAll(\PDO::FETCH_ASSOC);
+
+    $data = [];
+    foreach ($rows as $row) {
+      $payload = json_decode((string) ($row['payload'] ?? '{}'), TRUE) ?: [];
+      $bodyRaw = is_string($payload['body'] ?? NULL) ? $payload['body'] : '';
+      $data[] = [
+        'transaction_id' => $row['transaction_id'] ?? '',
+        'subject' => $row['subject'] ?? '',
+        'body_html' => Xss::filterAdmin($bodyRaw),
+        'status' => $row['status'] ?? '',
+        'created' => (int) ($row['created'] ?? 0),
+        'created_iso' => gmdate('c', (int) ($row['created'] ?? 0)),
+      ];
+    }
+
+    return new JsonResponse(['data' => $data]);
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/aabenforms_mitid.services.yml
+++ b/web/modules/custom/aabenforms_mitid/aabenforms_mitid.services.yml
@@ -8,7 +8,7 @@ services:
   aabenforms_mitid.session_manager:
     class: Drupal\aabenforms_mitid\Service\MitIdSessionManager
     arguments:
-      - '@tempstore.private'
+      - '@keyvalue.expirable'
       - '@datetime.time'
       - '@logger.factory'
       - '@aabenforms_core.audit_logger'

--- a/web/modules/custom/aabenforms_mitid/src/Controller/MitIdController.php
+++ b/web/modules/custom/aabenforms_mitid/src/Controller/MitIdController.php
@@ -54,8 +54,10 @@ class MitIdController extends ControllerBase {
    *   Redirect to MitID authorization.
    */
   public function login(Request $request): TrustedRedirectResponse {
-    // Get workflow ID from query params or generate.
-    $workflowId = $request->query->get('workflow_id') ?? 'default_' . uniqid();
+    // Get workflow ID from query params or generate. The generated ID is the
+    // bearer capability for the session payload, so it must be unguessable -
+    // bin2hex(random_bytes(...)) gives 32 hex chars (128 bits of entropy).
+    $workflowId = $request->query->get('workflow_id') ?? 'wf_' . bin2hex(random_bytes(16));
 
     // Get redirect URL (where to return after auth).
     // Validate that it's an internal path to prevent open redirect attacks.
@@ -179,6 +181,12 @@ class MitIdController extends ControllerBase {
       $separator = str_contains($returnUrl, '?') ? '&' : '?';
       $redirectUrl = $returnUrl . $separator . 'session=' . urlencode($workflowId);
 
+      // Use TrustedRedirectResponse when the return URL is external - the
+      // open-redirect guard in login() already validated the origin against
+      // CORS_ALLOW_ORIGIN, so this is safe.
+      if (preg_match('#^https?://#i', $redirectUrl)) {
+        return new TrustedRedirectResponse($redirectUrl);
+      }
       return new RedirectResponse($redirectUrl);
 
     }
@@ -233,7 +241,12 @@ class MitIdController extends ControllerBase {
       return new JsonResponse(['error' => 'Session not found or expired'], 404);
     }
 
+    $address = $sessionManager->getAddressFromSession($session_id);
+
     // Return session data in JSON:API-like format for frontend compatibility.
+    // Additive shape: name/cpr/email/expiry have always been here; the demo
+    // route consumes given_name/family_name/birthdate/address/assurance_level
+    // when present. mitid_uuid/auth_time/issuer remain server-side only.
     return new JsonResponse([
       'data' => [
         'type' => 'mitid-session',
@@ -243,6 +256,11 @@ class MitIdController extends ControllerBase {
           'cpr' => $session['cpr'] ?? '',
           'email' => $session['email'] ?? '',
           'expiry' => $session['expires_at'] ?? '',
+          'given_name' => $session['given_name'] ?? '',
+          'family_name' => $session['family_name'] ?? '',
+          'birthdate' => $session['birthdate'] ?? '',
+          'address' => $address,
+          'assurance_level' => $session['assurance_level'] ?? '',
         ],
       ],
     ]);

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdCprExtractor.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdCprExtractor.php
@@ -130,6 +130,14 @@ class MitIdCprExtractor {
       'birthdate' => $claims['birthdate'] ?? NULL,
       'email' => $claims['email'] ?? NULL,
 
+      // Address (mock IdP only - real MitID/NemLog-in does not issue these
+      // claims; absent claims fall through as NULL and the frontend falls
+      // back to manual entry).
+      'street' => $claims['street'] ?? NULL,
+      'postal_code' => $claims['postal_code'] ?? NULL,
+      'city' => $claims['city'] ?? NULL,
+      'municipality_code' => $claims['municipality_code'] ?? NULL,
+
       // Authentication metadata.
     // NSIS level (substantial/high)
       'assurance_level' => $claims['acr'] ?? NULL,

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
@@ -4,8 +4,8 @@ namespace Drupal\aabenforms_mitid\Service;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -16,6 +16,13 @@ use Psr\Log\LoggerInterface;
  * - Short-lived (15 minutes default)
  * - Auto-expiring (no permanent storage)
  * - GDPR compliant (deleted after workflow completion)
+ *
+ * Storage: KeyValueExpirable (NOT PrivateTempStore). The workflow_id IS
+ * the bearer capability - anyone holding it can read the session for 15
+ * minutes. PrivateTempStore was user-bound which broke the demo's
+ * cross-origin fetch (frontend on a different host than the backend cookie
+ * domain saw a fresh anonymous session and couldn't find the entry).
+ * The workflow_id is generated with random_bytes so it's unguessable.
  */
 class MitIdSessionManager {
 
@@ -25,11 +32,16 @@ class MitIdSessionManager {
   protected const SESSION_EXPIRATION = 900;
 
   /**
-   * The private tempstore.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   * The keyvalue-expirable store collection name.
    */
-  protected PrivateTempStoreFactory $tempStore;
+  private const STORE_COLLECTION = 'aabenforms_mitid_sessions';
+
+  /**
+   * The keyvalue-expirable factory.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface
+   */
+  protected KeyValueExpirableFactoryInterface $keyValue;
 
   /**
    * The time service.
@@ -55,8 +67,8 @@ class MitIdSessionManager {
   /**
    * Constructs a MitIdSessionManager.
    *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store
-   *   The private tempstore factory.
+   * @param \Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface $key_value
+   *   The keyvalue-expirable factory.
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
@@ -65,15 +77,22 @@ class MitIdSessionManager {
    *   The audit logger.
    */
   public function __construct(
-    PrivateTempStoreFactory $temp_store,
+    KeyValueExpirableFactoryInterface $key_value,
     TimeInterface $time,
     LoggerChannelFactoryInterface $logger_factory,
     AuditLogger $audit_logger,
   ) {
-    $this->tempStore = $temp_store;
+    $this->keyValue = $key_value;
     $this->time = $time;
     $this->logger = $logger_factory->get('aabenforms_mitid');
     $this->auditLogger = $audit_logger;
+  }
+
+  /**
+   * Returns the underlying keyvalue-expirable store.
+   */
+  private function store() {
+    return $this->keyValue->get(self::STORE_COLLECTION);
   }
 
   /**
@@ -89,15 +108,14 @@ class MitIdSessionManager {
    */
   public function storeSession(string $workflow_id, array $session_data): bool {
     try {
-      $store = $this->tempStore->get('aabenforms_mitid');
-
       // Add metadata.
       $session_data['created_at'] = $this->time->getRequestTime();
       $session_data['expires_at'] = $this->time->getRequestTime() + self::SESSION_EXPIRATION;
       $session_data['workflow_id'] = $workflow_id;
 
-      // Store session.
-      $store->set($workflow_id, $session_data);
+      // Store session in the keyvalue-expirable store with the configured TTL
+      // - the value auto-disappears after SESSION_EXPIRATION seconds.
+      $this->store()->setWithExpire($workflow_id, $session_data, self::SESSION_EXPIRATION);
 
       $this->logger->info('MitID session stored for workflow: {workflow_id}', [
         'workflow_id' => $workflow_id,
@@ -136,14 +154,14 @@ class MitIdSessionManager {
    */
   public function getSession(string $workflow_id): ?array {
     try {
-      $store = $this->tempStore->get('aabenforms_mitid');
-      $session_data = $store->get($workflow_id);
+      $session_data = $this->store()->get($workflow_id);
 
-      if (!$session_data) {
+      if (!$session_data || !is_array($session_data)) {
         return NULL;
       }
 
-      // Check expiration.
+      // Defense-in-depth - the keyvalue store should already have GC'd this,
+      // but check the saved expires_at as well in case TTL drift.
       $expiresAt = $session_data['expires_at'] ?? 0;
       if ($expiresAt < $this->time->getRequestTime()) {
         $this->logger->info('MitID session expired for workflow: {workflow_id}', [
@@ -176,8 +194,7 @@ class MitIdSessionManager {
    */
   public function deleteSession(string $workflow_id): bool {
     try {
-      $store = $this->tempStore->get('aabenforms_mitid');
-      $store->delete($workflow_id);
+      $this->store()->delete($workflow_id);
 
       $this->logger->info('MitID session deleted for workflow: {workflow_id}', [
         'workflow_id' => $workflow_id,
@@ -255,6 +272,40 @@ class MitIdSessionManager {
       'email' => $session['email'] ?? NULL,
       'assurance_level' => $session['assurance_level'] ?? NULL,
       'mitid_uuid' => $session['mitid_uuid'] ?? NULL,
+    ];
+  }
+
+  /**
+   * Gets address from workflow session.
+   *
+   * Returns NULL when no address keys are present (the typical case for real
+   * MitID/NemLog-in - those IdPs don't issue address claims, so the frontend
+   * falls back to manual entry).
+   *
+   * @param string $workflow_id
+   *   The workflow instance ID.
+   *
+   * @return array|null
+   *   ['street' => ..., 'postal_code' => ..., 'city' => ..., 'municipality_code' => ...]
+   *   when at least one key is present, NULL otherwise.
+   */
+  public function getAddressFromSession(string $workflow_id): ?array {
+    $session = $this->getSession($workflow_id);
+    if (!$session) {
+      return NULL;
+    }
+    $hasAny = isset($session['street'])
+      || isset($session['postal_code'])
+      || isset($session['city'])
+      || isset($session['municipality_code']);
+    if (!$hasAny) {
+      return NULL;
+    }
+    return [
+      'street' => $session['street'] ?? NULL,
+      'postal_code' => $session['postal_code'] ?? NULL,
+      'city' => $session['city'] ?? NULL,
+      'municipality_code' => $session['municipality_code'] ?? NULL,
     ];
   }
 

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
@@ -286,8 +286,8 @@ class MitIdSessionManager {
    *   The workflow instance ID.
    *
    * @return array|null
-   *   ['street' => ..., 'postal_code' => ..., 'city' => ..., 'municipality_code' => ...]
-   *   when at least one key is present, NULL otherwise.
+   *   Array with keys street, postal_code, city, municipality_code when at
+   *   least one is present in the session; NULL otherwise.
    */
   public function getAddressFromSession(string $workflow_id): ?array {
     $session = $this->getSession($workflow_id);

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
@@ -5,14 +5,18 @@ namespace Drupal\Tests\aabenforms_mitid\Unit\Service;
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\TempStore\PrivateTempStore;
-use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 /**
  * Tests MitID session management.
+ *
+ * Backed by KeyValueExpirable (not PrivateTempStore) so the workflow_id can
+ * function as a true bearer capability across origins - the demo SPA reads
+ * the session from a different host than the cookie domain.
  *
  * @coversDefaultClass \Drupal\aabenforms_mitid\Service\MitIdSessionManager
  * @group aabenforms_mitid
@@ -27,11 +31,11 @@ class MitIdSessionManagerTest extends UnitTestCase {
   protected MitIdSessionManager $sessionManager;
 
   /**
-   * Mock private tempstore.
+   * Mock keyvalue-expirable store.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $tempStore;
+  protected $store;
 
   /**
    * Mock time service.
@@ -62,17 +66,24 @@ class MitIdSessionManagerTest extends UnitTestCase {
   protected int $currentTime = 1706198400;
 
   /**
+   * Session TTL in seconds (mirrors MitIdSessionManager::SESSION_EXPIRATION).
+   *
+   * @var int
+   */
+  protected int $sessionTtl = 900;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
 
-    // Mock dependencies.
-    $this->tempStore = $this->createMock(PrivateTempStore::class);
-    $tempStoreFactory = $this->createMock(PrivateTempStoreFactory::class);
-    $tempStoreFactory->method('get')
-      ->with('aabenforms_mitid')
-      ->willReturn($this->tempStore);
+    // Mock the keyvalue-expirable store + the factory that returns it.
+    $this->store = $this->createMock(KeyValueStoreExpirableInterface::class);
+    $keyValueFactory = $this->createMock(KeyValueExpirableFactoryInterface::class);
+    $keyValueFactory->method('get')
+      ->with('aabenforms_mitid_sessions')
+      ->willReturn($this->store);
 
     $this->time = $this->createMock(TimeInterface::class);
     $this->time->method('getRequestTime')
@@ -86,9 +97,8 @@ class MitIdSessionManagerTest extends UnitTestCase {
 
     $this->auditLogger = $this->createMock(AuditLogger::class);
 
-    // Create session manager with mocks.
     $this->sessionManager = new MitIdSessionManager(
-      $tempStoreFactory,
+      $keyValueFactory,
       $this->time,
       $loggerFactory,
       $this->auditLogger
@@ -112,13 +122,13 @@ class MitIdSessionManagerTest extends UnitTestCase {
     // Expected stored data with metadata.
     $expectedData = $sessionData + [
       'created_at' => $this->currentTime,
-      'expires_at' => $this->currentTime + 900,
+      'expires_at' => $this->currentTime + $this->sessionTtl,
       'workflow_id' => $workflowId,
     ];
 
-    $this->tempStore->expects($this->once())
-      ->method('set')
-      ->with($workflowId, $expectedData);
+    $this->store->expects($this->once())
+      ->method('setWithExpire')
+      ->with($workflowId, $expectedData, $this->sessionTtl);
 
     $this->logger->expects($this->once())
       ->method('info')
@@ -151,8 +161,8 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'temp_data' => 'value',
     ];
 
-    $this->tempStore->expects($this->once())
-      ->method('set');
+    $this->store->expects($this->once())
+      ->method('setWithExpire');
 
     $this->logger->expects($this->once())
       ->method('info');
@@ -174,8 +184,8 @@ class MitIdSessionManagerTest extends UnitTestCase {
     $workflowId = 'workflow-789';
     $sessionData = ['data' => 'value'];
 
-    $this->tempStore->expects($this->once())
-      ->method('set')
+    $this->store->expects($this->once())
+      ->method('setWithExpire')
       ->willThrowException(new \Exception('Storage error'));
 
     $this->logger->expects($this->once())
@@ -207,7 +217,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'workflow_id' => $workflowId,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->with($workflowId)
       ->willReturn($sessionData);
@@ -224,7 +234,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testGetNonExistentSession(): void {
     $workflowId = 'workflow-missing';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->with($workflowId)
       ->willReturn(NULL);
@@ -247,17 +257,17 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'workflow_id' => $workflowId,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->with($workflowId)
       ->willReturn($sessionData);
 
-    // Logger will be called twice: once for expiration, once for deletion.
+    // Logger called twice: once for expiration, once for deletion.
     $this->logger->expects($this->exactly(2))
       ->method('info');
 
     // Should delete expired session.
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('delete')
       ->with($workflowId);
 
@@ -273,7 +283,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testGetSessionWithException(): void {
     $workflowId = 'workflow-error';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willThrowException(new \Exception('Retrieval error'));
 
@@ -299,7 +309,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testDeleteSession(): void {
     $workflowId = 'workflow-delete';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('delete')
       ->with($workflowId);
 
@@ -331,7 +341,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testDeleteSessionWithException(): void {
     $workflowId = 'workflow-delete-fail';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('delete')
       ->willThrowException(new \Exception('Delete error'));
 
@@ -361,7 +371,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'expires_at' => $this->currentTime + 600,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn($sessionData);
 
@@ -377,7 +387,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testHasValidSessionFalse(): void {
     $workflowId = 'workflow-no-valid';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn(NULL);
 
@@ -398,7 +408,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'expires_at' => $this->currentTime + 600,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn($sessionData);
 
@@ -414,7 +424,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testGetCprFromMissingSession(): void {
     $workflowId = 'workflow-no-cpr';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn(NULL);
 
@@ -434,7 +444,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'expires_at' => $this->currentTime + 600,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn($sessionData);
 
@@ -461,7 +471,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'expires_at' => $this->currentTime + 600,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn($sessionData);
 
@@ -494,7 +504,7 @@ class MitIdSessionManagerTest extends UnitTestCase {
       'expires_at' => $this->currentTime + 600,
     ];
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn($sessionData);
 
@@ -522,12 +532,65 @@ class MitIdSessionManagerTest extends UnitTestCase {
   public function testGetPersonDataFromMissingSession(): void {
     $workflowId = 'workflow-no-person';
 
-    $this->tempStore->expects($this->once())
+    $this->store->expects($this->once())
       ->method('get')
       ->willReturn(NULL);
 
     $result = $this->sessionManager->getPersonDataFromSession($workflowId);
     $this->assertNull($result);
+  }
+
+  /**
+   * Tests getAddressFromSession returns NULL when no address keys present.
+   *
+   * @covers ::getAddressFromSession
+   */
+  public function testGetAddressFromSessionNoAddress(): void {
+    $workflowId = 'workflow-no-addr';
+    $sessionData = [
+      'cpr' => '0101001234',
+      'name' => 'Test Testesen',
+      'expires_at' => $this->currentTime + 600,
+    ];
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn($sessionData);
+
+    $result = $this->sessionManager->getAddressFromSession($workflowId);
+    $this->assertNull($result);
+  }
+
+  /**
+   * Tests getAddressFromSession returns the address block when present.
+   *
+   * @covers ::getAddressFromSession
+   */
+  public function testGetAddressFromSessionWithAddress(): void {
+    $workflowId = 'workflow-addr';
+    $sessionData = [
+      'cpr' => '0101001234',
+      'street' => 'Nørrebrogade 142, 3. tv.',
+      'postal_code' => '2200',
+      'city' => 'København N',
+      'municipality_code' => '0101',
+      'expires_at' => $this->currentTime + 600,
+    ];
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn($sessionData);
+
+    $result = $this->sessionManager->getAddressFromSession($workflowId);
+
+    $expected = [
+      'street' => 'Nørrebrogade 142, 3. tv.',
+      'postal_code' => '2200',
+      'city' => 'København N',
+      'municipality_code' => '0101',
+    ];
+
+    $this->assertEquals($expected, $result);
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.info.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.info.yml
@@ -6,6 +6,7 @@ package: ÅbenForms
 
 dependencies:
   - aabenforms_core:aabenforms_core
+  - aabenforms_mitid:aabenforms_mitid
   - eca:eca
   - webform:webform
   - modeler_api:modeler_api

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
@@ -76,6 +76,15 @@ aabenforms_workflows.parent_approval_mitid:
     _permission: 'access content'
     parent_number: '1|2'
 
+aabenforms_workflows.parent_approval_mitid_complete:
+  path: '/parent-approval/{parent_number}/{submission_id}/{token}/mitid/complete'
+  defaults:
+    _controller: '\Drupal\aabenforms_workflows\Controller\ParentApprovalController::mitidComplete'
+    _title: 'Parent Approval - MitID Complete'
+  requirements:
+    _permission: 'access content'
+    parent_number: '1|2'
+
 aabenforms_workflows.parent_approval_complete:
   path: '/parent-approval/complete/{action}'
   defaults:

--- a/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
@@ -5,6 +5,7 @@ namespace Drupal\aabenforms_workflows\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -40,22 +41,33 @@ class ParentApprovalController extends ControllerBase {
   protected LoggerInterface $logger;
 
   /**
+   * The MitID session manager.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager
+   */
+  protected MitIdSessionManager $mitidSessionManager;
+
+  /**
    * Constructs a ParentApprovalController object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\aabenforms_workflows\Service\ApprovalTokenService $token_service
    *   The approval token service.
+   * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $mitid_session_manager
+   *   The MitID session manager (for verifying OIDC handoff).
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     ApprovalTokenService $token_service,
+    MitIdSessionManager $mitid_session_manager,
     LoggerInterface $logger,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->tokenService = $token_service;
+    $this->mitidSessionManager = $mitid_session_manager;
     $this->logger = $logger;
   }
 
@@ -66,6 +78,7 @@ class ParentApprovalController extends ControllerBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('aabenforms_workflows.approval_token'),
+      $container->get('aabenforms_mitid.session_manager'),
       $container->get('logger.factory')->get('aabenforms_workflows')
     );
   }
@@ -267,21 +280,86 @@ class ParentApprovalController extends ControllerBase {
   }
 
   /**
-   * Handles the parent's MitID login handoff.
+   * Initiates the parent's MitID OIDC login.
    *
-   * Demo-mode behaviour: validates the token (same gating as
-   * approvalPage so a tampered/expired/malformed link can't bypass the
-   * MitID requirement by navigating directly to this route), flips the
-   * parent's session flag, then redirects back to the approval page
-   * which now renders the form instead of the login button.
+   * Validates the token (same gating as approvalPage so a tampered or
+   * malformed link can't bypass the MitID requirement by navigating
+   * directly to this route), then redirects to the aabenforms_mitid
+   * OIDC login route with a workflow_id scoped to this parent and a
+   * return_url pointing at our matching `mitid/complete` endpoint.
    *
-   * @todo Replace the session-flag flip with a real OIDC handoff via
-   *   aabenforms_mitid: send the parent through MitId\Service\MitIdOidcClient::getAuthorizationUrl()
-   *   with a return URL of /parent-approval/{p}/{sid}/{token}, and on
-   *   the OIDC callback verify the CPR matches the submission's
-   *   parent{N}_email tied to the consenting parent before flipping the
-   *   session. The current stub is sufficient for the citizen-flow
-   *   smoke; production needs the real handoff.
+   * After the OIDC round-trip the parent lands at mitidComplete()
+   * below, which verifies a real authenticated MitID session is in
+   * tempstore for this workflow_id before flipping the session flag.
+   *
+   * The workflow_id namespace `parent_approval_<sid>_p<N>` keeps each
+   * parent's MitID session isolated so two parents reviewing the same
+   * submission from different browsers don't collide.
+   *
+   * @param int $parent_number
+   *   The parent number (1 or 2).
+   * @param int $submission_id
+   *   The webform submission ID.
+   * @param string $token
+   *   The security token.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect to /mitid/login with the parent context attached.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   */
+  public function mitidLogin(int $parent_number, int $submission_id, string $token, Request $request): RedirectResponse {
+    if (!$this->tokenService->validateToken($submission_id, $parent_number, $token)) {
+      $this->logger->warning('Invalid token at MitID handoff for submission @sid, parent @parent', [
+        '@sid' => $submission_id,
+        '@parent' => $parent_number,
+      ]);
+      throw new AccessDeniedHttpException('Invalid approval token.');
+    }
+
+    $workflow_id = sprintf('parent_approval_%d_p%d', $submission_id, $parent_number);
+    $return_url = Url::fromRoute(
+      'aabenforms_workflows.parent_approval_mitid_complete',
+      [
+        'parent_number' => $parent_number,
+        'submission_id' => $submission_id,
+        'token' => $token,
+      ],
+      ['absolute' => TRUE],
+    )->toString();
+
+    $login_url = Url::fromRoute(
+      'aabenforms_mitid.login',
+      [],
+      [
+        'query' => [
+          'workflow_id' => $workflow_id,
+          'return_url' => $return_url,
+        ],
+      ],
+    )->toString();
+
+    return new RedirectResponse($login_url);
+  }
+
+  /**
+   * Handles the post-OIDC return from MitID for the parent flow.
+   *
+   * Re-validates the token (defence in depth: the workflow_id query
+   * arg can be inspected/altered by a malicious return target), then
+   * checks the aabenforms_mitid session manager for a real OIDC
+   * session under our scoped workflow_id. If both pass, flips the
+   * parent's per-session flag and redirects to the approval page
+   * which now renders the form.
+   *
+   * @todo Add CPR-vs-parent verification once the parent_request_form
+   *   schema carries parent CPRs (today it only stores email, which
+   *   isn't a usable identity assertion). Once that lands, compare
+   *   $this->mitidSessionManager->getCprFromSession($workflow_id)
+   *   against the submission's parent{N}_cpr field; on mismatch, log
+   *   warning + 403.
    *
    * @param int $parent_number
    *   The parent number (1 or 2).
@@ -297,17 +375,27 @@ class ParentApprovalController extends ControllerBase {
    *
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    */
-  public function mitidLogin(int $parent_number, int $submission_id, string $token, Request $request): RedirectResponse {
+  public function mitidComplete(int $parent_number, int $submission_id, string $token, Request $request): RedirectResponse {
     if (!$this->tokenService->validateToken($submission_id, $parent_number, $token)) {
-      $this->logger->warning('Invalid token at MitID handoff for submission @sid, parent @parent', [
+      $this->logger->warning('Invalid token at MitID complete for submission @sid, parent @parent', [
         '@sid' => $submission_id,
         '@parent' => $parent_number,
       ]);
       throw new AccessDeniedHttpException('Invalid approval token.');
     }
 
+    $workflow_id = sprintf('parent_approval_%d_p%d', $submission_id, $parent_number);
+    if (!$this->mitidSessionManager->hasValidSession($workflow_id)) {
+      $this->logger->warning('No valid MitID session for workflow @wid (parent @parent, submission @sid)', [
+        '@wid' => $workflow_id,
+        '@parent' => $parent_number,
+        '@sid' => $submission_id,
+      ]);
+      throw new AccessDeniedHttpException('MitID authentication did not complete.');
+    }
+
     $request->getSession()->set("mitid_authenticated_parent{$parent_number}", TRUE);
-    $this->logger->info('Parent @parent MitID handoff complete for submission @sid (demo stub)', [
+    $this->logger->info('Parent @parent MitID handoff verified for submission @sid', [
       '@parent' => $parent_number,
       '@sid' => $submission_id,
     ]);


### PR DESCRIPTION
## Summary
- New /demo/byggetilladelse flagship demo backed by real integrations: themed Keycloak login (FreeMarker theme aabenforms-mitid), claim-prefilled webform, synchronous ECA workflow steps, Digital Post log surfaced as a faux NgDP inbox
- MitIdSessionManager moved from PrivateTempStore to KeyValueExpirable so the workflow_id functions as a true bearer capability across origins; workflow_id now uses bin2hex(random_bytes(16))
- New aabenforms_digital_post_session_inbox bridge submodule exposes GET /api/digital-post/recent?session={wf_id}, hashing CPR with the same cpr:DIGITS recipe as Recipient::identifierHash() and sanitising bodies with Xss::filterAdmin()
- Realm JSON: loginTheme + 4 address protocol mappers (street/postal_code/city/municipality_code) + per-user address attributes for Freja, Mikkel, Sofie and Karen; explicit given_name/family_name/name/email mappers added to the aabenforms-backend client
- MitIdController.callback uses TrustedRedirectResponse for external return URLs; getSession exposes additive demo helper fields (given_name, family_name, birthdate, address, assurance_level)
- DDEV CORS_ALLOW_ORIGIN extended to the frontend host:port so the open-redirect guard accepts the SPA return URL

Builds on top of the parent-approval MitID OIDC handoff already on this branch.

## Test plan
- [ ] docker rm -f ddev-aabenforms-keycloak && ddev start  (force realm re-import)
- [ ] ddev drush en aabenforms_digital_post_session_inbox -y && ddev drush cr
- [ ] curl http://localhost:8080/realms/danish-gov-test/.well-known/openid-configuration  (verify scopes intact: openid, ssn, profile, email, roles, web-origins, acr)
- [ ] Hit https://aabenforms.ddev.site/mitid/login?return_url=http://aabenforms-frontend.ddev.site:3000/demo/byggetilladelse, log in as freja.nielsen / test1234, land back at the demo with prefilled CPR + name + address
- [ ] curl 'https://aabenforms.ddev.site/mitid/session/<wf_id>' returns address block
- [ ] curl 'https://aabenforms.ddev.site/api/digital-post/recent?session=<wf_id>' returns recent letters after a building_permit submission
- [ ] Verify themed login resources at /resources/<id>/login/aabenforms-mitid/css/login.css