### PR TITLE
Host the demo Keycloak publicly at auth.aabenforms.dk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,5 +92,49 @@ services:
       options:
         max-size: "50m"
 
+  # Keycloak hosts the public mock IdP at https://auth.aabenforms.dk for the
+  # interactive Byggetilladelse demo. Browsers hit the public hostname over
+  # TLS via Traefik; Drupal performs the server-side token exchange against
+  # the internal http://keycloak:8080 address on the shared internal network
+  # so the round-trip stays inside the docker bridge. The H2 store is volume-
+  # mounted so the imported realm survives container restarts; on first
+  # boot --import-realm seeds the realm from the JSON below. To force a re-
+  # import after editing the realm: docker compose down keycloak &&
+  # docker volume rm api.aabenforms.dk_keycloak_data && docker compose up -d
+  # keycloak.
+  keycloak:
+    image: quay.io/keycloak/keycloak:23.0
+    container_name: aabenforms_keycloak
+    restart: always
+    env_file:
+      - .env
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_HOSTNAME: auth.aabenforms.dk
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_PROXY: edge
+      KC_HTTP_PORT: 8080
+    volumes:
+      - ./docker/keycloak/realms/danish-gov-test.json:/opt/keycloak/data/import/danish-gov-test.json:ro
+      - ./docker/keycloak/themes:/opt/keycloak/themes:ro
+      - keycloak_data:/opt/keycloak/data
+    command:
+      - start-dev
+      - --import-realm
+      - --http-relative-path=/
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.aabenforms_keycloak.rule=Host(`auth.aabenforms.dk`)"
+      - "traefik.http.routers.aabenforms_keycloak.entrypoints=websecure"
+      - "traefik.http.routers.aabenforms_keycloak.tls.certresolver=lets-encrypt"
+      - "traefik.http.services.aabenforms_keycloak.loadbalancer.server.port=8080"
+    networks:
+      - internal
+      - web
+
 volumes:
   drupal_files:
+  keycloak_data:

--- a/docker/keycloak/realms/danish-gov-test.json
+++ b/docker/keycloak/realms/danish-gov-test.json
@@ -1,0 +1,812 @@
+{
+  "id": "danish-gov-test",
+  "realm": "danish-gov-test",
+  "displayName": "Danish Government Test Realm",
+  "displayNameHtml": "<div class=\"kc-logo-text\"><span>🇩🇰 Danish Government Test</span></div>",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": true,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "defaultSignatureAlgorithm": "RS256",
+  "accessTokenLifespan": 3600,
+  "internationalizationEnabled": true,
+  "supportedLocales": [
+    "da",
+    "en"
+  ],
+  "defaultLocale": "da",
+  "loginTheme": "aabenforms-mitid",
+  "clients": [
+    {
+      "clientId": "aabenforms-backend",
+      "name": "ÅbenForms Backend (Drupal)",
+      "description": "ÅbenForms Drupal backend OIDC client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "aabenforms-backend-secret-change-in-production",
+      "redirectUris": [
+        "http://aabenforms.ddev.site/*",
+        "http://localhost:3000/*",
+        "https://aabenforms.ddev.site/*",
+        "https://aabenforms.dk/*",
+        "https://api.aabenforms.dk/*"
+      ],
+      "webOrigins": [
+        "http://aabenforms.ddev.site",
+        "http://localhost:3000",
+        "https://aabenforms.ddev.site",
+        "https://aabenforms.dk",
+        "https://api.aabenforms.dk"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "attributes": {
+        "access.token.lifespan": "3600"
+      },
+      "protocolMappers": [
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "claim.name": "given_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "claim.name": "family_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "cpr",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "cpr",
+            "claim.name": "cpr",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "cvr",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "cvr",
+            "claim.name": "cvr",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "organization_name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "organization_name",
+            "claim.name": "organization_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "birthdate",
+            "claim.name": "birthdate",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "assurance_level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "assurance_level",
+            "claim.name": "acr",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "street",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "street",
+            "claim.name": "street",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "postal_code",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "postal_code",
+            "claim.name": "postal_code",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "city",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "city",
+            "claim.name": "city",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "municipality_code",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "municipality_code",
+            "claim.name": "municipality_code",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "aabenforms-frontend",
+      "name": "ÅbenForms Frontend (Nuxt)",
+      "description": "ÅbenForms Nuxt 3 frontend OIDC client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost:3000/*",
+        "http://localhost:3001/*",
+        "https://aabenforms-frontend.ddev.site/*",
+        "https://aabenforms.dk/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000",
+        "http://localhost:3001",
+        "https://aabenforms-frontend.ddev.site",
+        "https://aabenforms.dk"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false
+    }
+  ],
+  "users": [
+    {
+      "username": "freja.nielsen",
+      "firstName": "Freja",
+      "lastName": "Nielsen",
+      "email": "freja.nielsen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "0101904521"
+        ],
+        "birthdate": [
+          "1990-01-01"
+        ],
+        "given_name": [
+          "Freja"
+        ],
+        "family_name": [
+          "Nielsen"
+        ],
+        "street": [
+          "Nørrebrogade 142, 3. tv."
+        ],
+        "postal_code": [
+          "2200"
+        ],
+        "city": [
+          "København N"
+        ],
+        "municipality_code": [
+          "0101"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Typical citizen - Common Danish name, Copenhagen resident"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "mikkel.jensen",
+      "firstName": "Mikkel",
+      "lastName": "Jensen",
+      "email": "mikkel.jensen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "1502856234"
+        ],
+        "birthdate": [
+          "1985-02-15"
+        ],
+        "given_name": [
+          "Mikkel"
+        ],
+        "family_name": [
+          "Jensen"
+        ],
+        "street": [
+          "Vestergade 27, 2. th."
+        ],
+        "postal_code": [
+          "8000"
+        ],
+        "city": [
+          "Aarhus C"
+        ],
+        "municipality_code": [
+          "0751"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Typical citizen - Most common Danish surname"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "sofie.hansen",
+      "firstName": "Sofie",
+      "lastName": "Hansen",
+      "email": "sofie.hansen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "2506924015"
+        ],
+        "birthdate": [
+          "1992-06-25"
+        ],
+        "given_name": [
+          "Sofie"
+        ],
+        "family_name": [
+          "Hansen"
+        ],
+        "street": [
+          "Hjallesevej 88"
+        ],
+        "postal_code": [
+          "5230"
+        ],
+        "city": [
+          "Odense M"
+        ],
+        "municipality_code": [
+          "0461"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Young parent with children"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "lars.andersen",
+      "firstName": "Lars",
+      "lastName": "Andersen",
+      "email": "lars.andersen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "0803755210"
+        ],
+        "birthdate": [
+          "1975-03-08"
+        ],
+        "given_name": [
+          "Lars"
+        ],
+        "family_name": [
+          "Andersen"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Middle-aged citizen, Aarhus resident"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "emma.pedersen",
+      "firstName": "Emma",
+      "lastName": "Pedersen",
+      "email": "emma.pedersen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "1010005206"
+        ],
+        "birthdate": [
+          "2000-10-10"
+        ],
+        "given_name": [
+          "Emma"
+        ],
+        "family_name": [
+          "Pedersen"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Young adult, recent graduate"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "karen.christensen",
+      "firstName": "Karen",
+      "lastName": "Christensen",
+      "email": "karen@test-aps.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "1205705432"
+        ],
+        "cvr": [
+          "12345678"
+        ],
+        "birthdate": [
+          "1970-05-12"
+        ],
+        "given_name": [
+          "Karen"
+        ],
+        "family_name": [
+          "Christensen"
+        ],
+        "organization_name": [
+          "Test ApS"
+        ],
+        "street": [
+          "Nytorv 11"
+        ],
+        "postal_code": [
+          "9000"
+        ],
+        "city": [
+          "Aalborg"
+        ],
+        "municipality_code": [
+          "0851"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/high"
+        ],
+        "description": [
+          "Business owner - MitID Erhverv user with CVR"
+        ]
+      },
+      "realmRoles": [
+        "user",
+        "business"
+      ]
+    },
+    {
+      "username": "protected.person",
+      "firstName": "[BESKYTTET]",
+      "lastName": "[BESKYTTET]",
+      "email": "protected@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "0101804321"
+        ],
+        "birthdate": [
+          "1980-01-01"
+        ],
+        "given_name": [
+          "[BESKYTTET]"
+        ],
+        "family_name": [
+          "[BESKYTTET]"
+        ],
+        "protected": [
+          "true"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Protected person - Name and address hidden (navne- og adressebeskyttelse)"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "morten.rasmussen",
+      "firstName": "Morten",
+      "lastName": "Rasmussen",
+      "email": "morten.rasmussen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "2209674523"
+        ],
+        "birthdate": [
+          "1967-09-22"
+        ],
+        "given_name": [
+          "Morten"
+        ],
+        "family_name": [
+          "Rasmussen"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Senior citizen, retiree"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "ida.mortensen",
+      "firstName": "Ida",
+      "lastName": "Mortensen",
+      "email": "ida.mortensen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "0507985634"
+        ],
+        "birthdate": [
+          "1998-07-05"
+        ],
+        "given_name": [
+          "Ida"
+        ],
+        "family_name": [
+          "Mortensen"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Young professional, Odense resident"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    },
+    {
+      "username": "peter.larsen",
+      "firstName": "Peter",
+      "lastName": "Larsen",
+      "email": "peter.larsen@example.dk",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test1234",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "cpr": [
+          "1811826547"
+        ],
+        "birthdate": [
+          "1982-11-18"
+        ],
+        "given_name": [
+          "Peter"
+        ],
+        "family_name": [
+          "Larsen"
+        ],
+        "assurance_level": [
+          "http://eidas.europa.eu/LoA/substantial"
+        ],
+        "description": [
+          "Typical male citizen, common Danish name"
+        ]
+      },
+      "realmRoles": [
+        "user"
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "Standard user role"
+      },
+      {
+        "name": "business",
+        "description": "Business user with CVR"
+      },
+      {
+        "name": "caseworker",
+        "description": "Municipality caseworker"
+      }
+    ]
+  },
+  "scopeMappings": [],
+  "clientScopeMappings": {},
+  "clientScopes": [
+    {
+      "name": "ssn",
+      "description": "Danish Social Security Number (CPR) - MitID ssn scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "ssn-cpr",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "cpr",
+            "claim.name": "ssn",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "profile",
+      "description": "OpenID Connect built-in profile scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      }
+    },
+    {
+      "name": "email",
+      "description": "OpenID Connect built-in email scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      }
+    },
+    {
+      "name": "roles",
+      "description": "OpenID Connect realm roles scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      }
+    },
+    {
+      "name": "web-origins",
+      "description": "OpenID Connect built-in web-origins scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      }
+    },
+    {
+      "name": "acr",
+      "description": "OpenID Connect authentication context reference scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      }
+    },
+    {
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "ssn"
+  ],
+  "browserFlow": "browser",
+  "directGrantFlow": "direct grant"
+}

--- a/docker/keycloak/themes/aabenforms-mitid/login/login.ftl
+++ b/docker/keycloak/themes/aabenforms-mitid/login/login.ftl
@@ -1,0 +1,91 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=false; section>
+    <#if section = "header">
+        <span class="aabenforms-hidden-title">${msg("loginAccountTitle")}</span>
+    <#elseif section = "form">
+        <div class="aabenforms-brand-header">
+            <div class="aabenforms-brand-row">
+                <img src="${url.resourcesPath}/img/logo.svg" alt="ÅbenForms" class="aabenforms-logo" />
+                <span class="aabenforms-brand-mark">MitID - Demo</span>
+            </div>
+            <p class="aabenforms-brand-tag">${msg("aabenformsBrandTagline")}</p>
+        </div>
+        <div class="aabenforms-demo-banner" role="note">
+            <span class="aabenforms-demo-banner-icon" aria-hidden="true">●</span>
+            <div>
+                <strong>${msg("aabenformsDemoBannerTitle")}</strong>
+                <span class="aabenforms-demo-banner-body">${msg("aabenformsDemoBannerBody")}</span>
+            </div>
+        </div>
+        <h2 class="aabenforms-pagetitle">${msg("loginAccountTitle")}</h2>
+
+        <div id="kc-form">
+            <div id="kc-form-wrapper">
+                <#if realm.password>
+                    <form id="kc-form-login" class="aabenforms-form" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                        <#if !usernameHidden??>
+                            <div class="aabenforms-field">
+                                <label for="username" class="aabenforms-label">
+                                    <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+                                </label>
+                                <input
+                                    tabindex="2"
+                                    id="username"
+                                    class="aabenforms-input"
+                                    name="username"
+                                    value="${(login.username!'')}"
+                                    type="text"
+                                    autofocus
+                                    autocomplete="username"
+                                    aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                                />
+                                <#if messagesPerField.existsError('username','password')>
+                                    <span id="input-error" class="aabenforms-error" aria-live="polite">
+                                        ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                    </span>
+                                </#if>
+                            </div>
+                        </#if>
+
+                        <div class="aabenforms-field">
+                            <label for="password" class="aabenforms-label">${msg("password")}</label>
+                            <input
+                                tabindex="3"
+                                id="password"
+                                class="aabenforms-input"
+                                name="password"
+                                type="password"
+                                autocomplete="current-password"
+                                aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                            />
+                        </div>
+
+                        <div class="aabenforms-helper-row">
+                            <span class="aabenforms-helper">${msg("aabenformsCredentialHint")}</span>
+                        </div>
+
+                        <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+
+                        <div id="kc-form-buttons" class="aabenforms-actions">
+                            <button
+                                tabindex="4"
+                                class="aabenforms-button-primary"
+                                name="login"
+                                id="kc-login"
+                                type="submit"
+                            >
+                                <span class="aabenforms-button-label">${msg("doLogIn")}</span>
+                                <span class="aabenforms-button-arrow" aria-hidden="true">→</span>
+                            </button>
+                        </div>
+                    </form>
+                </#if>
+            </div>
+        </div>
+
+        <div class="aabenforms-foot">
+            <p class="aabenforms-foot-line">${msg("aabenformsFooterLicense")}</p>
+            <p class="aabenforms-foot-line">${msg("aabenformsFooterReturn")}</p>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/docker/keycloak/themes/aabenforms-mitid/login/messages/messages_da.properties
+++ b/docker/keycloak/themes/aabenforms-mitid/login/messages/messages_da.properties
@@ -1,0 +1,16 @@
+loginAccountTitle=Log ind med MitID
+doLogIn=Bekræft og fortsæt
+username=MitID brugernavn
+usernameOrEmail=MitID brugernavn
+password=Adgangskode
+errorTitle=Login mislykkedes
+invalidUserMessage=Forkert brugernavn eller adgangskode.
+backToLogin=Tilbage til login
+
+# AabenForms-specific overrides surfaced by the custom login.ftl.
+aabenformsBrandTagline=Demo-identitetsudbyder for ÅbenForms-borgerforløb.
+aabenformsDemoBannerTitle=Mock-IdP - ikke ægte MitID
+aabenformsDemoBannerBody=Intet rigtigt CPR-nummer sendes. Brug en af demo-brugerne (kodeord test1234) for at se flowet.
+aabenformsCredentialHint=Demo-brugere: freja.nielsen, mikkel.jensen, sofie.hansen, karen.christensen - kodeord test1234.
+aabenformsFooterLicense=ÅbenForms · Åben kildekode under EUPL-1.2.
+aabenformsFooterReturn=Du sendes tilbage til ÅbenForms efter godkendelse.

--- a/docker/keycloak/themes/aabenforms-mitid/login/messages/messages_en.properties
+++ b/docker/keycloak/themes/aabenforms-mitid/login/messages/messages_en.properties
@@ -1,0 +1,16 @@
+loginAccountTitle=Sign in with MitID
+doLogIn=Confirm and continue
+username=MitID username
+usernameOrEmail=MitID username
+password=Password
+errorTitle=Sign-in failed
+invalidUserMessage=Invalid username or password.
+backToLogin=Back to sign-in
+
+# AabenForms-specific overrides surfaced by the custom login.ftl.
+aabenformsBrandTagline=Demo identity provider for AabenForms citizen flows.
+aabenformsDemoBannerTitle=Mock IdP - not real MitID
+aabenformsDemoBannerBody=No real CPR number is transmitted. Use one of the demo users (password test1234) to see the flow.
+aabenformsCredentialHint=Demo users: freja.nielsen, mikkel.jensen, sofie.hansen, karen.christensen - password test1234.
+aabenformsFooterLicense=AabenForms · Open source under EUPL-1.2.
+aabenformsFooterReturn=You will be returned to AabenForms after authentication.

--- a/docker/keycloak/themes/aabenforms-mitid/login/resources/css/login.css
+++ b/docker/keycloak/themes/aabenforms-mitid/login/resources/css/login.css
@@ -1,0 +1,397 @@
+/* AabenForms MitID-style mock theme.
+ *
+ * Visual language: Danish gov-tech credibility - navy + coral, Atkinson
+ * Hyperlegible Next, generous whitespace, soft elevation. The "demo" banner
+ * is a non-negotiable: every interaction screen must surface that this is a
+ * mock IdP and no real CPR is in flight. */
+
+@import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;500;600;700&display=swap');
+
+:root {
+    --af-navy: #0a2240;
+    --af-navy-deep: #061830;
+    --af-coral: #ff5a5f;
+    --af-coral-hover: #ff3d44;
+    --af-paper: #ffffff;
+    --af-canvas: #eef1f6;
+    --af-line: #d8dde6;
+    --af-text: #11203a;
+    --af-text-soft: #5b6781;
+    --af-amber: #f4b21a;
+    --af-amber-soft: #fff4d2;
+    --af-radius: 12px;
+    --af-radius-sm: 8px;
+    --af-shadow: 0 24px 60px rgba(10, 34, 64, 0.14), 0 6px 16px rgba(10, 34, 64, 0.08);
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--af-canvas);
+    color: var(--af-text);
+    font-family: 'Atkinson Hyperlegible Next', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* Hide Keycloak's default page chrome - the inherited template.ftl wraps
+ * the form with a header section, page title and a dark patterned bg image
+ * we don't want. We hide the lot and re-anchor inside the form section. */
+.aabenforms-hidden-title,
+#kc-page-title,
+.login-pf-header,
+.login-pf-page-header,
+#kc-header,
+#kc-header-wrapper { display: none !important; }
+
+/* Page background gets a subtle navy gradient hairline at the top edge to
+ * frame the login card. */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0 0 auto 0;
+    height: 6px;
+    background: linear-gradient(90deg, var(--af-navy) 0%, var(--af-coral) 100%);
+    z-index: 50;
+}
+
+/* Aggressive backdrop reset - kill the inherited diamond pattern bg image
+ * and the dark gradient the parent theme paints behind everything. The
+ * Keycloak parent CSS sets the diamond pattern via a body background-image
+ * and an injected ::before pseudo - we wipe both. */
+html, html body,
+html.login-pf, body.login-pf, body.login-pf-body,
+.login-pf, .login-pf-page,
+.login-pf-page-header, .login-pf-body {
+    background: var(--af-canvas) !important;
+    background-image: none !important;
+    background-color: var(--af-canvas) !important;
+    color: var(--af-text) !important;
+}
+
+body::after, .login-pf-page::before, .login-pf-page::after,
+.login-pf-body::before, .login-pf-body::after {
+    background: none !important;
+    background-image: none !important;
+    content: none !important;
+    display: none !important;
+}
+
+.login-pf-page {
+    padding-top: 64px;
+    padding-bottom: 64px;
+    min-height: 100vh;
+    box-sizing: border-box;
+    position: relative;
+    z-index: 1;
+}
+
+.card-pf {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    max-width: 480px;
+    margin: 0 auto;
+}
+
+#kc-content,
+#kc-content-wrapper {
+    background: var(--af-paper);
+    border-radius: var(--af-radius);
+    box-shadow: var(--af-shadow);
+    padding: 0;
+    overflow: hidden;
+    border: 1px solid var(--af-line);
+}
+
+#kc-form,
+#kc-form-wrapper {
+    background: transparent;
+    padding: 0 32px 28px;
+}
+
+/* Brand header - navy band with logo + "MitID Demo" tag. */
+.aabenforms-brand-header {
+    background: linear-gradient(140deg, var(--af-navy) 0%, var(--af-navy-deep) 100%);
+    color: var(--af-paper);
+    padding: 28px 32px 24px;
+}
+
+.aabenforms-brand-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.aabenforms-logo {
+    height: 32px;
+    width: auto;
+    display: block;
+}
+
+.aabenforms-brand-mark {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.aabenforms-brand-tag {
+    margin: 12px 0 0;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+/* Demo banner - amber, immediately under the brand header. */
+.aabenforms-demo-banner {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    background: var(--af-amber-soft);
+    color: #5a4505;
+    padding: 14px 32px;
+    border-bottom: 1px solid #f0e0a8;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.aabenforms-demo-banner-icon {
+    color: var(--af-amber);
+    font-size: 18px;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.aabenforms-demo-banner strong {
+    display: block;
+    color: #4a3a04;
+    margin-bottom: 2px;
+    font-weight: 700;
+}
+
+.aabenforms-demo-banner-body {
+    display: block;
+    color: #6a5510;
+}
+
+/* Page title inside the card. */
+.aabenforms-pagetitle {
+    margin: 28px 32px 18px;
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--af-text);
+}
+
+/* Form fields. */
+.aabenforms-field {
+    margin-bottom: 18px;
+}
+
+.aabenforms-label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--af-text);
+    letter-spacing: 0.01em;
+}
+
+.aabenforms-input,
+input[type="text"]#username,
+input[type="password"]#password {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 14px;
+    border: 1.5px solid var(--af-line);
+    border-radius: var(--af-radius-sm);
+    background: var(--af-paper);
+    color: var(--af-text);
+    font-family: inherit;
+    font-size: 15px;
+    line-height: 1.4;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.aabenforms-input:focus,
+input[type="text"]#username:focus,
+input[type="password"]#password:focus {
+    outline: none;
+    border-color: var(--af-navy);
+    box-shadow: 0 0 0 3px rgba(10, 34, 64, 0.12);
+}
+
+.aabenforms-input[aria-invalid="true"] {
+    border-color: var(--af-coral);
+    box-shadow: 0 0 0 3px rgba(255, 90, 95, 0.12);
+}
+
+.aabenforms-error {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--af-coral-hover);
+    font-weight: 500;
+}
+
+.aabenforms-helper-row {
+    margin: -8px 0 18px;
+}
+
+.aabenforms-helper {
+    font-size: 12px;
+    color: var(--af-text-soft);
+}
+
+/* Primary CTA - coral with arrow. */
+.aabenforms-actions {
+    margin-top: 24px;
+}
+
+.aabenforms-button-primary,
+button#kc-login {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 14px 20px;
+    border: none;
+    border-radius: var(--af-radius-sm);
+    background: var(--af-coral);
+    color: var(--af-paper);
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: background 120ms ease, transform 120ms ease;
+}
+
+.aabenforms-button-primary:hover,
+button#kc-login:hover {
+    background: var(--af-coral-hover);
+}
+
+.aabenforms-button-primary:active,
+button#kc-login:active {
+    transform: translateY(1px);
+}
+
+.aabenforms-button-arrow {
+    font-size: 18px;
+    line-height: 1;
+}
+
+/* Footer copy under form. */
+.aabenforms-foot {
+    margin: 22px 32px 28px;
+    padding-top: 18px;
+    border-top: 1px solid var(--af-line);
+    text-align: center;
+}
+
+.aabenforms-foot-line {
+    margin: 4px 0;
+    font-size: 12px;
+    color: var(--af-text-soft);
+    line-height: 1.5;
+}
+
+/* Locale switcher - top-right of the card area. Keycloak renders it as
+ * #kc-locale; we want it visible but minimal. */
+#kc-locale {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    z-index: 60;
+}
+
+#kc-locale ul {
+    display: flex;
+    gap: 6px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+#kc-locale a {
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: var(--af-text-soft);
+    font-size: 12px;
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px solid var(--af-line);
+}
+
+#kc-locale a:hover {
+    background: var(--af-paper);
+    color: var(--af-navy);
+}
+
+/* Alert messages from Keycloak - re-skin as our coral/amber/green. */
+.alert {
+    border-radius: var(--af-radius-sm);
+    padding: 12px 14px;
+    margin: 0 32px 16px;
+    font-size: 13px;
+    border: 1px solid transparent;
+}
+
+.alert-error {
+    background: #fde9ea;
+    color: #8a1a1f;
+    border-color: #f5b7ba;
+}
+
+.alert-warning {
+    background: var(--af-amber-soft);
+    color: #6a5510;
+    border-color: #f0e0a8;
+}
+
+.alert-success {
+    background: #e3f4ea;
+    color: #155f3b;
+    border-color: #a7d8bb;
+}
+
+/* Mobile. */
+@media (max-width: 540px) {
+    .login-pf-page,
+    body.login-pf {
+        padding-top: 24px;
+        padding-bottom: 24px;
+    }
+    .card-pf {
+        max-width: 100%;
+        margin: 0 16px;
+    }
+    .aabenforms-brand-header,
+    .aabenforms-demo-banner,
+    .aabenforms-pagetitle,
+    #kc-form-wrapper,
+    .aabenforms-foot {
+        padding-left: 22px;
+        padding-right: 22px;
+    }
+    .aabenforms-foot {
+        margin-left: 0;
+        margin-right: 0;
+    }
+}

--- a/docker/keycloak/themes/aabenforms-mitid/login/resources/img/logo.svg
+++ b/docker/keycloak/themes/aabenforms-mitid/login/resources/img/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 64" fill="none" role="img" aria-label="ÅbenForms">
+  <!-- Icon: identical to /favicon.svg (blue square + white BPMN grid). -->
+  <rect width="64" height="64" rx="12" fill="#0071b9"/>
+  <g fill="#ffffff" transform="translate(8 8) scale(2.0833)">
+    <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
+  </g>
+  <!-- Wordmark, white on the navy login header band. -->
+  <text x="80" y="43" fill="#ffffff" font-family="'Atkinson Hyperlegible Next', system-ui, -apple-system, sans-serif" font-weight="700" font-size="28" letter-spacing="0.5">ÅbenForms</text>
+</svg>

--- a/docker/keycloak/themes/aabenforms-mitid/login/theme.properties
+++ b/docker/keycloak/themes/aabenforms-mitid/login/theme.properties
@@ -1,0 +1,18 @@
+parent=keycloak
+import=common/keycloak
+
+styles=css/login.css
+
+locales=da,en
+
+# Make the inherited template inject our banner via the page header area.
+kcHeaderClass=aabenforms-header
+kcLoginClass=aabenforms-login
+kcFormHeaderClass=aabenforms-formheader
+kcContentWrapperClass=aabenforms-content
+kcFormClass=aabenforms-form
+kcInputClass=aabenforms-input
+kcButtonClass=aabenforms-button
+kcButtonPrimaryClass=aabenforms-button-primary
+kcButtonBlockClass=aabenforms-button-block
+kcButtonLargeClass=aabenforms-button-large

--- a/settings.php
+++ b/settings.php
@@ -43,6 +43,34 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 $settings['reverse_proxy'] = true;
 $settings['reverse_proxy_addresses'] = array(@$_SERVER['REMOTE_ADDR']);
 
+# MitID OIDC: production overrides for the public mock IdP at
+# https://auth.aabenforms.dk. The browser hits the public hostname for the
+# /auth redirect and Drupal does the server-side token exchange against the
+# internal http://keycloak:8080. Issuer must match what's claimed in the
+# id_token, so it has to be the public URL.
+# Local DDEV leaves these env vars unset and falls back to the YAML config.
+if ($mitid_authz = getenv('MITID_AUTH_ENDPOINT')) {
+  $config['aabenforms_mitid.settings']['authorization_endpoint'] = $mitid_authz;
+}
+if ($mitid_token = getenv('MITID_TOKEN_ENDPOINT')) {
+  $config['aabenforms_mitid.settings']['token_endpoint'] = $mitid_token;
+}
+if ($mitid_userinfo = getenv('MITID_USERINFO_ENDPOINT')) {
+  $config['aabenforms_mitid.settings']['userinfo_endpoint'] = $mitid_userinfo;
+}
+if ($mitid_issuer = getenv('MITID_ISSUER')) {
+  $config['aabenforms_mitid.settings']['issuer'] = $mitid_issuer;
+}
+if ($mitid_redirect = getenv('MITID_REDIRECT_URI')) {
+  $config['aabenforms_mitid.settings']['redirect_uri'] = $mitid_redirect;
+}
+if ($mitid_client_secret = getenv('MITID_CLIENT_SECRET')) {
+  $config['aabenforms_mitid.settings']['client_secret'] = $mitid_client_secret;
+}
+if (getenv('AABENFORMS_PROD_MITID') === 'true') {
+  $config['aabenforms_mitid.settings']['production'] = TRUE;
+}
+
 # SMTP configuration from environment
 if (getenv('SMTP_PASSWORD')) {
   $config['smtp.settings']['smtp_on'] = TRUE;


### PR DESCRIPTION
## Summary
Adds a public Keycloak service to the aabenforms backend stack so the interactive Byggetilladelse demo can run end-to-end on production. Browsers hit https://auth.aabenforms.dk; Drupal does the server-side token exchange against http://keycloak:8080 internally.

- **docker-compose.yml**: new keycloak service (Keycloak 23, KC_PROXY=edge, KC_HOSTNAME=auth.aabenforms.dk), Traefik labels for auth.aabenforms.dk with the lets-encrypt resolver, joined to internal + web networks. H2 store volume-mounted (keycloak_data) so the imported realm survives restarts
- **docker/keycloak/realms/danish-gov-test.json**: prod copy of the realm with public redirect URIs and webOrigins added (https://aabenforms.dk + https://api.aabenforms.dk alongside the DDEV ones - same realm serves both environments)
- **docker/keycloak/themes/aabenforms-mitid/**: copy of the FreeMarker theme tree, bind-mounted read-only at /opt/keycloak/themes/aabenforms-mitid
- **settings.php**: env-driven MitID overrides. Local DDEV leaves the vars unset and falls back to the YAML config; prod .env supplies the public values

## Required prod setup
DNS A record `auth.aabenforms.dk` -> VPS2 IP (already done).

`~/docker/api.aabenforms.dk/.env` additions on VPS2:
\`\`\`
KEYCLOAK_ADMIN_PASSWORD=<strong>
CORS_ALLOW_ORIGIN=https://aabenforms.dk
MITID_AUTH_ENDPOINT=https://auth.aabenforms.dk/realms/danish-gov-test/protocol/openid-connect/auth
MITID_ISSUER=https://auth.aabenforms.dk/realms/danish-gov-test
MITID_REDIRECT_URI=https://api.aabenforms.dk/mitid/callback
AABENFORMS_PROD_MITID=true
\`\`\`

After merge + deploy:
\`\`\`
ssh ...VPS2
cd ~/docker/api.aabenforms.dk
docker compose up -d keycloak
\`\`\`

The deploy workflow auto-pulls the new docker/keycloak/ tree because line 105 of deploy.yml already pulls docker/ for Drupal projects. The companion infra PR adds the NUXT_PUBLIC build-args for aabenforms.dk so the frontend's hero CTA flips to "Åben interaktiv demo".

## Test plan
- [ ] LE cert issued for auth.aabenforms.dk (verify in Traefik logs and curl -vI https://auth.aabenforms.dk/realms/danish-gov-test/.well-known/openid-configuration)
- [ ] OIDC discovery returns the right scopes (openid, ssn, profile, email, roles, web-origins, acr)
- [ ] Themed login renders at https://auth.aabenforms.dk/realms/danish-gov-test/protocol/openid-connect/auth?...
- [ ] Full flow from https://aabenforms.dk/demo/byggetilladelse: kickoff -> themed login as freja.nielsen/test1234 -> prefilled form -> submit -> workflow steps -> Digital Post inbox letter visible
- [ ] curl 'https://api.aabenforms.dk/api/digital-post/recent?session=<wf_id>' returns the freshly written letter