### PR TITLE
Revive 7 AuditLogActionTest cases and fix array-token bug

### DIFF
--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
@@ -186,7 +186,7 @@ class AuditLogAction extends AabenFormsActionBase {
     preg_match_all('/\[([^\]]+)\]/', $string, $matches);
 
     foreach ($matches[1] as $tokenName) {
-      $value = $this->getTokenValue($tokenName, '[' . $tokenName . ']', '');
+      $value = $this->getTokenValue($tokenName, '[' . $tokenName . ']');
       if (!is_string($value) && !is_numeric($value)) {
         $value = is_array($value) ? json_encode($value) : (string) $value;
       }

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
@@ -130,10 +130,12 @@ class AuditLogAction extends AabenFormsActionBase {
       $message = $this->configuration['message_template'] ?? 'Workflow action executed';
       $message = $this->replaceTokensInString($message);
 
-      // Get additional data.
+      // Get additional data. Read the raw token (mixed) instead of going through
+      // getTokenValue(), which coerces to string and silently drops arrays - the
+      // exact case the form field 'Additional data token' is meant to handle.
       $additionalData = [];
       if (!empty($this->configuration['additional_data_token'])) {
-        $data = $this->getTokenValue($this->configuration['additional_data_token'], '');
+        $data = $this->tokenService->getTokenData($this->configuration['additional_data_token']);
         if (is_array($data)) {
           $additionalData = $data;
         }

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -122,21 +122,27 @@ class AuditLogActionTest extends UnitTestCase {
   /**
    * Tests audit log entry creation.
    *
-   * NOTE: This test is currently marked as skipped because the AuditLogAction
-   * has a bug - it calls the protected log() method directly instead of using
-   * the public logWorkflowAccess() method.
-   *
    * @covers ::execute
    */
   public function testLogEntryCreation(): void {
-    $this->markTestSkipped('AuditLogAction calls protected log() method - needs refactoring to use public methods');
-
     // Set test data.
     $this->tokenStorage['cpr'] = '0101001234';
 
-    // Expected: Should call logWorkflowAccess() but currently calls protected log().
+    // Default config: event_type='workflow_action', message='Workflow action
+    // executed'. Falls into the else branch of execute(); the AuditLogger's
+    // generic log() is the right entry point for the multi-event-type action.
     $this->auditLogger->expects($this->once())
-      ->method('logWorkflowAccess');
+      ->method('log')
+      ->with(
+        'workflow_action',
+        '0101001234',
+        'Workflow action executed',
+        'success',
+        $this->callback(function ($context) {
+          return isset($context['action_id'])
+            && $context['action_id'] === 'aabenforms_audit_log';
+        })
+      );
 
     // Execute action.
     $this->action->execute();
@@ -148,7 +154,6 @@ class AuditLogActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testStructuredDataCapture(): void {
-    $this->markTestSkipped('AuditLogAction calls protected log() method - needs refactoring');
     $additionalData = [
       'workflow_id' => 'workflow-123',
       'step' => 'approval',
@@ -166,22 +171,25 @@ class AuditLogActionTest extends UnitTestCase {
     $config['additional_data_token'] = 'additional_data';
     $configProperty->setValue($this->action, $config);
 
-    // Expect log with additional data merged into metadata.
+    // Expect log with additional data merged into the context (5th arg).
     $this->auditLogger->expects($this->once())
       ->method('log')
       ->with(
-              $this->anything(),
-              $this->anything(),
-              $this->anything(),
-              $this->callback(
-                  function ($metadata) {
-                      return isset($metadata['workflow_id']) &&
-                       $metadata['workflow_id'] === 'workflow-123' &&
-                       isset($metadata['decision']) &&
-                       $metadata['decision'] === 'approved';
-                  }
-              )
-          );
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        $this->callback(
+          function ($context) {
+            return isset($context['workflow_id'])
+              && $context['workflow_id'] === 'workflow-123'
+              && isset($context['decision'])
+              && $context['decision'] === 'approved'
+              && isset($context['step'])
+              && $context['step'] === 'approval';
+          }
+        )
+      );
 
     // Execute action.
     $this->action->execute();
@@ -193,7 +201,6 @@ class AuditLogActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testTenantContext(): void {
-    $this->markTestSkipped('AuditLogAction calls protected log() method - needs refactoring');
     // Set tenant context in tokens.
     $this->tokenStorage['tenant_id'] = 'aarhus-kommune';
     $this->tokenStorage['tenant_name'] = 'Aarhus Kommune';
@@ -206,15 +213,16 @@ class AuditLogActionTest extends UnitTestCase {
     $config['message_template'] = 'Action by [tenant_name] (ID: [tenant_id])';
     $configProperty->setValue($this->action, $config);
 
-    // Expect log with replaced tokens.
+    // Token-replaced message lands in the purpose slot (3rd arg).
     $this->auditLogger->expects($this->once())
       ->method('log')
       ->with(
-              $this->anything(),
-              'Action by Aarhus Kommune (ID: aarhus-kommune)',
-              $this->anything(),
-              $this->anything()
-          );
+        $this->anything(),
+        $this->anything(),
+        'Action by Aarhus Kommune (ID: aarhus-kommune)',
+        $this->anything(),
+        $this->anything()
+      );
 
     // Execute action.
     $this->action->execute();
@@ -226,9 +234,6 @@ class AuditLogActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testGdprCompliance(): void {
-    $this->markTestSkipped(
-      'Test asserts assertion-shape that drifted from the AuditLogAction implementation; needs rework against the current GDPR-context array. Tracked in #35.'
-    );
     $cpr = '010100-1234';
 
     // Set CPR token with hyphen (should be normalized).
@@ -242,15 +247,21 @@ class AuditLogActionTest extends UnitTestCase {
     $config['event_type'] = 'cpr_access';
     $configProperty->setValue($this->action, $config);
 
-    // Expect logCprLookup to be called with normalized CPR.
+    // CPR-access branch: action='cpr_access', identifier=normalized CPR,
+    // purpose='workflow_action' (hardcoded by execute()), context contains
+    // the original message under 'message'.
     $this->auditLogger->expects($this->once())
-      ->method('logCprLookup')
+      ->method('log')
       ->with(
-              '0101001234',
-              'workflow_action',
-              'success',
-              $this->anything()
-          );
+        'cpr_access',
+        '0101001234',
+        'workflow_action',
+        'success',
+        $this->callback(function ($context) {
+          return isset($context['message'])
+            && $context['message'] === 'Workflow action executed';
+        })
+      );
 
     // Execute action.
     $this->action->execute();
@@ -262,7 +273,6 @@ class AuditLogActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testBatchLogging(): void {
-    $this->markTestSkipped('AuditLogAction calls protected log() method - needs refactoring');
     // First execution.
     $this->auditLogger->expects($this->exactly(2))
       ->method('log');
@@ -279,7 +289,6 @@ class AuditLogActionTest extends UnitTestCase {
    * @covers ::replaceTokensInString
    */
   public function testTokenReplacement(): void {
-    $this->markTestSkipped('AuditLogAction calls protected log() method - needs refactoring');
     // Set various token types.
     $this->tokenStorage['user_name'] = 'John Doe';
     $this->tokenStorage['workflow_id'] = 'workflow-456';
@@ -293,15 +302,16 @@ class AuditLogActionTest extends UnitTestCase {
     $config['message_template'] = 'User [user_name] completed [action_count] actions in [workflow_id]';
     $configProperty->setValue($this->action, $config);
 
-    // Expect log with all tokens replaced.
+    // Token-replaced message lands in the purpose slot (3rd arg).
     $this->auditLogger->expects($this->once())
       ->method('log')
       ->with(
-              $this->anything(),
-              'User John Doe completed 5 actions in workflow-456',
-              $this->anything(),
-              $this->anything()
-          );
+        $this->anything(),
+        $this->anything(),
+        'User John Doe completed 5 actions in workflow-456',
+        $this->anything(),
+        $this->anything()
+      );
 
     // Execute action.
     $this->action->execute();
@@ -313,13 +323,13 @@ class AuditLogActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testErrorHandling(): void {
-    $this->markTestSkipped('AuditLogAction calls protected log() method - needs refactoring');
     // Mock audit logger throwing exception.
     $this->auditLogger->expects($this->once())
       ->method('log')
       ->willThrowException(new \Exception('Database connection error'));
 
-    // Expect error log.
+    // handleError() routes through the protected base log() at 'error' level,
+    // which reaches the injected channel as logger->error().
     $this->logger->expects($this->once())
       ->method('error');
 


### PR DESCRIPTION
## Summary

- Unskips 7 of the 8 \`AuditLogActionTest\` cases. All 8 are now green; \`Unit\` suite skips drop from 53 to 46.
- Fixes a real production bug in \`AuditLogAction\` that the revived \`testStructuredDataCapture\` exposes: the \`additional_data_token\` config field was dead because \`execute()\` read it through \`getTokenValue()\` (which always coerces to string), silently dropping array tokens.

## What was wrong with the tests

All 6 of the "calls protected \`log()\` method - needs refactoring" skips diagnosed the wrong thing. Production calls \`\$this->auditLogger->log(...)\` - the **public** 5-arg method on the \`AuditLogger\` service: \`(action, identifier, purpose, status, context)\`. The test \`->with(...)\` matchers used 4 args, putting their string match or callback in the wrong slot. Two tests (\`testLogEntryCreation\`, \`testGdprCompliance\`) additionally expected \`logWorkflowAccess()\` / \`logCprLookup()\`, but production calls the generic \`log()\` for all event types - the domain-specific helpers exist for direct callers, not for a multi-event-type action.

Fixed all 7 by aligning expectations to the actual signature. \`testBatchLogging\` and \`testErrorHandling\` had no positional args to fix; just unskipped.

## What was wrong with production

\`testStructuredDataCapture\` exercises the \`additional_data_token\` form field by setting an array-valued token and asserting it lands in the AuditLogger context. The test was \"failing\" not because of test rot but because production never wired it up:

\`\`\`php
// Before: getTokenValue() returns string, arrays coerce to '', merge becomes a no-op
\$data = \$this->getTokenValue(\$this->configuration['additional_data_token'], '');
if (is_array(\$data)) { \$additionalData = \$data; }   // never true

// After: read raw token (mixed), merge when actually array
\$data = \$this->tokenService->getTokenData(\$this->configuration['additional_data_token']);
if (is_array(\$data)) { \$additionalData = \$data; }   // now works
\`\`\`

The form field, the if-branch, and the merge already existed - the read was just going through the wrong helper.

## Test plan

- [x] \`ddev exec ./vendor/bin/phpunit AuditLogActionTest.php\` -> 8/8 pass, 41 assertions
- [x] Full \`aabenforms_workflows/tests/src/Unit/\` suite -> 108/108 (no regressions, 0 failures)
- [ ] CI runs \`unit\` + \`kernel\` testsuites green
- [ ] Coverage badge picks up the +7 revived tests on next badge refresh