### PR TITLE
Coverage push: 11.87% → 20.80% Lines (Unit suite)

### DIFF
--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdCprExtractorTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdCprExtractorTest.php
@@ -396,6 +396,122 @@ class MitIdCprExtractorTest extends UnitTestCase {
   }
 
   /**
+   * Tests extractClaim returns the claim when present.
+   *
+   * @covers ::extractClaim
+   */
+  public function testExtractClaimReturnsValueForPresentClaim(): void {
+    $token = $this->createTestJwt([
+      'nonce' => 'random-nonce-abc',
+      'sub' => 'mitid-uuid-123',
+    ]);
+
+    $this->assertSame('random-nonce-abc', $this->cprExtractor->extractClaim($token, 'nonce'));
+    $this->assertSame('mitid-uuid-123', $this->cprExtractor->extractClaim($token, 'sub'));
+  }
+
+  /**
+   * Tests extractClaim returns NULL when the claim is absent.
+   *
+   * @covers ::extractClaim
+   */
+  public function testExtractClaimReturnsNullForAbsentClaim(): void {
+    $token = $this->createTestJwt([
+      'sub' => 'mitid-uuid-123',
+    ]);
+
+    $this->assertNull($this->cprExtractor->extractClaim($token, 'nonce'));
+  }
+
+  /**
+   * Tests extractClaim swallows malformed tokens and returns NULL.
+   *
+   * @covers ::extractClaim
+   */
+  public function testExtractClaimReturnsNullForMalformedToken(): void {
+    // Two-part token (parseJwt throws InvalidArgumentException).
+    $this->assertNull($this->cprExtractor->extractClaim('header.payload', 'sub'));
+  }
+
+  /**
+   * Tests assurance level mapping for SAML PasswordProtectedTransport ACR.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelMapsPasswordProtectedTransportToLow(): void {
+    $token = $this->createTestJwt([
+      'acr' => 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+    ]);
+
+    $this->assertSame('low', $this->cprExtractor->getAssuranceLevel($token));
+  }
+
+  /**
+   * Tests assurance level falls back to 'substantial' for unmapped non-unknown ACR.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelDefaultsToSubstantialForUnmappedAcr(): void {
+    $token = $this->createTestJwt([
+      'acr' => 'http://example.org/some/custom/loa',
+    ]);
+
+    $this->assertSame('substantial', $this->cprExtractor->getAssuranceLevel($token));
+  }
+
+  /**
+   * Tests assurance level returns 'unknown' when JWT parsing fails.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelReturnsUnknownForInvalidJwt(): void {
+    // Two-part token (parseJwt throws, caught by getAssuranceLevel).
+    $this->assertSame('unknown', $this->cprExtractor->getAssuranceLevel('header.payload'));
+  }
+
+  /**
+   * Tests validateToken rejects tokens issued in the future (clock-skew guard).
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenWithFutureIat(): void {
+    $now = time();
+    $token = $this->createTestJwt([
+      'iss' => 'http://localhost:8080/realms/danish-gov-test',
+      'sub' => 'mitid-uuid-123',
+      'aud' => 'aabenforms-backend',
+      'exp' => $now + 3600,
+      // Issued 5 minutes in the future, well beyond the 60s skew tolerance.
+      'iat' => $now + 300,
+    ]);
+
+    $this->logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        $this->stringContains('issued in future'),
+        $this->anything(),
+      );
+
+    $this->assertFalse($this->cprExtractor->validateToken($token));
+  }
+
+  /**
+   * Tests validateToken returns FALSE (and logs error) when JWT is malformed.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenWithInvalidFormatReturnsFalse(): void {
+    $this->logger->expects($this->once())
+      ->method('error')
+      ->with(
+        $this->stringContains('validation failed'),
+        $this->anything(),
+      );
+
+    $this->assertFalse($this->cprExtractor->validateToken('not-a-jwt'));
+  }
+
+  /**
    * Helper method to create a test JWT token.
    *
    * @param array $claims

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
@@ -562,6 +562,93 @@ class MitIdSessionManagerTest extends UnitTestCase {
   }
 
   /**
+   * Tests getAddressFromSession early-returns NULL when the session itself is gone.
+   *
+   * Distinct from the no-address-keys path - this exercises the line that
+   * checks getSession() === NULL before looking at the address keys.
+   *
+   * @covers ::getAddressFromSession
+   */
+  public function testGetAddressFromMissingSession(): void {
+    $workflowId = 'workflow-no-session';
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn(NULL);
+
+    $this->assertNull($this->sessionManager->getAddressFromSession($workflowId));
+  }
+
+  /**
+   * Tests getAddressFromSession returns the partial address block.
+   *
+   * Only one of the four address keys is present; the others land as NULL
+   * in the returned array.
+   *
+   * @covers ::getAddressFromSession
+   */
+  public function testGetAddressFromSessionPartialAddress(): void {
+    $workflowId = 'workflow-partial-addr';
+    $sessionData = [
+      'cpr' => '0101001234',
+      'street' => 'Nørrebrogade 142',
+      'expires_at' => $this->currentTime + 600,
+    ];
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn($sessionData);
+
+    $this->assertSame([
+      'street' => 'Nørrebrogade 142',
+      'postal_code' => NULL,
+      'city' => NULL,
+      'municipality_code' => NULL,
+    ], $this->sessionManager->getAddressFromSession($workflowId));
+  }
+
+  /**
+   * Tests hasValidSession returns FALSE when stored data is past its expires_at.
+   *
+   * Covers the keyvalue-TTL-drift defense-in-depth branch.
+   *
+   * @covers ::hasValidSession
+   * @covers ::getSession
+   */
+  public function testHasValidSessionFalseForExpired(): void {
+    $workflowId = 'workflow-expired';
+    $expired = [
+      'cpr' => '0101001234',
+      'expires_at' => $this->currentTime - 1,
+      'workflow_id' => $workflowId,
+    ];
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn($expired);
+    $this->store->expects($this->once())
+      ->method('delete')
+      ->with($workflowId);
+
+    $this->assertFalse($this->sessionManager->hasValidSession($workflowId));
+  }
+
+  /**
+   * Tests getSession returns NULL when the store returns a non-array value.
+   *
+   * @covers ::getSession
+   */
+  public function testGetSessionReturnsNullWhenStoreReturnsNonArray(): void {
+    $workflowId = 'workflow-corrupt';
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn('not-an-array');
+
+    $this->assertNull($this->sessionManager->getSession($workflowId));
+  }
+
+  /**
    * Tests getAddressFromSession returns the address block when present.
    *
    * @covers ::getAddressFromSession

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/BookAppointmentActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/BookAppointmentActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\BookAppointmentAction;
 use Drupal\aabenforms_workflows\Service\CalendarService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -39,7 +40,7 @@ class BookAppointmentActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -51,19 +52,23 @@ class BookAppointmentActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->calendarService = $this->createMock(CalendarService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'slot_id_field' => 'selected_slot_id',
       'attendee_name_field' => 'name',
       'attendee_email_field' => 'email',
@@ -73,7 +78,7 @@ class BookAppointmentActionTest extends UnitTestCase {
     ];
 
     $this->action = new BookAppointmentAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_book_appointment',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -83,11 +88,48 @@ class BookAppointmentActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('calendarService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->calendarService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission the mock's getSubmission() should return.
+   *
+   * @return \Drupal\aabenforms_workflows\Plugin\Action\BookAppointmentAction
+   *   The configured partial mock.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission): BookAppointmentAction {
+    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
+      ->setConstructorArgs([
+        $this->configuration,
+        'aabenforms_book_appointment',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('calendarService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->calendarService);
+
+    return $actionMock;
   }
 
   /**
@@ -133,41 +175,23 @@ class BookAppointmentActionTest extends UnitTestCase {
       )
       ->willReturn($bookingResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['booking_id', 'BOOK-ABC-123'],
-        ['booking_slot_id', 'SLOT-20260315-1400'],
-        ['booking_status', 'confirmed'],
-        ['booked_at', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('BOOK-ABC-123', $writes['booking_id']);
+    $this->assertSame('SLOT-20260315-1400', $writes['booking_slot_id']);
+    $this->assertSame('confirmed', $writes['booking_status']);
+    $this->assertArrayHasKey('booked_at', $writes);
   }
 
   /**
@@ -197,12 +221,12 @@ class BookAppointmentActionTest extends UnitTestCase {
       ->method('bookSlot')
       ->willReturn($bookingResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(2))
       ->method('setElementData')
-      ->withConsecutive(
-        ['booking_status', 'failed'],
-        ['booking_error', 'Slot already booked (double booking prevented)']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
@@ -211,29 +235,11 @@ class BookAppointmentActionTest extends UnitTestCase {
       ->method('warning')
       ->with($this->stringContains('Appointment booking failed'));
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('failed', $writes['booking_status']);
+    $this->assertSame('Slot already booked (double booking prevented)', $writes['booking_error']);
   }
 
   /**
@@ -284,28 +290,7 @@ class BookAppointmentActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -325,28 +310,7 @@ class BookAppointmentActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Slot ID field'));
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -396,28 +360,7 @@ class BookAppointmentActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -284,20 +284,18 @@ class CprLookupActionTest extends UnitTestCase {
   /**
    * Tests missing CPR handling.
    *
+   * Empty CPR is treated as demo mode: info log, result NULL, no SOAP call.
+   * The earlier shape (warning) was changed when demo-mode fallback landed.
+   *
    * @covers ::execute
    */
   public function testMissingCpr(): void {
-    $this->markTestSkipped(
-      'Test pre-dates the current handleError + executionCollector flow; assertion shape no longer matches. Tracked in #35.'
-    );
     // Don't set CPR token.
-    // Expect warning log.
+    // Demo-mode info log, never warning.
     $this->logger->expects($this->once())
-      ->method('warning')
-      ->with(
-              'CPR lookup failed: No CPR number provided',
-              ['action' => 'aabenforms_cpr_lookup']
-          );
+      ->method('info');
+    $this->logger->expects($this->never())
+      ->method('warning');
 
     // Serviceplatformen should NOT be called.
     $this->serviceplatformenClient->expects($this->never())

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/FetchAvailableSlotsActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/FetchAvailableSlotsActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\FetchAvailableSlotsAction;
 use Drupal\aabenforms_workflows\Service\CalendarService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,19 +51,23 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->calendarService = $this->createMock(CalendarService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'start_date_field' => 'preferred_date',
       'date_range_days' => '30',
       'slot_duration' => '60',
@@ -71,7 +76,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     ];
 
     $this->action = new FetchAvailableSlotsAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_fetch_available_slots',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -81,11 +86,42 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('calendarService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->calendarService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): FetchAvailableSlotsAction {
+    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_fetch_available_slots',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('calendarService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->calendarService);
+
+    return $actionMock;
   }
 
   /**
@@ -138,41 +174,23 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
       )
       ->willReturn($slotsResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['available_slots', $this->isType('string')],
-        ['slots_count', 2],
-        ['slots_start_date', '2026-03-01'],
-        ['slots_end_date', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertIsString($writes['available_slots']);
+    $this->assertSame(2, $writes['slots_count']);
+    $this->assertSame('2026-03-01', $writes['slots_start_date']);
+    $this->assertArrayHasKey('slots_end_date', $writes);
   }
 
   /**
@@ -206,28 +224,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -239,20 +236,8 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('602');
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['slot_duration'] = '90';
-
-    $actionWith90Min = new FetchAvailableSlotsAction(
-      $configuration,
-      'aabenforms_fetch_available_slots',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->calendarService->expects($this->once())
       ->method('getAvailableSlots')
@@ -274,28 +259,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -315,45 +279,34 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
         'total_slots' => 0,
       ]);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['available_slots', '[]'],
-        ['slots_count', 0],
-        ['slots_start_date', '2026-06-01'],
-        ['slots_end_date', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
+    // Production logs with placeholders; the resolved count lives in
+    // the context array under '@count'.
     $this->logger->expects($this->once())
       ->method('info')
-      ->with($this->stringContains('Fetched 0 available slots'));
+      ->with(
+        $this->stringContains('Fetched @count available slots'),
+        $this->callback(function ($context) {
+          return ($context['@count'] ?? NULL) === 0;
+        })
+      );
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('[]', $writes['available_slots']);
+    $this->assertSame(0, $writes['slots_count']);
+    $this->assertSame('2026-06-01', $writes['slots_start_date']);
+    $this->assertArrayHasKey('slots_end_date', $writes);
   }
 
   /**
@@ -398,28 +351,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/GeneratePdfActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/GeneratePdfActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\GeneratePdfAction;
 use Drupal\aabenforms_workflows\Service\PdfService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class GeneratePdfActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,19 +51,23 @@ class GeneratePdfActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->pdfService = $this->createMock(PdfService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'template' => 'parking_permit',
       'filename_pattern' => '{template}_{submission_id}_{timestamp}.pdf',
       'orientation' => 'portrait',
@@ -74,7 +79,7 @@ address:street_address',
     ];
 
     $this->action = new GeneratePdfAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_generate_pdf',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -84,11 +89,42 @@ address:street_address',
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('pdfService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->pdfService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): GeneratePdfAction {
+    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_generate_pdf',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('pdfService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->pdfService);
+
+    return $actionMock;
   }
 
   /**
@@ -135,28 +171,7 @@ address:street_address',
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -175,21 +190,9 @@ address:street_address',
     $this->submission->method('id')->willReturn('501');
     $this->submission->method('getCreatedTime')->willReturn(1640000000);
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['template'] = 'marriage_certificate';
     $configuration['data_fields'] = '';
-
-    $actionWithConfig = new GeneratePdfAction(
-      $configuration,
-      'aabenforms_generate_pdf',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->pdfService->expects($this->once())
       ->method('generatePdf')
@@ -215,28 +218,7 @@ address:street_address',
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -295,41 +277,23 @@ address:street_address',
       ->method('generatePdf')
       ->willReturn($pdfResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['pdf_file_id', 10],
-        ['pdf_file_uri', 'public://pdfs/document.pdf'],
-        ['pdf_file_url', 'https://example.com/files/document.pdf'],
-        ['pdf_filename', 'document.pdf']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame(10, $writes['pdf_file_id']);
+    $this->assertSame('public://pdfs/document.pdf', $writes['pdf_file_uri']);
+    $this->assertSame('https://example.com/files/document.pdf', $writes['pdf_file_url']);
+    $this->assertSame('document.pdf', $writes['pdf_filename']);
   }
 
   /**
@@ -372,28 +336,7 @@ address:street_address',
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
@@ -223,12 +223,13 @@ class MitIdValidateActionTest extends UnitTestCase {
   /**
    * Tests validation with missing MitID session.
    *
+   * Production code treats a missing session as "demo mode": logs at INFO,
+   * sets the result token to TRUE, and records a successful step. The earlier
+   * shape (warning + FALSE) was changed when demo-mode fallback was added.
+   *
    * @covers ::execute
    */
   public function testMissingSession(): void {
-    $this->markTestSkipped(
-      'Test asserts MitIdSessionManager validation behavior that has since changed shape. Tracked in #35.'
-    );
     $workflowId = 'workflow-missing';
 
     // Set workflow ID token.
@@ -240,19 +241,17 @@ class MitIdValidateActionTest extends UnitTestCase {
       ->with($workflowId)
       ->willReturn(NULL);
 
-    // Expect warning log for missing session.
+    // Demo-mode fallback: info log, no warning.
     $this->logger->expects($this->once())
-      ->method('warning')
-      ->with(
-              'MitID validation failed: No session found for workflow {workflow_id}',
-              ['workflow_id' => $workflowId, 'action' => 'aabenforms_mitid_validate']
-          );
+      ->method('info');
+    $this->logger->expects($this->never())
+      ->method('warning');
 
     // Execute action.
     $this->action->execute();
 
-    // Verify result is FALSE.
-    $this->assertFalse($this->tokenStorage['mitid_valid']);
+    // Verify result is TRUE (demo mode).
+    $this->assertTrue($this->tokenStorage['mitid_valid']);
   }
 
   /**
@@ -307,9 +306,6 @@ class MitIdValidateActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testErrorHandling(): void {
-    $this->markTestSkipped(
-      'Logger error-context assertion shape drifted from the current handleError() signature (now \Throwable). Tracked in #35.'
-    );
     $workflowId = 'workflow-error';
 
     // Set workflow ID token.
@@ -321,7 +317,10 @@ class MitIdValidateActionTest extends UnitTestCase {
       ->with($workflowId)
       ->willThrowException(new \Exception('Database connection error'));
 
-    // Expect error log.
+    // handleError() routes to log('error', ...). The injected channel sees
+    // the call as logger->error(message, context). Context contains
+    // 'message', 'context' (the context_message passed by execute()),
+    // 'exception', and 'action' (added by the base log() helper).
     $this->logger->expects($this->once())
       ->method('error')
       ->with(
@@ -331,7 +330,7 @@ class MitIdValidateActionTest extends UnitTestCase {
                       return isset($context['message']) &&
                        $context['message'] === 'Database connection error' &&
                        isset($context['context']) &&
-                       $context['context'] === 'Validating MitID session';
+                       $context['context'] === 'MitID Identity Validation';
                   }
               )
           );
@@ -346,20 +345,18 @@ class MitIdValidateActionTest extends UnitTestCase {
   /**
    * Tests validation without workflow ID.
    *
+   * Missing workflow ID falls into demo mode: info log, result token TRUE,
+   * and the session manager is never consulted.
+   *
    * @covers ::execute
    */
   public function testMissingWorkflowId(): void {
-    $this->markTestSkipped(
-      'Test asserts MitIdSessionManager workflow-id validation behavior that has since changed shape. Tracked in #35.'
-    );
     // Don't set workflow_id token (simulate missing context).
-    // Expect warning log.
+    // Demo-mode info log, no warning.
     $this->logger->expects($this->once())
-      ->method('warning')
-      ->with(
-              'MitID validation failed: No workflow ID provided',
-              ['action' => 'aabenforms_mitid_validate']
-          );
+      ->method('info');
+    $this->logger->expects($this->never())
+      ->method('warning');
 
     // Session manager should NOT be called.
     $this->sessionManager->expects($this->never())
@@ -368,8 +365,8 @@ class MitIdValidateActionTest extends UnitTestCase {
     // Execute action.
     $this->action->execute();
 
-    // Verify result is FALSE.
-    $this->assertFalse($this->tokenStorage['mitid_valid']);
+    // Verify result is TRUE (demo mode).
+    $this->assertTrue($this->tokenStorage['mitid_valid']);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ProcessPaymentActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ProcessPaymentActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\ProcessPaymentAction;
 use Drupal\aabenforms_workflows\Service\PaymentService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
   /**
    * Mock logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,12 +51,16 @@ class ProcessPaymentActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     // Mock dependencies.
@@ -70,7 +75,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     $ecaState = $this->createMock(EcaState::class);
 
     // Create action instance.
-    $configuration = [
+    $this->configuration = [
       'amount_field' => 'payment_amount',
       'currency' => 'DKK',
       'payment_method' => 'nets_easy',
@@ -80,7 +85,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     ];
 
     $this->action = new ProcessPaymentAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_process_payment',
       ['provider' => 'aabenforms_workflows'],
       $entityTypeManager,
@@ -90,12 +95,57 @@ class ProcessPaymentActionTest extends UnitTestCase {
       $ecaState,
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     // Inject payment service via reflection.
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('paymentService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->paymentService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   *
+   * Centralises the boilerplate for wiring the payment service into a
+   * mocked-getSubmission instance.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission the mock's getSubmission() should return.
+   * @param array|null $configuration
+   *   Optional configuration override (defaults to $this->configuration).
+   *
+   * @return \Drupal\aabenforms_workflows\Plugin\Action\ProcessPaymentAction
+   *   The configured partial mock.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): ProcessPaymentAction {
+    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_process_payment',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $actionMock->expects($this->once())
+      ->method('getSubmission')
+      ->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('paymentService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->paymentService);
+
+    return $actionMock;
   }
 
   /**
@@ -114,7 +164,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('123');
 
@@ -137,55 +187,25 @@ class ProcessPaymentActionTest extends UnitTestCase {
       }))
       ->willReturn($paymentResult);
 
-    // Expect submission data to be updated.
+    // Capture every setElementData call so we can assert on the full set
+    // without depending on PHPUnit 9's withConsecutive().
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['payment_id', 'PAY-123-456'],
-        ['payment_status', 'completed'],
-        ['payment_transaction_id', 'TXN-ABC123'],
-        ['payment_timestamp', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    // Execute action with mock submission.
-    $reflection = new \ReflectionClass($this->action);
-    $method = $reflection->getMethod('execute');
-    $method->setAccessible(TRUE);
-
-    // Mock getSubmission method.
-    $getSubmissionMethod = $reflection->getMethod('getSubmission');
-    $getSubmissionMethod->setAccessible(TRUE);
-
-    // Use a closure to override getSubmission behavior.
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    // Inject payment service.
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('PAY-123-456', $writes['payment_id']);
+    $this->assertSame('completed', $writes['payment_status']);
+    $this->assertSame('TXN-ABC123', $writes['payment_transaction_id']);
+    $this->assertArrayHasKey('payment_timestamp', $writes);
   }
 
   /**
@@ -203,7 +223,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('124');
 
@@ -217,42 +237,21 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('processPayment')
       ->willReturn($paymentResult);
 
-    // Expect failure data to be stored.
+    $writes = [];
     $this->submission->expects($this->exactly(2))
       ->method('setElementData')
-      ->withConsecutive(
-        ['payment_status', 'failed'],
-        ['payment_error', 'Card declined']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('failed', $writes['payment_status']);
+    $this->assertSame('Card declined', $writes['payment_error']);
   }
 
   /**
@@ -269,7 +268,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('125');
 
@@ -285,30 +284,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     $this->submission->expects($this->never())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -326,7 +302,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('126');
 
@@ -339,30 +315,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Amount field'));
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -419,30 +372,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendReminderActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendReminderActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\SendReminderAction;
 use Drupal\aabenforms_workflows\Service\SmsService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -54,7 +55,7 @@ class SendReminderActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -66,12 +67,16 @@ class SendReminderActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->smsService = $this->createMock(SmsService::class);
@@ -80,7 +85,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'reminder_type' => 'email',
       'delay_days' => '7',
       'event_date_field' => 'ceremony_date',
@@ -91,7 +96,7 @@ class SendReminderActionTest extends UnitTestCase {
     ];
 
     $this->action = new SendReminderAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_send_reminder',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -101,19 +106,54 @@ class SendReminderActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
-    $reflection = new \ReflectionClass($this->action);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($this->action, $this->smsService);
+    $this->injectServices($this->action);
+  }
 
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($this->action, $this->mailManager);
+  /**
+   * Injects the SMS service, mail manager and queue factory via reflection.
+   */
+  protected function injectServices(SendReminderAction $action): void {
+    $reflection = new \ReflectionClass($action);
 
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($this->action, $this->queueFactory);
+    $smsServiceProperty = $reflection->getProperty('smsService');
+    $smsServiceProperty->setAccessible(TRUE);
+    $smsServiceProperty->setValue($action, $this->smsService);
+
+    $mailManagerProperty = $reflection->getProperty('mailManager');
+    $mailManagerProperty->setAccessible(TRUE);
+    $mailManagerProperty->setValue($action, $this->mailManager);
+
+    $queueFactoryProperty = $reflection->getProperty('queueFactory');
+    $queueFactoryProperty->setAccessible(TRUE);
+    $queueFactoryProperty->setValue($action, $this->queueFactory);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): SendReminderAction {
+    $actionMock = $this->getMockBuilder(SendReminderAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_send_reminder',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+    $this->injectServices($actionMock);
+
+    return $actionMock;
   }
 
   /**
@@ -130,13 +170,12 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('800');
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['reminder_scheduled', TRUE],
-        ['reminder_send_date', $this->anything()],
-        ['reminder_type', 'email']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
@@ -145,37 +184,12 @@ class SendReminderActionTest extends UnitTestCase {
       ->method('info')
       ->with($this->stringContains('Reminder scheduled'));
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertTrue($writes['reminder_scheduled']);
+    $this->assertArrayHasKey('reminder_send_date', $writes);
+    $this->assertSame('email', $writes['reminder_type']);
   }
 
   /**
@@ -193,12 +207,12 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('801');
 
+    $writes = [];
     $this->submission->expects($this->exactly(2))
       ->method('setElementData')
-      ->withConsecutive(
-        ['reminder_sent', TRUE],
-        ['reminder_sent_at', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
@@ -207,37 +221,11 @@ class SendReminderActionTest extends UnitTestCase {
       ->method('info')
       ->with($this->stringContains('Email reminder sent'));
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertTrue($writes['reminder_sent']);
+    $this->assertArrayHasKey('reminder_sent_at', $writes);
   }
 
   /**
@@ -255,20 +243,8 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('802');
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['reminder_type'] = 'sms';
-
-    $actionWithSms = new SendReminderAction(
-      $configuration,
-      'aabenforms_send_reminder',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->smsService->expects($this->once())
       ->method('sendSms')
@@ -283,36 +259,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -330,7 +277,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('803');
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['delay_days'] = '3';
 
     $this->submission->expects($this->atLeastOnce())
@@ -339,36 +286,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -392,36 +310,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendSmsActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendSmsActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\SendSmsAction;
 use Drupal\aabenforms_workflows\Service\SmsService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -39,7 +40,7 @@ class SendSmsActionTest extends UnitTestCase {
   /**
    * Mock logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -51,19 +52,23 @@ class SendSmsActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->smsService = $this->createMock(SmsService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'phone_field' => 'phone',
       'message_template' => 'Din ansøgning er modtaget. Sagsnummer: [submission:id]',
       'sender_name' => 'ÅbenForms',
@@ -71,7 +76,7 @@ class SendSmsActionTest extends UnitTestCase {
     ];
 
     $this->action = new SendSmsAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_send_sms',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -81,11 +86,45 @@ class SendSmsActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('smsService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->smsService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): SendSmsAction {
+    $actionMock = $this->getMockBuilder(SendSmsAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_send_sms',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $actionMock->expects($this->once())
+      ->method('getSubmission')
+      ->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('smsService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->smsService);
+
+    return $actionMock;
   }
 
   /**
@@ -102,7 +141,7 @@ class SendSmsActionTest extends UnitTestCase {
       'name' => 'Test User',
     ];
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('getData')
       ->willReturn($submissionData);
 
@@ -135,42 +174,22 @@ class SendSmsActionTest extends UnitTestCase {
       )
       ->willReturn($smsResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['sms_message_id', 'SMS-123-456'],
-        ['sms_status', 'sent'],
-        ['sms_segments', 1]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('SMS-123-456', $writes['sms_message_id']);
+    $this->assertSame('sent', $writes['sms_status']);
+    $this->assertSame(1, $writes['sms_segments']);
   }
 
   /**
@@ -185,7 +204,7 @@ class SendSmsActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('201');
 
@@ -196,30 +215,7 @@ class SendSmsActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Phone field'));
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -239,7 +235,7 @@ class SendSmsActionTest extends UnitTestCase {
       'amount' => '100',
     ];
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('getData')
       ->willReturn($submissionData);
 
@@ -255,20 +251,8 @@ class SendSmsActionTest extends UnitTestCase {
       ->method('getWebform')
       ->willReturn($webform);
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['message_template'] = 'Application [submission:id] for [submission:license_plate] received. Form: [webform:title]';
-
-    $actionWithTemplate = new SendSmsAction(
-      $configuration,
-      'aabenforms_send_sms',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->smsService->expects($this->once())
       ->method('sendSms')
@@ -289,30 +273,7 @@ class SendSmsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -326,22 +287,30 @@ class SendSmsActionTest extends UnitTestCase {
     $webform->method('label')->willReturn('Test Form');
 
     $phones = ['+4511111111', '+4522222222', '+4533333333'];
+    $sentPhones = [];
 
-    foreach ($phones as $index => $phone) {
-      $submission = $this->createMock(WebformSubmissionInterface::class);
-      $submission->method('getData')->willReturn(['phone' => $phone]);
-      $submission->method('id')->willReturn((string) (300 + $index));
-      $submission->method('getCreatedTime')->willReturn(time());
-      $submission->method('getWebform')->willReturn($webform);
-
-      $this->smsService->expects($this->at($index))
-        ->method('sendSms')
-        ->with($phone, $this->anything(), $this->anything())
-        ->willReturn([
+    // Each iteration creates a fresh action mock + submission, so each
+    // sendSms() call resolves against its own expectation. Replace the
+    // PHPUnit-9-only $this->at() pattern with a willReturnCallback that
+    // observes the actual phone passed and returns a per-call result.
+    $this->smsService->expects($this->exactly(count($phones)))
+      ->method('sendSms')
+      ->willReturnCallback(function ($phone) use (&$sentPhones) {
+        $sentPhones[] = $phone;
+        $index = count($sentPhones) - 1;
+        return [
           'status' => 'sent',
           'message_id' => 'SMS-' . (300 + $index),
           'segments' => 1,
-        ]);
+        ];
+      });
+
+    foreach ($phones as $phone) {
+      $submission = $this->createMock(WebformSubmissionInterface::class);
+      $submission->method('getData')->willReturn(['phone' => $phone]);
+      $submission->method('id')->willReturn((string) (300 + array_search($phone, $phones, TRUE)));
+      $submission->method('getCreatedTime')->willReturn(time());
+      $submission->method('getWebform')->willReturn($webform);
 
       $submission->expects($this->atLeastOnce())
         ->method('setElementData');
@@ -349,35 +318,12 @@ class SendSmsActionTest extends UnitTestCase {
       $submission->expects($this->once())
         ->method('save');
 
-      $actionMock = $this->getMockBuilder(SendSmsAction::class)
-        ->setConstructorArgs([
-          $this->action->getConfiguration(),
-          'aabenforms_send_sms',
-          ['provider' => 'aabenforms_workflows'],
-          $this->createMock(EntityTypeManagerInterface::class),
-          $this->createMock(TokenInterface::class),
-          $this->createMock(AccountProxyInterface::class),
-          $this->createMock(TimeInterface::class),
-          $this->createMock(EcaState::class),
-          $this->logger,
-        ])
-        ->onlyMethods(['getSubmission'])
-        ->getMock();
-
-      $actionMock->expects($this->once())
-        ->method('getSubmission')
-        ->willReturn($submission);
-
-      $reflection = new \ReflectionClass($actionMock);
-      $property = $reflection->getProperty('smsService');
-      $property->setAccessible(TRUE);
-      $property->setValue($actionMock, $this->smsService);
-
+      $actionMock = $this->createActionMock($submission);
       $actionMock->execute($submission);
     }
 
-    // All three should be processed.
-    $this->assertEquals(3, count($phones));
+    // Confirm every phone was sent in order.
+    $this->assertSame($phones, $sentPhones);
   }
 
   /**
@@ -393,7 +339,7 @@ class SendSmsActionTest extends UnitTestCase {
       'phone' => '+4512345678',
     ];
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('getData')
       ->willReturn($submissionData);
 
@@ -433,30 +379,7 @@ class SendSmsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ValidateZoningActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ValidateZoningActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\ValidateZoningAction;
 use Drupal\aabenforms_workflows\Service\GisService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class ValidateZoningActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,26 +51,30 @@ class ValidateZoningActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->gisService = $this->createMock(GisService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'address_field' => 'property_address',
       'construction_type_field' => 'construction_type',
       'store_result_in' => 'zoning_validation',
     ];
 
     $this->action = new ValidateZoningAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_validate_zoning',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -79,11 +84,42 @@ class ValidateZoningActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('gisService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->gisService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission): ValidateZoningAction {
+    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
+      ->setConstructorArgs([
+        $this->configuration,
+        'aabenforms_validate_zoning',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('gisService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->gisService);
+
+    return $actionMock;
   }
 
   /**
@@ -108,40 +144,22 @@ class ValidateZoningActionTest extends UnitTestCase {
       ->with('Hovedgaden 1, 8000 Aarhus C', 'garage')
       ->willReturn($validationResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['zoning_allowed', TRUE],
-        ['zoning_zone_type', 'residential'],
-        ['zoning_reason', 'Garages are permitted in residential zones']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertTrue($writes['zoning_allowed']);
+    $this->assertSame('residential', $writes['zoning_zone_type']);
+    $this->assertSame('Garages are permitted in residential zones', $writes['zoning_reason']);
   }
 
   /**
@@ -171,32 +189,19 @@ class ValidateZoningActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
+    // The production logger call uses placeholder substitution; the
+    // resolved string ("ALLOWED" or "NOT ALLOWED") lives in the context
+    // array under '@result', not in the message template.
     $this->logger->expects($this->once())
       ->method('info')
-      ->with($this->stringContains('ALLOWED'));
+      ->with(
+        $this->stringContains('Zoning validation'),
+        $this->callback(function ($context) {
+          return ($context['@result'] ?? '') === 'ALLOWED';
+        })
+      );
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -221,44 +226,33 @@ class ValidateZoningActionTest extends UnitTestCase {
       ->method('validateConstructionType')
       ->willReturn($validationResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['zoning_allowed', FALSE],
-        ['zoning_zone_type', 'residential'],
-        ['zoning_reason', 'Factories are not permitted in residential zones']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
+    // The placeholder-resolved value lives in the context array, not the
+    // message template.
     $this->logger->expects($this->once())
       ->method('info')
-      ->with($this->stringContains('NOT ALLOWED'));
+      ->with(
+        $this->stringContains('Zoning validation'),
+        $this->callback(function ($context) {
+          return ($context['@result'] ?? '') === 'NOT ALLOWED';
+        })
+      );
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertFalse($writes['zoning_allowed']);
+    $this->assertSame('residential', $writes['zoning_zone_type']);
+    $this->assertSame('Factories are not permitted in residential zones', $writes['zoning_reason']);
   }
 
   /**
@@ -279,28 +273,7 @@ class ValidateZoningActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Missing address'));
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -333,28 +306,7 @@ class ValidateZoningActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -193,7 +193,7 @@ class ApprovalTokenServiceTest extends UnitTestCase {
   }
 
   /**
-   * generateToken emits an info log naming the submission and parent.
+   * GenerateToken emits an info log naming the submission and parent.
    */
   public function testGenerateTokenLogsInfo(): void {
     $this->logger->expects($this->once())

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -34,6 +34,13 @@ class ApprovalTokenServiceTest extends UnitTestCase {
   protected string $key = 'unit-test-key-not-secret';
 
   /**
+   * The mock logger - exposed so individual tests can assert on log calls.
+   *
+   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $logger;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -42,9 +49,9 @@ class ApprovalTokenServiceTest extends UnitTestCase {
     $private_key = $this->createMock(PrivateKey::class);
     $private_key->method('get')->willReturn($this->key);
 
-    $logger = $this->createMock(LoggerInterface::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
     $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
-    $logger_factory->method('get')->willReturn($logger);
+    $logger_factory->method('get')->willReturn($this->logger);
 
     $this->service = new ApprovalTokenService($private_key, $logger_factory);
   }
@@ -183,6 +190,61 @@ class ApprovalTokenServiceTest extends UnitTestCase {
     $this->assertFalse($this->service->isTokenExpired('!!!not-base64!!!'));
     $this->assertFalse($this->service->isTokenExpired(base64_encode('no-colon')));
     $this->assertFalse($this->service->isTokenExpired(base64_encode('hash:not-numeric')));
+  }
+
+  /**
+   * generateToken emits an info log naming the submission and parent.
+   */
+  public function testGenerateTokenLogsInfo(): void {
+    $this->logger->expects($this->once())
+      ->method('info')
+      ->with(
+        $this->stringContains('Generated approval token'),
+        $this->callback(function ($context) {
+          return ($context['@sid'] ?? NULL) === 42 && ($context['@parent'] ?? NULL) === 1;
+        })
+      );
+
+    $this->service->generateToken(42, 1);
+  }
+
+  /**
+   * Successful validation emits the success info log.
+   *
+   * Sets the expectation before any service calls so PHPUnit catches both
+   * the generate-time and validate-time info logs.
+   */
+  public function testValidateTokenSuccessLogsInfo(): void {
+    $info_calls = [];
+    $this->logger->method('info')->willReturnCallback(
+      function ($message, $context) use (&$info_calls) {
+        $info_calls[] = $message;
+      }
+    );
+
+    $token = $this->service->generateToken(42, 1);
+    $this->assertTrue($this->service->validateToken(42, 1, $token));
+
+    $this->assertCount(2, $info_calls);
+    $this->assertStringContainsString('Generated approval token', $info_calls[0]);
+    $this->assertStringContainsString('validated successfully', $info_calls[1]);
+  }
+
+  /**
+   * HMAC mismatch (well-formed token, wrong key/payload) emits a warning.
+   */
+  public function testValidateTokenHmacMismatchLogsWarning(): void {
+    // Token is well-formed (parses, in-date) but the hash is bogus.
+    $tampered = base64_encode('deadbeefdeadbeef:' . time());
+
+    $this->logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        $this->stringContains('Token validation failed'),
+        $this->anything()
+      );
+
+    $this->assertFalse($this->service->validateToken(42, 1, $tampered));
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
@@ -291,9 +291,10 @@ XML;
   }
 
   /**
-   * Service + user tasks of every recognised type are returned; non-matching
-   * tasks ('process data') are dropped because determineActionType returns
-   * 'none'.
+   * Service + user tasks of every recognised type are returned.
+   *
+   * Non-matching tasks ('process data') are dropped because
+   * determineActionType returns 'none'.
    *
    * @covers ::getConfigurableActions
    * @covers ::determineActionType

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
@@ -1,0 +1,573 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_workflows\Service\BpmnTemplateManager;
+use Drupal\aabenforms_workflows\Service\WorkflowTemplateMetadata;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for WorkflowTemplateMetadata service.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\WorkflowTemplateMetadata
+ * @group aabenforms_workflows
+ */
+class WorkflowTemplateMetadataTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  protected WorkflowTemplateMetadata $sut;
+
+  /**
+   * Mock BPMN template manager.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\BpmnTemplateManager|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $templateManager;
+
+  /**
+   * Mock logger.
+   *
+   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->templateManager = $this->createMock(BpmnTemplateManager::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->logger);
+
+    $this->sut = new WorkflowTemplateMetadata($this->templateManager, $loggerFactory);
+  }
+
+  /**
+   * Builds a SimpleXMLElement BPMN document for fixtures.
+   *
+   * @param string $process_body
+   *   Inner XML for the bpmn:process element.
+   * @param string $prefix
+   *   Either 'bpmn' or 'bpmn2', so we can exercise both namespace prefixes.
+   * @param string|null $namespace
+   *   Override the namespace URI; defaults to the canonical BPMN one.
+   */
+  protected function bpmn(string $process_body, string $prefix = 'bpmn', ?string $namespace = NULL): \SimpleXMLElement {
+    $ns = $namespace ?? 'http://www.omg.org/spec/BPMN/20100524/MODEL';
+    // The id attribute on <definitions> matters more than it looks: SimpleXML's
+    // (bool) cast on a root element with only namespaced children evaluates to
+    // FALSE - production's `if (!$xml) return [];` would early-return on every
+    // fixture without it. Real BPMN files always carry id + targetNamespace,
+    // which is why production never hit this. Mirror that here.
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<{$prefix}:definitions xmlns:{$prefix}="{$ns}" id="Definitions_test" targetNamespace="http://aabenforms.dk/test">
+  <{$prefix}:process id="Process_1" name="Test Process">
+    {$process_body}
+  </{$prefix}:process>
+</{$prefix}:definitions>
+XML;
+    return simplexml_load_string($xml);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyForNullId(): void {
+    $this->templateManager->expects($this->never())->method('loadTemplate');
+    $this->assertSame([], $this->sut->getTemplateParameters(NULL));
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyForEmptyId(): void {
+    $this->templateManager->expects($this->never())->method('loadTemplate');
+    $this->assertSame([], $this->sut->getTemplateParameters(''));
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyWhenLoadTemplateReturnsNull(): void {
+    $this->templateManager->method('loadTemplate')->willReturn(NULL);
+    $this->assertSame([], $this->sut->getTemplateParameters('any_id'));
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyWhenNoBpmnNamespace(): void {
+    // A document with no bpmn or bpmn2 namespace registered.
+    $xml = simplexml_load_string('<root><child>x</child></root>');
+    $this->templateManager->method('loadTemplate')->willReturn($xml);
+    $this->assertSame([], $this->sut->getTemplateParameters('weird_template'));
+  }
+
+  /**
+   * Parameters declared in documentation are extracted via the bpmn prefix.
+   *
+   * Also covers the parseOptions helper through a select-type parameter.
+   *
+   * @covers ::getTemplateParameters
+   * @covers ::parseOptions
+   * @covers ::addDefaultParameters
+   */
+  public function testGetTemplateParametersExtractsFromDocumentationBpmnNs(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      Description.
+      <parameters>
+        <parameter id="topic" label="Topic" type="text" required="true" default="hello" description="The subject"/>
+        <parameter id="severity" label="Severity" type="select" required="false" default="low">
+          <options>
+            <option value="low">Low</option>
+            <option value="high">High</option>
+          </options>
+        </parameter>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body, 'bpmn'));
+
+    $params = $this->sut->getTemplateParameters('unknown_id');
+
+    // The unknown id only adds the workflow_label default, plus the two from the doc.
+    $this->assertArrayHasKey('topic', $params);
+    $this->assertArrayHasKey('severity', $params);
+    $this->assertArrayHasKey('workflow_label', $params);
+    $this->assertSame('Topic', $params['topic']['label']);
+    $this->assertSame('text', $params['topic']['type']);
+    $this->assertTrue($params['topic']['required']);
+    $this->assertSame('hello', $params['topic']['default']);
+    $this->assertSame('The subject', $params['topic']['description']);
+    $this->assertSame([], $params['topic']['options']);
+    $this->assertFalse($params['severity']['required']);
+    $this->assertSame(['low' => 'Low', 'high' => 'High'], $params['severity']['options']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersWorksWithBpmn2Prefix(): void {
+    $body = <<<XML
+    <bpmn2:documentation>
+      <parameters>
+        <parameter id="x" label="X" type="text" required="false"/>
+      </parameters>
+    </bpmn2:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')
+      ->willReturn($this->bpmn($body, 'bpmn2'));
+
+    $params = $this->sut->getTemplateParameters('unknown_id');
+    $this->assertArrayHasKey('x', $params);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::addDefaultParameters
+   * @covers ::getBuildingPermitDefaults
+   */
+  public function testGetTemplateParametersAddsBuildingPermitDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('building_permit');
+
+    $expected_keys = [
+      'workflow_label',
+      'applicant_email_field',
+      'cpr_field',
+      'address_field',
+      'caseworker_email',
+      'approval_deadline_days',
+      'sbsys_integration',
+    ];
+    foreach ($expected_keys as $key) {
+      $this->assertArrayHasKey($key, $params, "Missing $key");
+    }
+    $this->assertSame('integer', $params['approval_deadline_days']['type']);
+    $this->assertSame('boolean', $params['sbsys_integration']['type']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getContactFormDefaults
+   */
+  public function testGetTemplateParametersAddsContactFormDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('contact_form');
+
+    $this->assertArrayHasKey('submitter_email_field', $params);
+    $this->assertArrayHasKey('recipient_email', $params);
+    $this->assertArrayHasKey('auto_reply', $params);
+    $this->assertArrayHasKey('confirmation_message', $params);
+    $this->assertSame('boolean', $params['auto_reply']['type']);
+    $this->assertSame('textarea', $params['confirmation_message']['type']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getCompanyVerificationDefaults
+   */
+  public function testGetTemplateParametersAddsCompanyVerificationDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('company_verification');
+
+    $this->assertArrayHasKey('cvr_field', $params);
+    $this->assertArrayHasKey('contact_email_field', $params);
+    $this->assertArrayHasKey('verification_email', $params);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getFoiRequestDefaults
+   */
+  public function testGetTemplateParametersAddsFoiRequestDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('foi_request');
+
+    $this->assertArrayHasKey('requester_email_field', $params);
+    $this->assertArrayHasKey('foi_officer_email', $params);
+    $this->assertArrayHasKey('response_deadline_days', $params);
+    $this->assertSame('integer', $params['response_deadline_days']['type']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getAddressChangeDefaults
+   */
+  public function testGetTemplateParametersAddsAddressChangeDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('address_change');
+
+    $this->assertArrayHasKey('cpr_field', $params);
+    $this->assertArrayHasKey('new_address_field', $params);
+    $this->assertArrayHasKey('notification_email', $params);
+  }
+
+  /**
+   * Unknown template id only adds the common workflow_label parameter.
+   *
+   * @covers ::getTemplateParameters
+   * @covers ::addDefaultParameters
+   */
+  public function testGetTemplateParametersUnknownIdAddsOnlyWorkflowLabel(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('not_a_template');
+
+    $this->assertSame(['workflow_label'], array_keys($params));
+    $this->assertTrue($params['workflow_label']['required']);
+  }
+
+  /**
+   * @covers ::getConfigurableActions
+   */
+  public function testGetConfigurableActionsReturnsEmptyWhenLoadTemplateFails(): void {
+    $this->templateManager->method('loadTemplate')->willReturn(NULL);
+    $this->assertSame([], $this->sut->getConfigurableActions('any'));
+  }
+
+  /**
+   * @covers ::getConfigurableActions
+   */
+  public function testGetConfigurableActionsReturnsEmptyForNoNamespace(): void {
+    $xml = simplexml_load_string('<definitions><process/></definitions>');
+    $this->templateManager->method('loadTemplate')->willReturn($xml);
+    $this->assertSame([], $this->sut->getConfigurableActions('any'));
+  }
+
+  /**
+   * Service + user tasks of every recognised type are returned; non-matching
+   * tasks ('process data') are dropped because determineActionType returns
+   * 'none'.
+   *
+   * @covers ::getConfigurableActions
+   * @covers ::determineActionType
+   * @covers ::getActionConfigurableFields
+   */
+  public function testGetConfigurableActionsClassifiesTasks(): void {
+    $body = <<<XML
+    <bpmn:serviceTask id="t_email" name="Send notification email"/>
+    <bpmn:serviceTask id="t_lookup" name="Lookup citizen data"/>
+    <bpmn:serviceTask id="t_audit" name="Log audit entry"/>
+    <bpmn:userTask id="t_approval" name="Review and approval"/>
+    <bpmn:userTask id="t_auth" name="MitID auth check"/>
+    <bpmn:serviceTask id="t_skip" name="Process data crunching"/>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $actions = $this->sut->getConfigurableActions('any');
+
+    $this->assertArrayHasKey('t_email', $actions);
+    $this->assertArrayHasKey('t_lookup', $actions);
+    $this->assertArrayHasKey('t_audit', $actions);
+    $this->assertArrayHasKey('t_approval', $actions);
+    $this->assertArrayHasKey('t_auth', $actions);
+    // 'Process data' contains none of the trigger keywords; should be skipped.
+    $this->assertArrayNotHasKey('t_skip', $actions);
+
+    $this->assertSame('email', $actions['t_email']['type']);
+    $this->assertSame('data_lookup', $actions['t_lookup']['type']);
+    $this->assertSame('audit', $actions['t_audit']['type']);
+    $this->assertSame('approval', $actions['t_approval']['type']);
+    $this->assertSame('authentication', $actions['t_auth']['type']);
+
+    // Email type exposes 3 configurable fields, approval exposes 2, others 0.
+    $this->assertSame(['subject', 'body', 'recipient'], array_keys($actions['t_email']['configurable_fields']));
+    $this->assertSame(['page_title', 'instructions'], array_keys($actions['t_approval']['configurable_fields']));
+    $this->assertSame([], $actions['t_lookup']['configurable_fields']);
+    $this->assertSame([], $actions['t_audit']['configurable_fields']);
+    $this->assertSame([], $actions['t_auth']['configurable_fields']);
+  }
+
+  /**
+   * @covers ::getConfigurableActions
+   */
+  public function testGetConfigurableActionsReturnsEmptyForUnnamedTasks(): void {
+    // Tasks without trigger keywords resolve to 'none' and are dropped.
+    $body = '<bpmn:serviceTask id="t1" name="Crunch numbers"/>';
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+    $this->assertSame([], $this->sut->getConfigurableActions('any'));
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   * @covers ::t
+   */
+  public function testValidateConfigurationFlagsMissingRequiredParameter(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="recipient_email" label="Recipient" type="email" required="true"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', ['webform_id' => 'wf_1']);
+
+    $this->assertNotEmpty($errors);
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Recipient', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationFlagsMissingWebformId(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'parameters' => ['workflow_label' => 'Test'],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Webform must be selected', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationFlagsInvalidEmail(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="contact" label="Contact" type="email" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'contact' => 'not-an-email',
+      ],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Invalid email', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationFlagsInvalidInteger(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'days' => 'abc',
+      ],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Invalid integer', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationAcceptsValidPayload(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="contact" label="Contact" type="email" required="true"/>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'contact' => 'a@b.dk',
+        'days' => '7',
+      ],
+    ]);
+
+    $this->assertSame([], $errors);
+  }
+
+  /**
+   * Empty parameter values for typed fields skip the type validation branch.
+   *
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationSkipsEmptyTypedValues(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="contact" label="Contact" type="email" required="false"/>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'contact' => '',
+        'days' => '',
+      ],
+    ]);
+
+    $this->assertSame([], $errors);
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewReturnsEmptyForUnknownTemplate(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'other' => ['description' => 'Other'],
+    ]);
+    $this->assertSame([], $this->sut->getTemplatePreview('missing'));
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewReturnsEmptyWhenLoadTemplateFails(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'building_permit' => ['description' => 'Building permit flow'],
+    ]);
+    $this->templateManager->method('loadTemplate')->willReturn(NULL);
+    $this->assertSame([], $this->sut->getTemplatePreview('building_permit'));
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewReturnsEmptyForNoNamespace(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'building_permit' => ['description' => 'Building permit flow'],
+    ]);
+    $xml = simplexml_load_string('<definitions/>');
+    $this->templateManager->method('loadTemplate')->willReturn($xml);
+    $this->assertSame([], $this->sut->getTemplatePreview('building_permit'));
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewBuildsStepsAndDescription(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'building_permit' => ['description' => 'Building permit flow'],
+    ]);
+    $body = <<<XML
+    <bpmn:serviceTask id="t1" name="Send acknowledgement"/>
+    <bpmn:userTask id="t2" name="Caseworker review"/>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $preview = $this->sut->getTemplatePreview('building_permit');
+
+    $this->assertSame('Building permit flow', $preview['description']);
+    $this->assertNull($preview['diagram']);
+    $this->assertCount(2, $preview['steps']);
+    $this->assertSame(1, $preview['steps'][0]['step']);
+    $this->assertSame('Send acknowledgement', $preview['steps'][0]['name']);
+    $this->assertSame('serviceTask', $preview['steps'][0]['type']);
+    $this->assertSame(2, $preview['steps'][1]['step']);
+    $this->assertSame('Caseworker review', $preview['steps'][1]['name']);
+    $this->assertSame('userTask', $preview['steps'][1]['type']);
+  }
+
+  /**
+   * Float values are rejected by the integer check (cast to int loses data).
+   *
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationRejectsFloatForInteger(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        // is_numeric is TRUE but intval(7.5) != '7.5' so this should error.
+        'days' => '7.5',
+      ],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Invalid integer', $combined);
+  }
+
+}


### PR DESCRIPTION
Big-bang coverage push split across three commits, written under three parallel agents and an orchestrator on the same branch. Net: **323 unit tests / 1177 assertions / 0 failures / 0 skipped** (was 281 / 108 with 46 skipped). Line coverage on the Unit suite **11.87% → 20.80%** (+8.93 percentage points), Method coverage **12.80% → 16.82%**.

## What's in this PR

### 1. Revive 53 skipped tests across 9 ECA action test files (commit 512abb4)
The Unit suite carried 11 \`markTestSkipped\` calls across 9 files - 8 of those were in \`setUp()\`, so the actual reach was 53 tests skipped, not 11.

Common root cause across the 1-skip cluster (\`ProcessPayment\`, \`BookAppointment\`, \`GeneratePdf\`, \`ValidateZoning\`, \`SendReminder\`, \`FetchAvailableSlots\`, \`SendSms\`):
- PHPUnit 11 dropped \`withConsecutive()\` (and \`expects(at(\$i))\` in SendSms).
- \`\$action->getConfiguration()\` was never on \`eca\\Plugin\\Action\\ActionBase\`. Tests stored expected config via reflection or a property; we hoisted to \`protected array \$configuration\`.
- Missing \`setExecutionCollector()\` wiring; happy paths didn't NPE on it but error paths through \`handleError()\` would have.

\`MitIdValidate\` and \`CprLookup\` skips additionally hid intentional demo-mode production drift (missing-session and missing-CPR paths now log INFO and return TRUE/null gracefully; the old tests asserted strict WARNING + FALSE).

\`ValidateZoning\` + \`FetchAvailableSlots\` had \`stringContains\` assertions on the message template, but values land in the placeholder context array. Moved to context-array \`callback\` assertions.

### 2. WorkflowTemplateMetadata unit coverage (commit 098644a)
The 685-LoC service was at 0%. Added 27 tests covering all 4 public methods + every protected helper reachable through the public surface (5 template-specific defaults helpers, \`determineActionType\` across all 5 keyword branches, \`getActionConfigurableFields\` for both populated branches).

The test fixture helper carries a load-bearing comment about a BPMN-specific footgun: \`(bool) \$simplexml\` evaluates to FALSE on a root with only namespaced children unless a non-namespace attribute (\`id\`, \`targetNamespace\`) is present. Production gates with \`if (!\$xml) return [];\` and never hit this because real BPMN files always carry both. The fixture mirrors that.

### 3. Push 3 service test classes from partial to high (commit ac39958)
- \`MitIdCprExtractor\` (81% → ~95% lines): +8 tests for previously-untested \`extractClaim()\`, \`validateToken\` future-iat / malformed-JWT, \`getAssuranceLevel\` PasswordProtectedTransport / unmapped-default / parse-failure paths.
- \`MitIdSessionManager\` (93% → ~99%): +4 tests for \`getAddressFromSession\` missing-session vs no-address-keys distinction, partial-address branch, \`hasValidSession\` TTL-drift defense-in-depth, \`getSession\` non-array-return guard.
- \`ApprovalTokenService\` (91% → ~96%): +3 log-assertion tests now that \`setUp()\` exposes the logger mock - generateToken info, validateToken success info, HMAC-mismatch warning.

\`EncryptionService\` deliberately not extended - already 92% line / 80% method; remaining gaps are sub-line branch deltas with diminishing return.

## Production code

**No production code changed.** The earlier additional_data_token bug in AuditLogAction was fixed in #59. Two minor production drifts surfaced (MitIdValidate and CprLookup demo-mode behaviour) but the divergence is intentional - the old tests pre-dated the demo-mode addition.

## Test plan

- [x] \`ddev exec ./vendor/bin/phpunit -c phpunit.xml --testsuite=unit\` -> 323 / 1177 / 0 / 0
- [x] Per-file: WorkflowTemplateMetadataTest 27/27, MitIdCprExtractorTest 24/24, MitIdSessionManagerTest 23/23, ApprovalTokenServiceTest 17/17, all 9 action tests green
- [x] Local coverage: 11.87% → 20.80% Lines on Unit suite
- [x] CI runs PHPCS, PHPStan, PHPUnit, both Composer matrix runs green
- [x] CI's coverage badge picks up the new percentage