### PR TITLE
Suppress webform CDN warning correctly (requirements.cdn=false)

### DIFF
--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -330,7 +330,7 @@ libraries:
     - jquery.chosen
   cdn: true
 requirements:
-  cdn: true
+  cdn: false
   clientside_validation: true
   spam: true
 third_party_settings:


### PR DESCRIPTION
## Summary
PR #57 flipped \`webform.settings.requirements.cdn\` to \`true\` thinking that suppressed the warning. It does the opposite: \`WebformLibrariesManager::requirements()\` reads it and only bumps severity to \`REQUIREMENT_WARNING\` when it's TRUE.

Source proof:
\`\`\`php
// web/modules/contrib/webform/src/WebformLibrariesManager.php:86
\$cdn = \$this->configFactory->get('webform.settings')->get('requirements.cdn') ?: FALSE;
// ...
elseif (\$cdn) {
  // Missing.
  \$severity = REQUIREMENT_WARNING;
}
else {
  // CDN.  (no severity bump)
}
\`\`\`

So FALSE = "I'm fine with CDN, don't warn me" and TRUE = "warn me to install locally". Flipping back to FALSE.

\`libraries.cdn\` stays \`true\` - that controls whether CDN libraries are actually loaded (we don't host the 12 webform JS libs locally so we need CDN).

Already applied directly via \`drush cset\` on prod; this commit aligns the source-of-truth so a future \`drush cim\` doesn't flip it back.

## Test plan
- [ ] After deploy: /admin/reports/status no longer flags "Webform: External libraries 14 libraries (0 installed; 2 excluded; 12 CDN)" as a Warning - it should drop to Info / OK