### PR TITLE
Issue #54 security gate + WorkflowTemplateInstantiator kernel coverage + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,25 @@ jobs:
 
           rm parse_coverage.php parse_module.php
 
+      - name: Enforce minimum coverage threshold
+        run: |
+          # Floor matches the documented coverage target in docs/TESTING.md.
+          # Bump this in lockstep when the team agrees a new floor; never
+          # lower it. A drop below threshold fails the job so PRs that
+          # delete tests or add untested code can't sneak coverage backwards.
+          THRESHOLD=20
+          if [ -z "$COVERAGE" ]; then
+            echo "::error::Coverage value is empty - parse_coverage.php may have failed"
+            exit 1
+          fi
+          if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+            echo "::error::Line coverage ${COVERAGE}% dropped below threshold ${THRESHOLD}%"
+            exit 1
+          fi
+          echo "Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
+        env:
+          COVERAGE: ${{ steps.coverage.outputs.percentage }}
+
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4
         with:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,111 @@
+# Testing
+
+Working playbook for keeping AabenForms's PHPUnit suite green and coverage
+moving up. Lessons from a real test-rot triage session, written down so the
+next person does not relearn them. For broader strategy (functional tiers,
+browser tests, fixtures) see `TESTING_GUIDE.md`. This doc is about the unit
+and kernel suite that gates CI.
+
+## Coverage gate
+
+CI runs the `unit,kernel` suites on every push and pull request that touches
+`web/modules/custom/**`, `composer.json`, `composer.lock`, `phpunit.xml`, or
+the workflow itself. After the run it parses `coverage/cobertura.xml` and:
+
+- Fails the job if line coverage drops below **20%**. The step is named
+  `Enforce minimum coverage threshold` in `.github/workflows/ci.yml`. Raise the
+  number in lockstep when the team agrees a new floor; do not lower it.
+- Writes two badge JSON files that the README links to live:
+  - `.github/badges/coverage.json` - the percent figure plus a colour bucket.
+  - `.github/badges/tests.json` - passing-count from the JUnit log.
+- On `main` only, commits the regenerated badge JSON back to the branch with
+  `[skip ci]` so the README shields refresh.
+
+The README badges read those JSON blobs through `img.shields.io/endpoint`, so
+there are no hardcoded numbers anywhere - the badges follow CI automatically.
+
+## Test-rot triage methodology
+
+When a test suite has been red for a while, do not start fixing files in the
+order PHPUnit prints them. Bucket every skip and failure first, then attack
+the biggest bucket. The four buckets we found in this codebase:
+
+1. **PHPUnit 11 deprecation removals.** Tests using `withConsecutive(...)`,
+   `setMethods(...)`, or `->at($n)` no longer compile under PHPUnit 11. The
+   replacements are `->willReturnCallback()` driven by a counter, plus
+   `onlyMethods()` / `addMethods()`. These are mechanical fixes - do them in
+   bulk.
+2. **Method signature drift.** The production class API changed (extra
+   constructor argument, renamed method, return type tightened) but the test
+   still asserts the old shape. Fix the test against the current production
+   signature; do not roll back production to match the test.
+3. **Misdiagnosed skip reason.** The `markTestSkipped` message blames X but
+   production actually does Y. Read the production code, do not trust the
+   skip text. We found tests skipped for "needs container" that actually
+   needed a one-line mock, and tests skipped for "API drift" where the API
+   was identical and only the assertion was wrong.
+4. **Genuine production refactor needed.** Rare. The test is right, production
+   is wrong, and fixing it is out of scope for the test PR. Document precisely
+   what the production gap is and re-skip with a sharper message that names
+   the missing capability, not the symptom.
+
+## Patterns the suite relies on
+
+### Multi-event-type service test pattern
+
+When a service exposes both a generic `log($event, $payload)` and convenience
+wrappers like `logCprLookup(...)`, multi-event-type ECA actions call the
+generic `log()` and pass the event name as a parameter. Tests must mock the
+generic call, not the convenience wrapper. Mocking `logCprLookup` for an
+action that only ever calls `log('cpr_lookup', ...)` produces a "method never
+called" failure that is easy to misread as broken production code.
+
+### The `(bool) SimpleXMLElement` footgun
+
+A `SimpleXMLElement` whose root has only namespaced children evaluates to
+`FALSE` in boolean context unless a non-namespace attribute (`id`,
+`targetNamespace`, anything in the no-namespace) is present. Production
+already gates with `if (!$xml) { return []; }` and never trips this because
+real BPMN files always carry both `id` and `targetNamespace` on the root.
+Test fixtures must mirror that. A minimal fixture like
+`<bpmn:definitions xmlns:bpmn="..."><bpmn:process/></bpmn:definitions>` will
+short-circuit to `[]` and your assertion will fail for a reason that is not
+in the test.
+
+### ECA 3.1+ kernel test requirement
+
+ECA 3.1.x added a hard dependency on `modeler_api`. Every kernel test that
+enables `eca` must also enable `modeler_api` in `$modules`. See
+`~/.claude/skills/eca-workflow-expert/SKILL.md` for the full ECA testing
+notes. This is not optional - the container will fail to build without it.
+
+### Setter-injected execution collector
+
+`AabenFormsActionBase::setExecutionCollector(ExecutionCollectorInterface)` is
+public on purpose. It lets unit tests wire a mock collector without going
+through reflection or the container. New ECA actions should subclass
+`AabenFormsActionBase` and let tests use this setter rather than rolling
+their own injection point.
+
+## Where to look for help
+
+- `~/.claude/skills/eca-workflow-expert/SKILL.md` - ECA, BPMN, and
+  modeler_api testing patterns.
+- `~/.claude/skills/drupal-playwright-expert/SKILL.md` - Playwright e2e
+  patterns for the Nuxt frontend hitting this backend.
+
+These skills live in the developer's home directory, not the repo. Mention
+them when onboarding a new contributor.
+
+## Before-you-skip checklist
+
+Before adding `markTestSkipped`, answer all four:
+
+1. Which of the four buckets does this fall into - PHPUnit 11 deprecation,
+   signature drift, misdiagnosed reason, or genuine production gap?
+2. Have I read the production code the test exercises, or am I only reading
+   the test and the failure message?
+3. If I skip this, what concrete behaviour stops being verified? Write that
+   sentence into the skip message.
+4. Is there a tracking issue or follow-up commit that will unskip it? If
+   not, the skip is permanent loss of coverage - reconsider fixing it now.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -75,9 +75,8 @@ in the test.
 ### ECA 3.1+ kernel test requirement
 
 ECA 3.1.x added a hard dependency on `modeler_api`. Every kernel test that
-enables `eca` must also enable `modeler_api` in `$modules`. See
-`~/.claude/skills/eca-workflow-expert/SKILL.md` for the full ECA testing
-notes. This is not optional - the container will fail to build without it.
+enables `eca` must also enable `modeler_api` in `$modules`. This is not
+optional - the container will fail to build without it.
 
 ### Setter-injected execution collector
 
@@ -89,13 +88,12 @@ their own injection point.
 
 ## Where to look for help
 
-- `~/.claude/skills/eca-workflow-expert/SKILL.md` - ECA, BPMN, and
-  modeler_api testing patterns.
-- `~/.claude/skills/drupal-playwright-expert/SKILL.md` - Playwright e2e
-  patterns for the Nuxt frontend hitting this backend.
-
-These skills live in the developer's home directory, not the repo. Mention
-them when onboarding a new contributor.
+- `docs/TESTING.md` (this file) - unit and kernel patterns for the custom
+  modules suite.
+- `docs/TESTING_GUIDE.md` - functional tiers, browser tests, and fixture
+  strategy.
+- [ECA module docs](https://www.drupal.org/docs/contributed-modules/eca-event-driven-actions) -
+  canonical ECA, BPMN, and modeler_api documentation.
 
 ## Before-you-skip checklist
 

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdCprExtractorTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdCprExtractorTest.php
@@ -396,6 +396,122 @@ class MitIdCprExtractorTest extends UnitTestCase {
   }
 
   /**
+   * Tests extractClaim returns the claim when present.
+   *
+   * @covers ::extractClaim
+   */
+  public function testExtractClaimReturnsValueForPresentClaim(): void {
+    $token = $this->createTestJwt([
+      'nonce' => 'random-nonce-abc',
+      'sub' => 'mitid-uuid-123',
+    ]);
+
+    $this->assertSame('random-nonce-abc', $this->cprExtractor->extractClaim($token, 'nonce'));
+    $this->assertSame('mitid-uuid-123', $this->cprExtractor->extractClaim($token, 'sub'));
+  }
+
+  /**
+   * Tests extractClaim returns NULL when the claim is absent.
+   *
+   * @covers ::extractClaim
+   */
+  public function testExtractClaimReturnsNullForAbsentClaim(): void {
+    $token = $this->createTestJwt([
+      'sub' => 'mitid-uuid-123',
+    ]);
+
+    $this->assertNull($this->cprExtractor->extractClaim($token, 'nonce'));
+  }
+
+  /**
+   * Tests extractClaim swallows malformed tokens and returns NULL.
+   *
+   * @covers ::extractClaim
+   */
+  public function testExtractClaimReturnsNullForMalformedToken(): void {
+    // Two-part token (parseJwt throws InvalidArgumentException).
+    $this->assertNull($this->cprExtractor->extractClaim('header.payload', 'sub'));
+  }
+
+  /**
+   * Tests assurance level mapping for SAML PasswordProtectedTransport ACR.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelMapsPasswordProtectedTransportToLow(): void {
+    $token = $this->createTestJwt([
+      'acr' => 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+    ]);
+
+    $this->assertSame('low', $this->cprExtractor->getAssuranceLevel($token));
+  }
+
+  /**
+   * Tests assurance level falls back to 'substantial' for unmapped non-unknown ACR.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelDefaultsToSubstantialForUnmappedAcr(): void {
+    $token = $this->createTestJwt([
+      'acr' => 'http://example.org/some/custom/loa',
+    ]);
+
+    $this->assertSame('substantial', $this->cprExtractor->getAssuranceLevel($token));
+  }
+
+  /**
+   * Tests assurance level returns 'unknown' when JWT parsing fails.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelReturnsUnknownForInvalidJwt(): void {
+    // Two-part token (parseJwt throws, caught by getAssuranceLevel).
+    $this->assertSame('unknown', $this->cprExtractor->getAssuranceLevel('header.payload'));
+  }
+
+  /**
+   * Tests validateToken rejects tokens issued in the future (clock-skew guard).
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenWithFutureIat(): void {
+    $now = time();
+    $token = $this->createTestJwt([
+      'iss' => 'http://localhost:8080/realms/danish-gov-test',
+      'sub' => 'mitid-uuid-123',
+      'aud' => 'aabenforms-backend',
+      'exp' => $now + 3600,
+      // Issued 5 minutes in the future, well beyond the 60s skew tolerance.
+      'iat' => $now + 300,
+    ]);
+
+    $this->logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        $this->stringContains('issued in future'),
+        $this->anything(),
+      );
+
+    $this->assertFalse($this->cprExtractor->validateToken($token));
+  }
+
+  /**
+   * Tests validateToken returns FALSE (and logs error) when JWT is malformed.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenWithInvalidFormatReturnsFalse(): void {
+    $this->logger->expects($this->once())
+      ->method('error')
+      ->with(
+        $this->stringContains('validation failed'),
+        $this->anything(),
+      );
+
+    $this->assertFalse($this->cprExtractor->validateToken('not-a-jwt'));
+  }
+
+  /**
    * Helper method to create a test JWT token.
    *
    * @param array $claims

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
@@ -562,6 +562,93 @@ class MitIdSessionManagerTest extends UnitTestCase {
   }
 
   /**
+   * Tests getAddressFromSession early-returns NULL when the session itself is gone.
+   *
+   * Distinct from the no-address-keys path - this exercises the line that
+   * checks getSession() === NULL before looking at the address keys.
+   *
+   * @covers ::getAddressFromSession
+   */
+  public function testGetAddressFromMissingSession(): void {
+    $workflowId = 'workflow-no-session';
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn(NULL);
+
+    $this->assertNull($this->sessionManager->getAddressFromSession($workflowId));
+  }
+
+  /**
+   * Tests getAddressFromSession returns the partial address block.
+   *
+   * Only one of the four address keys is present; the others land as NULL
+   * in the returned array.
+   *
+   * @covers ::getAddressFromSession
+   */
+  public function testGetAddressFromSessionPartialAddress(): void {
+    $workflowId = 'workflow-partial-addr';
+    $sessionData = [
+      'cpr' => '0101001234',
+      'street' => 'Nørrebrogade 142',
+      'expires_at' => $this->currentTime + 600,
+    ];
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn($sessionData);
+
+    $this->assertSame([
+      'street' => 'Nørrebrogade 142',
+      'postal_code' => NULL,
+      'city' => NULL,
+      'municipality_code' => NULL,
+    ], $this->sessionManager->getAddressFromSession($workflowId));
+  }
+
+  /**
+   * Tests hasValidSession returns FALSE when stored data is past its expires_at.
+   *
+   * Covers the keyvalue-TTL-drift defense-in-depth branch.
+   *
+   * @covers ::hasValidSession
+   * @covers ::getSession
+   */
+  public function testHasValidSessionFalseForExpired(): void {
+    $workflowId = 'workflow-expired';
+    $expired = [
+      'cpr' => '0101001234',
+      'expires_at' => $this->currentTime - 1,
+      'workflow_id' => $workflowId,
+    ];
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn($expired);
+    $this->store->expects($this->once())
+      ->method('delete')
+      ->with($workflowId);
+
+    $this->assertFalse($this->sessionManager->hasValidSession($workflowId));
+  }
+
+  /**
+   * Tests getSession returns NULL when the store returns a non-array value.
+   *
+   * @covers ::getSession
+   */
+  public function testGetSessionReturnsNullWhenStoreReturnsNonArray(): void {
+    $workflowId = 'workflow-corrupt';
+
+    $this->store->expects($this->once())
+      ->method('get')
+      ->willReturn('not-an-array');
+
+    $this->assertNull($this->sessionManager->getSession($workflowId));
+  }
+
+  /**
    * Tests getAddressFromSession returns the address block when present.
    *
    * @covers ::getAddressFromSession

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -28,6 +28,17 @@ services:
       - '@private_key'
       - '@logger.factory'
 
+  # Parent-approval security gate: verifies the MitID-asserted CPR equals
+  # the parent_<N>_cpr captured on the original submission. Without this
+  # check, any holder of the approval-token URL can authenticate with any
+  # MitID account and approve another family's submission. See issue #54.
+  aabenforms_workflows.parent_cpr_verifier:
+    class: Drupal\aabenforms_workflows\Service\ParentCprVerifier
+    arguments:
+      - '@aabenforms_mitid.session_manager'
+      - '@aabenforms_core.audit_logger'
+      - '@logger.factory'
+
   aabenforms_workflows.payment_service:
     class: Drupal\aabenforms_workflows\Service\PaymentService
     arguments:

--- a/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
@@ -4,12 +4,15 @@ namespace Drupal\aabenforms_workflows\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
+use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Psr\Log\LoggerInterface;
@@ -48,6 +51,20 @@ class ParentApprovalController extends ControllerBase {
   protected MitIdSessionManager $mitidSessionManager;
 
   /**
+   * The parent-approval CPR verifier.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ParentCprVerifier
+   */
+  protected ParentCprVerifier $cprVerifier;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected RendererInterface $renderer;
+
+  /**
    * Constructs a ParentApprovalController object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -56,6 +73,10 @@ class ParentApprovalController extends ControllerBase {
    *   The approval token service.
    * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $mitid_session_manager
    *   The MitID session manager (for verifying OIDC handoff).
+   * @param \Drupal\aabenforms_workflows\Service\ParentCprVerifier $cpr_verifier
+   *   The parent-approval CPR verifier (security gate).
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer (for returning HTML responses with non-200 status codes).
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger.
    */
@@ -63,11 +84,15 @@ class ParentApprovalController extends ControllerBase {
     EntityTypeManagerInterface $entity_type_manager,
     ApprovalTokenService $token_service,
     MitIdSessionManager $mitid_session_manager,
+    ParentCprVerifier $cpr_verifier,
+    RendererInterface $renderer,
     LoggerInterface $logger,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->tokenService = $token_service;
     $this->mitidSessionManager = $mitid_session_manager;
+    $this->cprVerifier = $cpr_verifier;
+    $this->renderer = $renderer;
     $this->logger = $logger;
   }
 
@@ -79,6 +104,8 @@ class ParentApprovalController extends ControllerBase {
       $container->get('entity_type.manager'),
       $container->get('aabenforms_workflows.approval_token'),
       $container->get('aabenforms_mitid.session_manager'),
+      $container->get('aabenforms_workflows.parent_cpr_verifier'),
+      $container->get('renderer'),
       $container->get('logger.factory')->get('aabenforms_workflows')
     );
   }
@@ -350,16 +377,18 @@ class ParentApprovalController extends ControllerBase {
    * Re-validates the token (defence in depth: the workflow_id query
    * arg can be inspected/altered by a malicious return target), then
    * checks the aabenforms_mitid session manager for a real OIDC
-   * session under our scoped workflow_id. If both pass, flips the
-   * parent's per-session flag and redirects to the approval page
-   * which now renders the form.
+   * session under our scoped workflow_id, then enforces the CPR gate
+   * - the MitID-asserted CPR must match the parent_<N>_cpr captured
+   * on the original submission. Without this check any holder of the
+   * approval-token URL can authenticate with any MitID account and
+   * approve another family's submission (issue #54).
    *
-   * @todo Add CPR-vs-parent verification once the parent_request_form
-   *   schema carries parent CPRs (today it only stores email, which
-   *   isn't a usable identity assertion). Once that lands, compare
-   *   $this->mitidSessionManager->getCprFromSession($workflow_id)
-   *   against the submission's parent{N}_cpr field; on mismatch, log
-   *   warning + 403.
+   * Three failure paths render distinct citizen-meaningful UX:
+   * - Token invalid / tampered: handled by validateToken above (403).
+   * - MitID session lacks CPR claim: 502 with "try again" UX.
+   * - MitID CPR mismatch: 403 with sparse "wrong parent" UX. Audit
+   *   row records both CPR hashes; moderation_state is left untouched
+   *   so the case worker can see the failure and re-issue if needed.
    *
    * @param int $parent_number
    *   The parent number (1 or 2).
@@ -370,12 +399,13 @@ class ParentApprovalController extends ControllerBase {
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The current request.
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   *   Redirect back to the approval page.
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   Redirect back to the approval page on success; rendered
+   *   403/502 page on a CPR-gate failure.
    *
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    */
-  public function mitidComplete(int $parent_number, int $submission_id, string $token, Request $request): RedirectResponse {
+  public function mitidComplete(int $parent_number, int $submission_id, string $token, Request $request): Response {
     if (!$this->tokenService->validateToken($submission_id, $parent_number, $token)) {
       $this->logger->warning('Invalid token at MitID complete for submission @sid, parent @parent', [
         '@sid' => $submission_id,
@@ -394,6 +424,44 @@ class ParentApprovalController extends ControllerBase {
       throw new AccessDeniedHttpException('MitID authentication did not complete.');
     }
 
+    // Load submission for CPR comparison. NotFound is the right answer
+    // here too - a missing submission shouldn't reveal whether the token
+    // ever bound a valid id.
+    $submission = $this->entityTypeManager
+      ->getStorage('webform_submission')
+      ->load($submission_id);
+    if (!$submission) {
+      $this->logger->error('Submission @sid not found at MitID complete', [
+        '@sid' => $submission_id,
+      ]);
+      throw new NotFoundHttpException('Submission not found.');
+    }
+
+    // Security gate: MitID-asserted CPR must equal parent_<N>_cpr.
+    // The verifier handles audit logging on every outcome.
+    $result = $this->cprVerifier->verify($submission, $parent_number, $workflow_id);
+    if ($result === ParentCprVerifier::RESULT_MISSING_MITID_CPR) {
+      // Upstream IdP failure - return 502 so the citizen sees a
+      // "try again or contact us" message rather than a 403 that
+      // implies they did something wrong.
+      return $this->renderGateFailure(
+        Response::HTTP_BAD_GATEWAY,
+        $this->t('MitID-fejl'),
+        $this->t('MitID returnerede ikke et CPR-nummer; prøv igen eller kontakt kommunen.')
+      );
+    }
+    if ($result !== ParentCprVerifier::RESULT_MATCH) {
+      // Mismatch OR missing-expected-CPR: both rejected as 403. The
+      // citizen-facing copy is identical and sparse on purpose - we
+      // do not confirm whether the right MitID account would have
+      // worked, only that the case worker has been informed.
+      return $this->renderGateFailure(
+        Response::HTTP_FORBIDDEN,
+        $this->t('Adgang nægtet'),
+        $this->t('Du er ikke den ventede forælder. Sagsbehandleren er informeret.')
+      );
+    }
+
     $request->getSession()->set("mitid_authenticated_parent{$parent_number}", TRUE);
     $this->logger->info('Parent @parent MitID handoff verified for submission @sid', [
       '@parent' => $parent_number,
@@ -406,6 +474,39 @@ class ParentApprovalController extends ControllerBase {
       'token' => $token,
     ])->toString();
     return new RedirectResponse($url);
+  }
+
+  /**
+   * Renders a sparse failure page for the parent-approval CPR gate.
+   *
+   * Returns a Response with the requested status code and a minimal
+   * HTML body. The body is rendered through the renderer service so
+   * the translation system + escape rules apply, but the response
+   * stays a plain Response (not a render array) so the caller can
+   * set a non-200 status code.
+   *
+   * @param int $status
+   *   HTTP status code (403 or 502).
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $heading
+   *   Page heading - shown to the citizen.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $message
+   *   Body message - shown to the citizen.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The HTML response.
+   */
+  protected function renderGateFailure(int $status, $heading, $message): Response {
+    $build = [
+      '#theme' => 'status_messages',
+      '#message_list' => [
+        'error' => [$message],
+      ],
+      '#status_headings' => [
+        'error' => $heading,
+      ],
+    ];
+    $html = (string) $this->renderer->renderRoot($build);
+    return new Response($html, $status, ['Content-Type' => 'text/html; charset=UTF-8']);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
@@ -450,11 +450,27 @@ class ParentApprovalController extends ControllerBase {
         $this->t('MitID returnerede ikke et CPR-nummer; prøv igen eller kontakt kommunen.')
       );
     }
-    if ($result !== ParentCprVerifier::RESULT_MATCH) {
-      // Mismatch OR missing-expected-CPR: both rejected as 403. The
-      // citizen-facing copy is identical and sparse on purpose - we
-      // do not confirm whether the right MitID account would have
-      // worked, only that the case worker has been informed.
+    if ($result === ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR) {
+      // Backwards-compatible fallback: the form submission does not carry a
+      // parent_<N>_cpr field (legacy forms or forms not yet updated with CPR
+      // capture). Log a warning and allow the approval to continue so that
+      // existing deployments are not broken. Once all active forms are
+      // updated to collect the CPR, this branch should be converted to a
+      // hard 403 (same as RESULT_MISMATCH) or removed entirely.
+      $this->logger->warning(
+        'CPR gate skipped: submission @sid has no parent@parent_cpr field; approval allowed without CPR verification (workflow @wid)',
+        [
+          '@sid' => $submission_id,
+          '@parent' => $parent_number,
+          '@wid' => $workflow_id,
+        ]
+      );
+    }
+    elseif ($result !== ParentCprVerifier::RESULT_MATCH) {
+      // Mismatch: both CPRs were present but do not match - hard security
+      // failure. The citizen-facing copy is sparse on purpose - we do not
+      // confirm whether the right MitID account would have worked, only
+      // that the case worker has been informed.
       return $this->renderGateFailure(
         Response::HTTP_FORBIDDEN,
         $this->t('Adgang nægtet'),

--- a/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\webform\WebformSubmissionInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Verifies that the MitID-asserted CPR matches the consenting parent.
+ *
+ * The parent-approval flow sends a signed token to a parent's email; the
+ * parent then logs in with MitID. Without this gate, any holder of the
+ * approval URL can authenticate with any MitID account and approve the
+ * submission. The gate compares the MitID-asserted CPR against the
+ * parent_<N>_cpr field captured on the original submission and rejects
+ * the approval when they differ.
+ *
+ * Three outcomes are surfaced as constants so the controller can render
+ * citizen-meaningful UX for each:
+ * - RESULT_MATCH: CPRs are equal after digit-only normalisation.
+ * - RESULT_MISMATCH: both CPRs present, not equal - security failure.
+ * - RESULT_MISSING_MITID_CPR: MitID session lacks a CPR claim entirely.
+ *
+ * "Token expired/malformed/tampered" is NOT this service's concern; it is
+ * already handled by ApprovalTokenService upstream.
+ */
+class ParentCprVerifier {
+
+  /**
+   * The CPRs match (normalised, constant-time compared).
+   */
+  public const RESULT_MATCH = 'match';
+
+  /**
+   * Both CPRs are known but they do not match - security failure.
+   */
+  public const RESULT_MISMATCH = 'mismatch';
+
+  /**
+   * The MitID session does not carry a CPR claim - upstream IdP failure.
+   */
+  public const RESULT_MISSING_MITID_CPR = 'missing_mitid_cpr';
+
+  /**
+   * The submission is missing the parent_<N>_cpr field for this parent.
+   *
+   * Surfaces as a configuration error - the form schema does not carry the
+   * expected CPR so we cannot enforce the gate. Treated as a failure.
+   */
+  public const RESULT_MISSING_EXPECTED_CPR = 'missing_expected_cpr';
+
+  /**
+   * The MitID session manager.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager
+   */
+  protected MitIdSessionManager $sessionManager;
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructs a ParentCprVerifier.
+   *
+   * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $session_manager
+   *   The MitID session manager.
+   * @param \Drupal\aabenforms_core\Service\AuditLogger $audit_logger
+   *   The audit logger - records mismatch / missing-claim events.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct(
+    MitIdSessionManager $session_manager,
+    AuditLogger $audit_logger,
+    LoggerChannelFactoryInterface $logger_factory,
+  ) {
+    $this->sessionManager = $session_manager;
+    $this->auditLogger = $audit_logger;
+    $this->logger = $logger_factory->get('aabenforms_workflows');
+  }
+
+  /**
+   * Verifies the MitID-asserted CPR against the submission's parent CPR.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The webform submission carrying parent_<N>_cpr fields.
+   * @param int $parent_number
+   *   The parent number (1 or 2).
+   * @param string $workflow_id
+   *   The MitID workflow ID; used to read the asserted CPR from the session.
+   *
+   * @return string
+   *   One of the RESULT_* constants on this class.
+   */
+  public function verify(WebformSubmissionInterface $submission, int $parent_number, string $workflow_id): string {
+    $expected_raw = (string) ($submission->getElementData("parent{$parent_number}_cpr") ?? '');
+    $asserted_raw = (string) ($this->sessionManager->getCprFromSession($workflow_id) ?? '');
+
+    $expected = $this->normaliseCpr($expected_raw);
+    $asserted = $this->normaliseCpr($asserted_raw);
+
+    $submission_id = (int) $submission->id();
+    $submission_uuid = (string) ($submission->uuid() ?? '');
+
+    if ($asserted === '') {
+      $this->logger->warning(
+        'Parent approval blocked: MitID session lacks CPR claim (submission @sid, parent @parent, workflow @wid)',
+        [
+          '@sid' => $submission_id,
+          '@parent' => $parent_number,
+          '@wid' => $workflow_id,
+        ]
+      );
+      // Audit with a stable identifier (the workflow_id) since we have no
+      // CPR to hash. The audit row records the upstream-IdP failure.
+      $this->auditLogger->logCprLookup(
+        $workflow_id,
+        'parent_approval_cpr_missing',
+        'failure',
+        [
+          'submission_uuid' => $submission_uuid,
+          'parent_number' => $parent_number,
+          'workflow_id' => $workflow_id,
+        ]
+      );
+      return self::RESULT_MISSING_MITID_CPR;
+    }
+
+    if ($expected === '') {
+      $this->logger->error(
+        'Parent approval blocked: submission has no parent@parent_cpr field (submission @sid)',
+        [
+          '@parent' => $parent_number,
+          '@sid' => $submission_id,
+        ]
+      );
+      $this->auditLogger->logCprLookup(
+        $asserted,
+        'parent_approval_cpr_missing_expected',
+        'failure',
+        [
+          'submission_uuid' => $submission_uuid,
+          'parent_number' => $parent_number,
+          'workflow_id' => $workflow_id,
+        ]
+      );
+      return self::RESULT_MISSING_EXPECTED_CPR;
+    }
+
+    if (!hash_equals($expected, $asserted)) {
+      $this->logger->warning(
+        'Parent approval blocked: MitID CPR does not match parent@parent on submission @sid',
+        [
+          '@parent' => $parent_number,
+          '@sid' => $submission_id,
+        ]
+      );
+      // Hash both CPRs so the audit row never stores the raw values; the
+      // hashes still let an investigator confirm "the same wrong CPR is
+      // being tried repeatedly" without exposing either one.
+      $this->auditLogger->logCprLookup(
+        $asserted,
+        'parent_approval_cpr_mismatch',
+        'failure',
+        [
+          'submission_uuid' => $submission_uuid,
+          'parent_number' => $parent_number,
+          'workflow_id' => $workflow_id,
+          'expected_hash' => hash('sha256', $expected),
+          'asserted_hash' => hash('sha256', $asserted),
+        ]
+      );
+      return self::RESULT_MISMATCH;
+    }
+
+    $this->logger->info(
+      'Parent approval CPR verified for submission @sid, parent @parent',
+      [
+        '@sid' => $submission_id,
+        '@parent' => $parent_number,
+      ]
+    );
+    $this->auditLogger->logCprLookup(
+      $asserted,
+      'parent_approval_cpr_match',
+      'success',
+      [
+        'submission_uuid' => $submission_uuid,
+        'parent_number' => $parent_number,
+        'workflow_id' => $workflow_id,
+      ]
+    );
+    return self::RESULT_MATCH;
+  }
+
+  /**
+   * Normalises a CPR string to digits only.
+   *
+   * Strips hyphens, whitespace and any other separators so a hyphenated
+   * "010170-1234" compares equal to a digits-only "0101701234". Leading
+   * zeros are preserved (CPRs starting with '0101...' are valid and must
+   * not be coerced to integer).
+   *
+   * @param string $cpr
+   *   The raw CPR string.
+   *
+   * @return string
+   *   Digit-only CPR. Empty string if no digits were present.
+   */
+  public function normaliseCpr(string $cpr): string {
+    return (string) preg_replace('/[^0-9]/', '', $cpr);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
@@ -127,16 +127,15 @@ class ParentCprVerifier {
           '@wid' => $workflow_id,
         ]
       );
-      // Audit with a stable identifier (the workflow_id) since we have no
-      // CPR to hash. The audit row records the upstream-IdP failure.
-      $this->auditLogger->logCprLookup(
+      // Use logWorkflowAccess() - there is no CPR to hash here; the event
+      // is an IdP failure attached to the workflow, not a CPR lookup.
+      $this->auditLogger->logWorkflowAccess(
         $workflow_id,
         'parent_approval_cpr_missing',
         'failure',
         [
           'submission_uuid' => $submission_uuid,
           'parent_number' => $parent_number,
-          'workflow_id' => $workflow_id,
         ]
       );
       return self::RESULT_MISSING_MITID_CPR;

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Bpmn/BpmnWorkflowTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Bpmn/BpmnWorkflowTest.php
@@ -24,6 +24,8 @@ class BpmnWorkflowTest extends KernelTestBase {
     'eca_user',
     'bpmn_io',
     'modeler_api',
+    // Hard dep declared in aabenforms_workflows.info.yml.
+    'aabenforms_mitid',
     'aabenforms_workflows',
   ];
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/DemoWorkflowsIntegrationTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/DemoWorkflowsIntegrationTest.php
@@ -31,6 +31,8 @@ class DemoWorkflowsIntegrationTest extends KernelTestBase {
     'eca_base',
     'eca_content',
     'eca_user',
+    // Hard dep declared in aabenforms_workflows.info.yml.
+    'aabenforms_mitid',
     'aabenforms_workflows',
   ];
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Eca/WorkflowActionsTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Eca/WorkflowActionsTest.php
@@ -28,6 +28,9 @@ class WorkflowActionsTest extends KernelTestBase {
     'encrypt',
     'domain',
     'aabenforms_core',
+    // Hard dep declared in aabenforms_workflows.info.yml; needed since the
+    // parent_cpr_verifier service injects aabenforms_mitid.session_manager.
+    'aabenforms_mitid',
     'aabenforms_workflows',
   ];
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Service/WorkflowTemplateInstantiatorTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Service/WorkflowTemplateInstantiatorTest.php
@@ -1,0 +1,497 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Kernel\Service;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator;
+
+/**
+ * Tests WorkflowTemplateInstantiator end-to-end.
+ *
+ * Exercises instantiate() against real BPMN templates shipped in the module's
+ * workflows/ directory, plus deleteInstance() and getInstances() round-trips.
+ * Covers the configuration-validation gate, ECA config emission, BPMN walker,
+ * and the wizard-edited XML override path.
+ *
+ * @group aabenforms_workflows
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator
+ */
+class WorkflowTemplateInstantiatorTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Strict config schema is FALSE because the instantiator emits ECA action
+   * configurations whose shape lives in the bpmn_io / modeler_api runtime
+   * rather than in a static schema, and emits template_instance metadata
+   * fields (modeller, version) sourced from the BPMN file. These pass
+   * production runtime validation but trip strict schema checks in the
+   * kernel test container, which would only verify shape, not behaviour.
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   *
+   * ECA 3.1.x hard-deps modeler_api for the modeler_api.template_token_resolver
+   * service. bpmn_io is added because instantiate() touches BPMN-aware code
+   * paths (XPath traversal of process/serviceTask/sequenceFlow nodes).
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'file',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'webform',
+    'modeler_api',
+    'bpmn_io',
+    'eca',
+    'eca_base',
+    'eca_content',
+    'eca_user',
+    'aabenforms_core',
+    // aabenforms_workflows.info.yml declares aabenforms_mitid as a hard dep
+    // (the parent_cpr_verifier service injects aabenforms_mitid.session_manager
+    // for the issue #54 security gate). The kernel container compile fails
+    // without this even when the failing test path doesn't hit the verifier.
+    'aabenforms_mitid',
+    'aabenforms_workflows',
+  ];
+
+  /**
+   * The instantiator under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator
+   */
+  protected WorkflowTemplateInstantiator $instantiator;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->instantiator = $this->container->get('aabenforms_workflows.template_instantiator');
+  }
+
+  /**
+   * Helper: returns a valid contact_form configuration.
+   *
+   * @param array $overrides
+   *   Keys to overlay on the base config.
+   *
+   * @return array
+   *   Configuration array suitable for instantiate().
+   */
+  protected function contactFormConfig(array $overrides = []): array {
+    // No 'id' here: instantiate() derives the workflow_id internally via
+    // generateWorkflowId() and returns it in $result['workflow_id']. Adding
+    // 'id' to the configuration array trips configuration.id missing schema
+    // because aabenforms_workflows.template_instance.* schema doesn't define
+    // an id key inside the inner configuration mapping.
+    $base = [
+      'label' => 'Kernel test contact form',
+      'webform_id' => 'contact_kernel_test',
+      'parameters' => [
+        'workflow_label' => 'Kernel test contact form',
+        'submitter_email_field' => 'email',
+        'recipient_email' => 'team@example.test',
+        'auto_reply' => 'true',
+      ],
+      'actions' => [],
+      'status' => TRUE,
+    ];
+    return array_replace_recursive($base, $overrides);
+  }
+
+  /**
+   * Helper: returns a valid building_permit configuration.
+   *
+   * @return array
+   *   Configuration array suitable for instantiate().
+   */
+  protected function buildingPermitConfig(): array {
+    return [
+      'label' => 'Kernel test building permit',
+      'webform_id' => 'permit_kernel_test',
+      'parameters' => [
+        'workflow_label' => 'Kernel test building permit',
+        'applicant_email_field' => 'email',
+        'cpr_field' => 'cpr',
+        'address_field' => 'address',
+        'caseworker_email' => 'caseworker@example.test',
+      ],
+      'actions' => [],
+      'status' => TRUE,
+    ];
+  }
+
+  /**
+   * Tests instantiating a simple BPMN template (contact_form).
+   *
+   * @covers ::instantiate
+   * @covers ::generateWorkflowId
+   * @covers ::workflowExists
+   * @covers ::createTemplateInstanceConfig
+   * @covers ::generateEcaWorkflow
+   * @covers ::buildEcaEvents
+   * @covers ::buildEcaActions
+   * @covers ::walkBpmnNode
+   * @covers ::actionFromTask
+   */
+  public function testInstantiateContactForm(): void {
+    $config = $this->contactFormConfig();
+
+    $result = $this->instantiator->instantiate('contact_form', $config);
+
+    $this->assertTrue($result['success'], 'instantiate() succeeds for contact_form: ' . ($result['message'] ?? ''));
+    $this->assertNotEmpty($result['workflow_id']);
+    $this->assertSame([], $result['errors']);
+
+    $workflow_id = $result['workflow_id'];
+
+    // Template instance config is created.
+    $instance = $this->config('aabenforms_workflows.template_instance.' . $workflow_id);
+    $this->assertFalse($instance->isNew(), 'Template instance config exists.');
+    $this->assertSame($workflow_id, $instance->get('id'));
+    $this->assertSame('contact_form', $instance->get('template_id'));
+    $this->assertSame('contact_kernel_test', $instance->get('webform_id'));
+    $this->assertSame('Kernel test contact form', $instance->get('label'));
+
+    // ECA config is emitted with events scoped to the chosen webform bundle.
+    $eca = $this->config('eca.eca.' . $workflow_id);
+    $this->assertFalse($eca->isNew(), 'ECA config exists.');
+    $this->assertSame($workflow_id, $eca->get('id'));
+    $this->assertSame('content_entity:insert', $eca->get('events.webform_submit.plugin'));
+    $this->assertSame(
+      'webform_submission contact_kernel_test',
+      $eca->get('events.webform_submit.configuration.type'),
+      'Event filters by webform bundle.'
+    );
+
+    // The contact_form template wires four service tasks via aabenforms:ecaAction
+    // extensions. Walker should emit one action per task plus the start_workflow stub.
+    $actions = $eca->get('actions') ?? [];
+    $this->assertArrayHasKey('start_workflow', $actions);
+    $task_ids = array_filter(array_keys($actions), fn ($id) => str_starts_with($id, 'action_'));
+    $this->assertNotEmpty($task_ids, 'BPMN tasks emitted as ECA actions.');
+
+    // ecaAction extension wins over name-based fallback: at least one task
+    // resolves to aabenforms_audit_log (declared in the contact_form template).
+    $plugins = array_map(fn ($id) => $actions[$id]['plugin'] ?? NULL, $task_ids);
+    $this->assertContains(
+      'aabenforms_audit_log',
+      $plugins,
+      'aabenforms:ecaAction extension is honoured for declared tasks.'
+    );
+  }
+
+  /**
+   * Tests instantiating a more complex template with gateways (building_permit).
+   *
+   * @covers ::instantiate
+   * @covers ::buildEcaActions
+   * @covers ::walkBpmnNode
+   * @covers ::createWorkflowRoutes
+   */
+  public function testInstantiateBuildingPermit(): void {
+    $config = $this->buildingPermitConfig();
+
+    $result = $this->instantiator->instantiate('building_permit', $config);
+
+    $this->assertTrue($result['success'], 'instantiate() succeeds for building_permit: ' . ($result['message'] ?? ''));
+    $workflow_id = $result['workflow_id'];
+
+    $eca = $this->config('eca.eca.' . $workflow_id);
+    $this->assertFalse($eca->isNew(), 'ECA config exists.');
+
+    // building_permit declares 22 service tasks + 2 user tasks + 4 exclusive
+    // gateways. The walker should emit at least a dozen distinct action_ ids,
+    // proving the recursion follows gateways and sequence flows.
+    $actions = $eca->get('actions') ?? [];
+    $task_ids = array_filter(array_keys($actions), fn ($id) => str_starts_with($id, 'action_'));
+    $this->assertGreaterThanOrEqual(
+      10,
+      count($task_ids),
+      'Walker emits actions for the bulk of building_permit tasks.'
+    );
+
+    // Each emitted action carries a non-empty plugin id - the fallback shape
+    // is aabenforms_log so anything else means actionFromTask resolved.
+    foreach ($task_ids as $id) {
+      $this->assertNotEmpty($actions[$id]['plugin'] ?? '', "Action $id has a plugin id.");
+      $this->assertArrayHasKey('successors', $actions[$id]);
+    }
+  }
+
+  /**
+   * Tests that an unknown template id surfaces the validator error path.
+   *
+   * The metadata service returns no parameters for an unknown id, so the only
+   * validator error is the missing webform_id. Pass an empty webform_id to
+   * force the validation gate to trip without ever reaching loadTemplate().
+   *
+   * @covers ::instantiate
+   */
+  public function testInstantiateUnknownTemplateFailsValidation(): void {
+    $result = $this->instantiator->instantiate('this_template_does_not_exist', [
+      'label' => 'Phantom',
+      'webform_id' => '',
+      'parameters' => [],
+      'actions' => [],
+    ]);
+
+    $this->assertFalse($result['success']);
+    $this->assertNull($result['workflow_id']);
+    $this->assertNotEmpty($result['errors']);
+    $this->assertSame('Configuration validation failed', $result['message']);
+  }
+
+  /**
+   * Tests that missing required parameters block instantiation.
+   *
+   * @covers ::instantiate
+   */
+  public function testInstantiateRejectsMissingRequiredParameters(): void {
+    $result = $this->instantiator->instantiate('contact_form', [
+      'label' => 'Incomplete',
+      'webform_id' => 'incomplete_form',
+      'parameters' => [
+      // recipient_email + submitter_email_field deliberately omitted.
+        'workflow_label' => 'Incomplete',
+      ],
+      'actions' => [],
+    ]);
+
+    $this->assertFalse($result['success']);
+    $this->assertNotEmpty($result['errors']);
+    $this->assertNull($result['workflow_id']);
+  }
+
+  /**
+   * Tests that a duplicate logical id is auto-suffixed instead of colliding.
+   *
+   * generateWorkflowId() defends against id collisions by appending _N until
+   * workflowExists() returns false. This is the workflowExists branch of the
+   * happy path - run instantiate() twice with the same explicit id and verify
+   * the second call lands on a different config name.
+   *
+   * @covers ::generateWorkflowId
+   * @covers ::workflowExists
+   */
+  public function testInstantiateAutoSuffixesDuplicateId(): void {
+    $explicit_id = 'duplicate_kernel_test_' . uniqid();
+    $first = $this->instantiator->instantiate('contact_form', $this->contactFormConfig([
+      'id' => $explicit_id,
+    ]));
+    $this->assertTrue($first['success'], 'First instantiate() succeeds.');
+    $this->assertSame($explicit_id, $first['workflow_id']);
+
+    $second = $this->instantiator->instantiate('contact_form', $this->contactFormConfig([
+      'id' => $explicit_id,
+    ]));
+    $this->assertTrue($second['success'], 'Second instantiate() succeeds with suffix.');
+    $this->assertNotSame($explicit_id, $second['workflow_id']);
+    $this->assertStringStartsWith($explicit_id . '_', $second['workflow_id']);
+  }
+
+  /**
+   * Tests the wizard-edited BPMN XML override path.
+   *
+   * When the wizard step 2 hands over edited XML, generateEcaWorkflow() must
+   * parse that XML directly instead of re-reading the on-disk template.
+   *
+   * @covers ::instantiate
+   * @covers ::generateEcaWorkflow
+   */
+  public function testInstantiateWithBpmnXmlOverride(): void {
+    $override_xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:aabenforms="http://aabenforms.dk/bpmn/eca"
+  id="Definitions_override"
+  targetNamespace="http://aabenforms.dk/bpmn">
+  <bpmn:process id="override_process" name="Override" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Task_Override" name="Override Task">
+      <bpmn:extensionElements>
+        <aabenforms:ecaAction plugin="aabenforms_log">
+          <aabenforms:config key="level">info</aabenforms:config>
+          <aabenforms:config key="message">Hello from override</aabenforms:config>
+        </aabenforms:ecaAction>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_Override"/>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_Override" targetRef="EndEvent_1"/>
+  </bpmn:process>
+</bpmn:definitions>
+XML;
+
+    $result = $this->instantiator->instantiate(
+      'contact_form',
+      $this->contactFormConfig(),
+      $override_xml,
+    );
+    $this->assertTrue($result['success'], 'Override path instantiates: ' . ($result['message'] ?? ''));
+
+    $eca = $this->config('eca.eca.' . $result['workflow_id']);
+    $actions = $eca->get('actions') ?? [];
+
+    // The override declares exactly one task; the on-disk contact_form has
+    // four. Confirm the override won by checking action count.
+    $task_ids = array_filter(array_keys($actions), fn ($id) => str_starts_with($id, 'action_'));
+    $this->assertCount(1, $task_ids, 'Override XML produced exactly one action.');
+    $action_id = reset($task_ids);
+    $this->assertSame('aabenforms_log', $actions[$action_id]['plugin']);
+    $this->assertSame('info', $actions[$action_id]['configuration']['level'] ?? NULL);
+    $this->assertSame('Hello from override', $actions[$action_id]['configuration']['message'] ?? NULL);
+  }
+
+  /**
+   * Tests that malformed BPMN XML override surfaces an error result.
+   *
+   * @covers ::instantiate
+   * @covers ::generateEcaWorkflow
+   */
+  public function testInstantiateRejectsMalformedXmlOverride(): void {
+    $bad = '<not-valid-xml<<<';
+    $result = $this->instantiator->instantiate(
+      'contact_form',
+      $this->contactFormConfig(),
+      $bad,
+    );
+
+    $this->assertFalse($result['success']);
+    $this->assertStringContainsString('Edited BPMN XML failed to parse', $result['message']);
+  }
+
+  /**
+   * Tests deleteInstance() removes both config entries.
+   *
+   * @covers ::deleteInstance
+   */
+  public function testDeleteInstance(): void {
+    $created = $this->instantiator->instantiate('contact_form', $this->contactFormConfig());
+    $this->assertTrue($created['success']);
+    $workflow_id = $created['workflow_id'];
+
+    // Sanity: configs exist.
+    $this->assertFalse($this->config('aabenforms_workflows.template_instance.' . $workflow_id)->isNew());
+    $this->assertFalse($this->config('eca.eca.' . $workflow_id)->isNew());
+
+    $deleted = $this->instantiator->deleteInstance($workflow_id);
+    $this->assertTrue($deleted, 'deleteInstance() returns TRUE on success.');
+
+    // Both ConfigFactory::config() and ConfigFactory::getEditable() return
+    // cached objects; checking via either still reads stale isNew() values
+    // after a delete in the same request. Hit the storage backend directly
+    // for a fresh existence check.
+    $storage = $this->container->get('config.storage');
+    $this->assertFalse(
+      $storage->exists('aabenforms_workflows.template_instance.' . $workflow_id),
+      'template_instance config is removed from storage.',
+    );
+    $this->assertFalse(
+      $storage->exists('eca.eca.' . $workflow_id),
+      'eca.eca.<id> is cascaded with the template_instance delete.',
+    );
+  }
+
+  /**
+   * Tests deleteInstance() on a non-existent id returns TRUE without error.
+   *
+   * The method only deletes when the config isn't new, so a missing id is a
+   * silent no-op - the catch block is reserved for actual storage failures.
+   *
+   * @covers ::deleteInstance
+   */
+  public function testDeleteInstanceMissingIsNoOp(): void {
+    $this->assertTrue($this->instantiator->deleteInstance('does_not_exist_anywhere'));
+  }
+
+  /**
+   * Tests getInstances() lists all created instances.
+   *
+   * @covers ::getInstances
+   */
+  public function testGetInstances(): void {
+    $this->assertSame([], $this->instantiator->getInstances(), 'No instances initially.');
+
+    $a = $this->instantiator->instantiate('contact_form', $this->contactFormConfig());
+    $b = $this->instantiator->instantiate('contact_form', $this->contactFormConfig());
+    $this->assertTrue($a['success']);
+    $this->assertTrue($b['success']);
+
+    $instances = $this->instantiator->getInstances();
+    $this->assertCount(2, $instances, 'Two instances listed.');
+
+    $ids = array_map(fn ($row) => $row['id'] ?? NULL, $instances);
+    $this->assertContains($a['workflow_id'], $ids);
+    $this->assertContains($b['workflow_id'], $ids);
+
+    // Each row carries the structural keys set by createTemplateInstanceConfig.
+    foreach ($instances as $row) {
+      $this->assertArrayHasKey('id', $row);
+      $this->assertArrayHasKey('label', $row);
+      $this->assertArrayHasKey('template_id', $row);
+      $this->assertArrayHasKey('webform_id', $row);
+      $this->assertArrayHasKey('configuration', $row);
+      $this->assertArrayHasKey('status', $row);
+      $this->assertArrayHasKey('created', $row);
+      $this->assertArrayHasKey('updated', $row);
+    }
+  }
+
+  /**
+   * Tests generateEmailTemplates() captures action subject/body pairs.
+   *
+   * @covers ::generateEmailTemplates
+   */
+  public function testGenerateEmailTemplatesPersistsActionContent(): void {
+    $config = $this->contactFormConfig([
+      'actions' => [
+        'send_confirmation' => [
+          'subject' => 'Thanks for contacting us',
+          'body' => 'We have received your inquiry.',
+          'recipient' => 'submitter@example.test',
+        ],
+      // No subject/body here, must be skipped.
+        'log_only' => [
+          'recipient' => 'audit@example.test',
+        ],
+      ],
+    ]);
+
+    $result = $this->instantiator->instantiate('contact_form', $config);
+    $this->assertTrue($result['success'], 'instantiate() succeeds: ' . ($result['message'] ?? ''));
+
+    $instance = $this->config('aabenforms_workflows.template_instance.' . $result['workflow_id']);
+    $email_templates = $instance->get('email_templates') ?? [];
+
+    $this->assertArrayHasKey('send_confirmation', $email_templates);
+    $this->assertSame('Thanks for contacting us', $email_templates['send_confirmation']['subject']);
+    $this->assertSame('We have received your inquiry.', $email_templates['send_confirmation']['body']);
+    $this->assertSame('submitter@example.test', $email_templates['send_confirmation']['recipient']);
+
+    $this->assertArrayNotHasKey(
+      'log_only',
+      $email_templates,
+      'Actions without subject+body are skipped.'
+    );
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Service/WorkflowTemplateInstantiatorTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Service/WorkflowTemplateInstantiatorTest.php
@@ -277,10 +277,10 @@ class WorkflowTemplateInstantiatorTest extends KernelTestBase {
   /**
    * Tests that a duplicate logical id is auto-suffixed instead of colliding.
    *
-   * generateWorkflowId() defends against id collisions by appending _N until
-   * workflowExists() returns false. This is the workflowExists branch of the
-   * happy path - run instantiate() twice with the same explicit id and verify
-   * the second call lands on a different config name.
+   * The generateWorkflowId() method defends against id collisions by appending
+   * _N until workflowExists() returns false. This is the workflowExists branch
+   * of the happy path - run instantiate() twice with the same explicit id and
+   * verify the second call lands on a different config name.
    *
    * @covers ::generateWorkflowId
    * @covers ::workflowExists
@@ -469,7 +469,7 @@ XML;
           'body' => 'We have received your inquiry.',
           'recipient' => 'submitter@example.test',
         ],
-      // No subject/body here, must be skipped.
+        // No subject/body here, must be skipped.
         'log_only' => [
           'recipient' => 'audit@example.test',
         ],

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/WorkflowsModuleTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/WorkflowsModuleTest.php
@@ -32,6 +32,9 @@ class WorkflowsModuleTest extends KernelTestBase {
     'eca_content',
     'eca_user',
     'aabenforms_core',
+    // Hard dep declared in aabenforms_workflows.info.yml; needed since the
+    // parent_cpr_verifier service injects aabenforms_mitid.session_manager.
+    'aabenforms_mitid',
     'aabenforms_workflows',
   ];
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/BookAppointmentActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/BookAppointmentActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\BookAppointmentAction;
 use Drupal\aabenforms_workflows\Service\CalendarService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -39,7 +40,7 @@ class BookAppointmentActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -51,19 +52,23 @@ class BookAppointmentActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->calendarService = $this->createMock(CalendarService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'slot_id_field' => 'selected_slot_id',
       'attendee_name_field' => 'name',
       'attendee_email_field' => 'email',
@@ -73,7 +78,7 @@ class BookAppointmentActionTest extends UnitTestCase {
     ];
 
     $this->action = new BookAppointmentAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_book_appointment',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -83,11 +88,48 @@ class BookAppointmentActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('calendarService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->calendarService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission the mock's getSubmission() should return.
+   *
+   * @return \Drupal\aabenforms_workflows\Plugin\Action\BookAppointmentAction
+   *   The configured partial mock.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission): BookAppointmentAction {
+    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
+      ->setConstructorArgs([
+        $this->configuration,
+        'aabenforms_book_appointment',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('calendarService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->calendarService);
+
+    return $actionMock;
   }
 
   /**
@@ -133,41 +175,23 @@ class BookAppointmentActionTest extends UnitTestCase {
       )
       ->willReturn($bookingResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['booking_id', 'BOOK-ABC-123'],
-        ['booking_slot_id', 'SLOT-20260315-1400'],
-        ['booking_status', 'confirmed'],
-        ['booked_at', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('BOOK-ABC-123', $writes['booking_id']);
+    $this->assertSame('SLOT-20260315-1400', $writes['booking_slot_id']);
+    $this->assertSame('confirmed', $writes['booking_status']);
+    $this->assertArrayHasKey('booked_at', $writes);
   }
 
   /**
@@ -197,12 +221,12 @@ class BookAppointmentActionTest extends UnitTestCase {
       ->method('bookSlot')
       ->willReturn($bookingResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(2))
       ->method('setElementData')
-      ->withConsecutive(
-        ['booking_status', 'failed'],
-        ['booking_error', 'Slot already booked (double booking prevented)']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
@@ -211,29 +235,11 @@ class BookAppointmentActionTest extends UnitTestCase {
       ->method('warning')
       ->with($this->stringContains('Appointment booking failed'));
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('failed', $writes['booking_status']);
+    $this->assertSame('Slot already booked (double booking prevented)', $writes['booking_error']);
   }
 
   /**
@@ -284,28 +290,7 @@ class BookAppointmentActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -325,28 +310,7 @@ class BookAppointmentActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Slot ID field'));
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -396,28 +360,7 @@ class BookAppointmentActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(BookAppointmentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_book_appointment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -284,20 +284,18 @@ class CprLookupActionTest extends UnitTestCase {
   /**
    * Tests missing CPR handling.
    *
+   * Empty CPR is treated as demo mode: info log, result NULL, no SOAP call.
+   * The earlier shape (warning) was changed when demo-mode fallback landed.
+   *
    * @covers ::execute
    */
   public function testMissingCpr(): void {
-    $this->markTestSkipped(
-      'Test pre-dates the current handleError + executionCollector flow; assertion shape no longer matches. Tracked in #35.'
-    );
     // Don't set CPR token.
-    // Expect warning log.
+    // Demo-mode info log, never warning.
     $this->logger->expects($this->once())
-      ->method('warning')
-      ->with(
-              'CPR lookup failed: No CPR number provided',
-              ['action' => 'aabenforms_cpr_lookup']
-          );
+      ->method('info');
+    $this->logger->expects($this->never())
+      ->method('warning');
 
     // Serviceplatformen should NOT be called.
     $this->serviceplatformenClient->expects($this->never())

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/FetchAvailableSlotsActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/FetchAvailableSlotsActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\FetchAvailableSlotsAction;
 use Drupal\aabenforms_workflows\Service\CalendarService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,19 +51,23 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->calendarService = $this->createMock(CalendarService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'start_date_field' => 'preferred_date',
       'date_range_days' => '30',
       'slot_duration' => '60',
@@ -71,7 +76,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     ];
 
     $this->action = new FetchAvailableSlotsAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_fetch_available_slots',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -81,11 +86,42 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('calendarService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->calendarService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): FetchAvailableSlotsAction {
+    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_fetch_available_slots',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('calendarService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->calendarService);
+
+    return $actionMock;
   }
 
   /**
@@ -138,41 +174,23 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
       )
       ->willReturn($slotsResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['available_slots', $this->isType('string')],
-        ['slots_count', 2],
-        ['slots_start_date', '2026-03-01'],
-        ['slots_end_date', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertIsString($writes['available_slots']);
+    $this->assertSame(2, $writes['slots_count']);
+    $this->assertSame('2026-03-01', $writes['slots_start_date']);
+    $this->assertArrayHasKey('slots_end_date', $writes);
   }
 
   /**
@@ -206,28 +224,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -239,20 +236,8 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('602');
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['slot_duration'] = '90';
-
-    $actionWith90Min = new FetchAvailableSlotsAction(
-      $configuration,
-      'aabenforms_fetch_available_slots',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->calendarService->expects($this->once())
       ->method('getAvailableSlots')
@@ -274,28 +259,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -315,45 +279,34 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
         'total_slots' => 0,
       ]);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['available_slots', '[]'],
-        ['slots_count', 0],
-        ['slots_start_date', '2026-06-01'],
-        ['slots_end_date', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
+    // Production logs with placeholders; the resolved count lives in
+    // the context array under '@count'.
     $this->logger->expects($this->once())
       ->method('info')
-      ->with($this->stringContains('Fetched 0 available slots'));
+      ->with(
+        $this->stringContains('Fetched @count available slots'),
+        $this->callback(function ($context) {
+          return ($context['@count'] ?? NULL) === 0;
+        })
+      );
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('[]', $writes['available_slots']);
+    $this->assertSame(0, $writes['slots_count']);
+    $this->assertSame('2026-06-01', $writes['slots_start_date']);
+    $this->assertArrayHasKey('slots_end_date', $writes);
   }
 
   /**
@@ -398,28 +351,7 @@ class FetchAvailableSlotsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(FetchAvailableSlotsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_fetch_available_slots',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('calendarService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->calendarService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/GeneratePdfActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/GeneratePdfActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\GeneratePdfAction;
 use Drupal\aabenforms_workflows\Service\PdfService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class GeneratePdfActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,19 +51,23 @@ class GeneratePdfActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->pdfService = $this->createMock(PdfService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'template' => 'parking_permit',
       'filename_pattern' => '{template}_{submission_id}_{timestamp}.pdf',
       'orientation' => 'portrait',
@@ -74,7 +79,7 @@ address:street_address',
     ];
 
     $this->action = new GeneratePdfAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_generate_pdf',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -84,11 +89,42 @@ address:street_address',
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('pdfService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->pdfService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): GeneratePdfAction {
+    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_generate_pdf',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('pdfService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->pdfService);
+
+    return $actionMock;
   }
 
   /**
@@ -135,28 +171,7 @@ address:street_address',
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -175,21 +190,9 @@ address:street_address',
     $this->submission->method('id')->willReturn('501');
     $this->submission->method('getCreatedTime')->willReturn(1640000000);
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['template'] = 'marriage_certificate';
     $configuration['data_fields'] = '';
-
-    $actionWithConfig = new GeneratePdfAction(
-      $configuration,
-      'aabenforms_generate_pdf',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->pdfService->expects($this->once())
       ->method('generatePdf')
@@ -215,28 +218,7 @@ address:street_address',
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -295,41 +277,23 @@ address:street_address',
       ->method('generatePdf')
       ->willReturn($pdfResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['pdf_file_id', 10],
-        ['pdf_file_uri', 'public://pdfs/document.pdf'],
-        ['pdf_file_url', 'https://example.com/files/document.pdf'],
-        ['pdf_filename', 'document.pdf']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame(10, $writes['pdf_file_id']);
+    $this->assertSame('public://pdfs/document.pdf', $writes['pdf_file_uri']);
+    $this->assertSame('https://example.com/files/document.pdf', $writes['pdf_file_url']);
+    $this->assertSame('document.pdf', $writes['pdf_filename']);
   }
 
   /**
@@ -372,28 +336,7 @@ address:street_address',
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(GeneratePdfAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_generate_pdf',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('pdfService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->pdfService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
@@ -223,12 +223,13 @@ class MitIdValidateActionTest extends UnitTestCase {
   /**
    * Tests validation with missing MitID session.
    *
+   * Production code treats a missing session as "demo mode": logs at INFO,
+   * sets the result token to TRUE, and records a successful step. The earlier
+   * shape (warning + FALSE) was changed when demo-mode fallback was added.
+   *
    * @covers ::execute
    */
   public function testMissingSession(): void {
-    $this->markTestSkipped(
-      'Test asserts MitIdSessionManager validation behavior that has since changed shape. Tracked in #35.'
-    );
     $workflowId = 'workflow-missing';
 
     // Set workflow ID token.
@@ -240,19 +241,17 @@ class MitIdValidateActionTest extends UnitTestCase {
       ->with($workflowId)
       ->willReturn(NULL);
 
-    // Expect warning log for missing session.
+    // Demo-mode fallback: info log, no warning.
     $this->logger->expects($this->once())
-      ->method('warning')
-      ->with(
-              'MitID validation failed: No session found for workflow {workflow_id}',
-              ['workflow_id' => $workflowId, 'action' => 'aabenforms_mitid_validate']
-          );
+      ->method('info');
+    $this->logger->expects($this->never())
+      ->method('warning');
 
     // Execute action.
     $this->action->execute();
 
-    // Verify result is FALSE.
-    $this->assertFalse($this->tokenStorage['mitid_valid']);
+    // Verify result is TRUE (demo mode).
+    $this->assertTrue($this->tokenStorage['mitid_valid']);
   }
 
   /**
@@ -307,9 +306,6 @@ class MitIdValidateActionTest extends UnitTestCase {
    * @covers ::execute
    */
   public function testErrorHandling(): void {
-    $this->markTestSkipped(
-      'Logger error-context assertion shape drifted from the current handleError() signature (now \Throwable). Tracked in #35.'
-    );
     $workflowId = 'workflow-error';
 
     // Set workflow ID token.
@@ -321,7 +317,10 @@ class MitIdValidateActionTest extends UnitTestCase {
       ->with($workflowId)
       ->willThrowException(new \Exception('Database connection error'));
 
-    // Expect error log.
+    // handleError() routes to log('error', ...). The injected channel sees
+    // the call as logger->error(message, context). Context contains
+    // 'message', 'context' (the context_message passed by execute()),
+    // 'exception', and 'action' (added by the base log() helper).
     $this->logger->expects($this->once())
       ->method('error')
       ->with(
@@ -331,7 +330,7 @@ class MitIdValidateActionTest extends UnitTestCase {
                       return isset($context['message']) &&
                        $context['message'] === 'Database connection error' &&
                        isset($context['context']) &&
-                       $context['context'] === 'Validating MitID session';
+                       $context['context'] === 'MitID Identity Validation';
                   }
               )
           );
@@ -346,20 +345,18 @@ class MitIdValidateActionTest extends UnitTestCase {
   /**
    * Tests validation without workflow ID.
    *
+   * Missing workflow ID falls into demo mode: info log, result token TRUE,
+   * and the session manager is never consulted.
+   *
    * @covers ::execute
    */
   public function testMissingWorkflowId(): void {
-    $this->markTestSkipped(
-      'Test asserts MitIdSessionManager workflow-id validation behavior that has since changed shape. Tracked in #35.'
-    );
     // Don't set workflow_id token (simulate missing context).
-    // Expect warning log.
+    // Demo-mode info log, no warning.
     $this->logger->expects($this->once())
-      ->method('warning')
-      ->with(
-              'MitID validation failed: No workflow ID provided',
-              ['action' => 'aabenforms_mitid_validate']
-          );
+      ->method('info');
+    $this->logger->expects($this->never())
+      ->method('warning');
 
     // Session manager should NOT be called.
     $this->sessionManager->expects($this->never())
@@ -368,8 +365,8 @@ class MitIdValidateActionTest extends UnitTestCase {
     // Execute action.
     $this->action->execute();
 
-    // Verify result is FALSE.
-    $this->assertFalse($this->tokenStorage['mitid_valid']);
+    // Verify result is TRUE (demo mode).
+    $this->assertTrue($this->tokenStorage['mitid_valid']);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ProcessPaymentActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ProcessPaymentActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\ProcessPaymentAction;
 use Drupal\aabenforms_workflows\Service\PaymentService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
   /**
    * Mock logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,12 +51,16 @@ class ProcessPaymentActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     // Mock dependencies.
@@ -70,7 +75,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     $ecaState = $this->createMock(EcaState::class);
 
     // Create action instance.
-    $configuration = [
+    $this->configuration = [
       'amount_field' => 'payment_amount',
       'currency' => 'DKK',
       'payment_method' => 'nets_easy',
@@ -80,7 +85,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     ];
 
     $this->action = new ProcessPaymentAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_process_payment',
       ['provider' => 'aabenforms_workflows'],
       $entityTypeManager,
@@ -90,12 +95,57 @@ class ProcessPaymentActionTest extends UnitTestCase {
       $ecaState,
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     // Inject payment service via reflection.
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('paymentService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->paymentService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   *
+   * Centralises the boilerplate for wiring the payment service into a
+   * mocked-getSubmission instance.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission the mock's getSubmission() should return.
+   * @param array|null $configuration
+   *   Optional configuration override (defaults to $this->configuration).
+   *
+   * @return \Drupal\aabenforms_workflows\Plugin\Action\ProcessPaymentAction
+   *   The configured partial mock.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): ProcessPaymentAction {
+    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_process_payment',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $actionMock->expects($this->once())
+      ->method('getSubmission')
+      ->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('paymentService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->paymentService);
+
+    return $actionMock;
   }
 
   /**
@@ -114,7 +164,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('123');
 
@@ -137,55 +187,25 @@ class ProcessPaymentActionTest extends UnitTestCase {
       }))
       ->willReturn($paymentResult);
 
-    // Expect submission data to be updated.
+    // Capture every setElementData call so we can assert on the full set
+    // without depending on PHPUnit 9's withConsecutive().
+    $writes = [];
     $this->submission->expects($this->exactly(4))
       ->method('setElementData')
-      ->withConsecutive(
-        ['payment_id', 'PAY-123-456'],
-        ['payment_status', 'completed'],
-        ['payment_transaction_id', 'TXN-ABC123'],
-        ['payment_timestamp', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    // Execute action with mock submission.
-    $reflection = new \ReflectionClass($this->action);
-    $method = $reflection->getMethod('execute');
-    $method->setAccessible(TRUE);
-
-    // Mock getSubmission method.
-    $getSubmissionMethod = $reflection->getMethod('getSubmission');
-    $getSubmissionMethod->setAccessible(TRUE);
-
-    // Use a closure to override getSubmission behavior.
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    // Inject payment service.
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('PAY-123-456', $writes['payment_id']);
+    $this->assertSame('completed', $writes['payment_status']);
+    $this->assertSame('TXN-ABC123', $writes['payment_transaction_id']);
+    $this->assertArrayHasKey('payment_timestamp', $writes);
   }
 
   /**
@@ -203,7 +223,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('124');
 
@@ -217,42 +237,21 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('processPayment')
       ->willReturn($paymentResult);
 
-    // Expect failure data to be stored.
+    $writes = [];
     $this->submission->expects($this->exactly(2))
       ->method('setElementData')
-      ->withConsecutive(
-        ['payment_status', 'failed'],
-        ['payment_error', 'Card declined']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('failed', $writes['payment_status']);
+    $this->assertSame('Card declined', $writes['payment_error']);
   }
 
   /**
@@ -269,7 +268,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('125');
 
@@ -285,30 +284,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     $this->submission->expects($this->never())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -326,7 +302,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('126');
 
@@ -339,30 +315,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Amount field'));
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -419,30 +372,7 @@ class ProcessPaymentActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ProcessPaymentAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_process_payment',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('paymentService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->paymentService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendReminderActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendReminderActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\SendReminderAction;
 use Drupal\aabenforms_workflows\Service\SmsService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -54,7 +55,7 @@ class SendReminderActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -66,12 +67,16 @@ class SendReminderActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->smsService = $this->createMock(SmsService::class);
@@ -80,7 +85,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'reminder_type' => 'email',
       'delay_days' => '7',
       'event_date_field' => 'ceremony_date',
@@ -91,7 +96,7 @@ class SendReminderActionTest extends UnitTestCase {
     ];
 
     $this->action = new SendReminderAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_send_reminder',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -101,19 +106,54 @@ class SendReminderActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
-    $reflection = new \ReflectionClass($this->action);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($this->action, $this->smsService);
+    $this->injectServices($this->action);
+  }
 
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($this->action, $this->mailManager);
+  /**
+   * Injects the SMS service, mail manager and queue factory via reflection.
+   */
+  protected function injectServices(SendReminderAction $action): void {
+    $reflection = new \ReflectionClass($action);
 
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($this->action, $this->queueFactory);
+    $smsServiceProperty = $reflection->getProperty('smsService');
+    $smsServiceProperty->setAccessible(TRUE);
+    $smsServiceProperty->setValue($action, $this->smsService);
+
+    $mailManagerProperty = $reflection->getProperty('mailManager');
+    $mailManagerProperty->setAccessible(TRUE);
+    $mailManagerProperty->setValue($action, $this->mailManager);
+
+    $queueFactoryProperty = $reflection->getProperty('queueFactory');
+    $queueFactoryProperty->setAccessible(TRUE);
+    $queueFactoryProperty->setValue($action, $this->queueFactory);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): SendReminderAction {
+    $actionMock = $this->getMockBuilder(SendReminderAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_send_reminder',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+    $this->injectServices($actionMock);
+
+    return $actionMock;
   }
 
   /**
@@ -130,13 +170,12 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('800');
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['reminder_scheduled', TRUE],
-        ['reminder_send_date', $this->anything()],
-        ['reminder_type', 'email']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
@@ -145,37 +184,12 @@ class SendReminderActionTest extends UnitTestCase {
       ->method('info')
       ->with($this->stringContains('Reminder scheduled'));
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertTrue($writes['reminder_scheduled']);
+    $this->assertArrayHasKey('reminder_send_date', $writes);
+    $this->assertSame('email', $writes['reminder_type']);
   }
 
   /**
@@ -193,12 +207,12 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('801');
 
+    $writes = [];
     $this->submission->expects($this->exactly(2))
       ->method('setElementData')
-      ->withConsecutive(
-        ['reminder_sent', TRUE],
-        ['reminder_sent_at', $this->anything()]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
@@ -207,37 +221,11 @@ class SendReminderActionTest extends UnitTestCase {
       ->method('info')
       ->with($this->stringContains('Email reminder sent'));
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertTrue($writes['reminder_sent']);
+    $this->assertArrayHasKey('reminder_sent_at', $writes);
   }
 
   /**
@@ -255,20 +243,8 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('802');
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['reminder_type'] = 'sms';
-
-    $actionWithSms = new SendReminderAction(
-      $configuration,
-      'aabenforms_send_reminder',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->smsService->expects($this->once())
       ->method('sendSms')
@@ -283,36 +259,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -330,7 +277,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->method('getData')->willReturn($submissionData);
     $this->submission->method('id')->willReturn('803');
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['delay_days'] = '3';
 
     $this->submission->expects($this->atLeastOnce())
@@ -339,36 +286,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -392,36 +310,7 @@ class SendReminderActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendReminderAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_reminder',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
-    $property = $reflection->getProperty('mailManager');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->mailManager);
-
-    $property = $reflection->getProperty('queueFactory');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->queueFactory);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendSmsActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/SendSmsActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\SendSmsAction;
 use Drupal\aabenforms_workflows\Service\SmsService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -39,7 +40,7 @@ class SendSmsActionTest extends UnitTestCase {
   /**
    * Mock logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -51,19 +52,23 @@ class SendSmsActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->smsService = $this->createMock(SmsService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'phone_field' => 'phone',
       'message_template' => 'Din ansøgning er modtaget. Sagsnummer: [submission:id]',
       'sender_name' => 'ÅbenForms',
@@ -71,7 +76,7 @@ class SendSmsActionTest extends UnitTestCase {
     ];
 
     $this->action = new SendSmsAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_send_sms',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -81,11 +86,45 @@ class SendSmsActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('smsService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->smsService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission, ?array $configuration = NULL): SendSmsAction {
+    $actionMock = $this->getMockBuilder(SendSmsAction::class)
+      ->setConstructorArgs([
+        $configuration ?? $this->configuration,
+        'aabenforms_send_sms',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $actionMock->expects($this->once())
+      ->method('getSubmission')
+      ->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('smsService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->smsService);
+
+    return $actionMock;
   }
 
   /**
@@ -102,7 +141,7 @@ class SendSmsActionTest extends UnitTestCase {
       'name' => 'Test User',
     ];
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('getData')
       ->willReturn($submissionData);
 
@@ -135,42 +174,22 @@ class SendSmsActionTest extends UnitTestCase {
       )
       ->willReturn($smsResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['sms_message_id', 'SMS-123-456'],
-        ['sms_status', 'sent'],
-        ['sms_segments', 1]
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertSame('SMS-123-456', $writes['sms_message_id']);
+    $this->assertSame('sent', $writes['sms_status']);
+    $this->assertSame(1, $writes['sms_segments']);
   }
 
   /**
@@ -185,7 +204,7 @@ class SendSmsActionTest extends UnitTestCase {
       ->method('getData')
       ->willReturn($submissionData);
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('id')
       ->willReturn('201');
 
@@ -196,30 +215,7 @@ class SendSmsActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Phone field'));
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -239,7 +235,7 @@ class SendSmsActionTest extends UnitTestCase {
       'amount' => '100',
     ];
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('getData')
       ->willReturn($submissionData);
 
@@ -255,20 +251,8 @@ class SendSmsActionTest extends UnitTestCase {
       ->method('getWebform')
       ->willReturn($webform);
 
-    $configuration = $this->action->getConfiguration();
+    $configuration = $this->configuration;
     $configuration['message_template'] = 'Application [submission:id] for [submission:license_plate] received. Form: [webform:title]';
-
-    $actionWithTemplate = new SendSmsAction(
-      $configuration,
-      'aabenforms_send_sms',
-      ['provider' => 'aabenforms_workflows'],
-      $this->createMock(EntityTypeManagerInterface::class),
-      $this->createMock(TokenInterface::class),
-      $this->createMock(AccountProxyInterface::class),
-      $this->createMock(TimeInterface::class),
-      $this->createMock(EcaState::class),
-      $this->logger
-    );
 
     $this->smsService->expects($this->once())
       ->method('sendSms')
@@ -289,30 +273,7 @@ class SendSmsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $configuration,
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission, $configuration);
     $actionMock->execute($this->submission);
   }
 
@@ -326,22 +287,30 @@ class SendSmsActionTest extends UnitTestCase {
     $webform->method('label')->willReturn('Test Form');
 
     $phones = ['+4511111111', '+4522222222', '+4533333333'];
+    $sentPhones = [];
 
-    foreach ($phones as $index => $phone) {
-      $submission = $this->createMock(WebformSubmissionInterface::class);
-      $submission->method('getData')->willReturn(['phone' => $phone]);
-      $submission->method('id')->willReturn((string) (300 + $index));
-      $submission->method('getCreatedTime')->willReturn(time());
-      $submission->method('getWebform')->willReturn($webform);
-
-      $this->smsService->expects($this->at($index))
-        ->method('sendSms')
-        ->with($phone, $this->anything(), $this->anything())
-        ->willReturn([
+    // Each iteration creates a fresh action mock + submission, so each
+    // sendSms() call resolves against its own expectation. Replace the
+    // PHPUnit-9-only $this->at() pattern with a willReturnCallback that
+    // observes the actual phone passed and returns a per-call result.
+    $this->smsService->expects($this->exactly(count($phones)))
+      ->method('sendSms')
+      ->willReturnCallback(function ($phone) use (&$sentPhones) {
+        $sentPhones[] = $phone;
+        $index = count($sentPhones) - 1;
+        return [
           'status' => 'sent',
           'message_id' => 'SMS-' . (300 + $index),
           'segments' => 1,
-        ]);
+        ];
+      });
+
+    foreach ($phones as $phone) {
+      $submission = $this->createMock(WebformSubmissionInterface::class);
+      $submission->method('getData')->willReturn(['phone' => $phone]);
+      $submission->method('id')->willReturn((string) (300 + array_search($phone, $phones, TRUE)));
+      $submission->method('getCreatedTime')->willReturn(time());
+      $submission->method('getWebform')->willReturn($webform);
 
       $submission->expects($this->atLeastOnce())
         ->method('setElementData');
@@ -349,35 +318,12 @@ class SendSmsActionTest extends UnitTestCase {
       $submission->expects($this->once())
         ->method('save');
 
-      $actionMock = $this->getMockBuilder(SendSmsAction::class)
-        ->setConstructorArgs([
-          $this->action->getConfiguration(),
-          'aabenforms_send_sms',
-          ['provider' => 'aabenforms_workflows'],
-          $this->createMock(EntityTypeManagerInterface::class),
-          $this->createMock(TokenInterface::class),
-          $this->createMock(AccountProxyInterface::class),
-          $this->createMock(TimeInterface::class),
-          $this->createMock(EcaState::class),
-          $this->logger,
-        ])
-        ->onlyMethods(['getSubmission'])
-        ->getMock();
-
-      $actionMock->expects($this->once())
-        ->method('getSubmission')
-        ->willReturn($submission);
-
-      $reflection = new \ReflectionClass($actionMock);
-      $property = $reflection->getProperty('smsService');
-      $property->setAccessible(TRUE);
-      $property->setValue($actionMock, $this->smsService);
-
+      $actionMock = $this->createActionMock($submission);
       $actionMock->execute($submission);
     }
 
-    // All three should be processed.
-    $this->assertEquals(3, count($phones));
+    // Confirm every phone was sent in order.
+    $this->assertSame($phones, $sentPhones);
   }
 
   /**
@@ -393,7 +339,7 @@ class SendSmsActionTest extends UnitTestCase {
       'phone' => '+4512345678',
     ];
 
-    $this->submission->expects($this->once())
+    $this->submission->expects($this->atLeastOnce())
       ->method('getData')
       ->willReturn($submissionData);
 
@@ -433,30 +379,7 @@ class SendSmsActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(SendSmsAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_send_sms',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->expects($this->once())
-      ->method('getSubmission')
-      ->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('smsService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->smsService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ValidateZoningActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ValidateZoningActionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\ValidateZoningAction;
 use Drupal\aabenforms_workflows\Service\GisService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -38,7 +39,7 @@ class ValidateZoningActionTest extends UnitTestCase {
   /**
    * The logger.
    *
-   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $logger;
 
@@ -50,26 +51,30 @@ class ValidateZoningActionTest extends UnitTestCase {
   protected $submission;
 
   /**
+   * Configuration array shared across the suite.
+   *
+   * @var array
+   */
+  protected array $configuration;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->markTestSkipped(
-      "Action plugin test relies on removed PHPUnit 9 APIs (withConsecutive) and on stub action methods that no longer exist (getConfiguration). Re-enable when the underlying action plugin ships a real service integration; tracked in #35."
-    );
     parent::setUp();
 
     $this->gisService = $this->createMock(GisService::class);
     $this->logger = $this->createMock(LoggerChannelInterface::class);
     $this->submission = $this->createMock(WebformSubmissionInterface::class);
 
-    $configuration = [
+    $this->configuration = [
       'address_field' => 'property_address',
       'construction_type_field' => 'construction_type',
       'store_result_in' => 'zoning_validation',
     ];
 
     $this->action = new ValidateZoningAction(
-      $configuration,
+      $this->configuration,
       'aabenforms_validate_zoning',
       ['provider' => 'aabenforms_workflows'],
       $this->createMock(EntityTypeManagerInterface::class),
@@ -79,11 +84,42 @@ class ValidateZoningActionTest extends UnitTestCase {
       $this->createMock(EcaState::class),
       $this->logger
     );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
 
     $reflection = new \ReflectionClass($this->action);
     $property = $reflection->getProperty('gisService');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $this->gisService);
+  }
+
+  /**
+   * Builds a partial-mock of the action that returns the supplied submission.
+   */
+  protected function createActionMock(WebformSubmissionInterface $submission): ValidateZoningAction {
+    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
+      ->setConstructorArgs([
+        $this->configuration,
+        'aabenforms_validate_zoning',
+        ['provider' => 'aabenforms_workflows'],
+        $this->createMock(EntityTypeManagerInterface::class),
+        $this->createMock(TokenInterface::class),
+        $this->createMock(AccountProxyInterface::class),
+        $this->createMock(TimeInterface::class),
+        $this->createMock(EcaState::class),
+        $this->logger,
+      ])
+      ->onlyMethods(['getSubmission'])
+      ->getMock();
+
+    $actionMock->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+    $actionMock->method('getSubmission')->willReturn($submission);
+
+    $reflection = new \ReflectionClass($actionMock);
+    $property = $reflection->getProperty('gisService');
+    $property->setAccessible(TRUE);
+    $property->setValue($actionMock, $this->gisService);
+
+    return $actionMock;
   }
 
   /**
@@ -108,40 +144,22 @@ class ValidateZoningActionTest extends UnitTestCase {
       ->with('Hovedgaden 1, 8000 Aarhus C', 'garage')
       ->willReturn($validationResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['zoning_allowed', TRUE],
-        ['zoning_zone_type', 'residential'],
-        ['zoning_reason', 'Garages are permitted in residential zones']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertTrue($writes['zoning_allowed']);
+    $this->assertSame('residential', $writes['zoning_zone_type']);
+    $this->assertSame('Garages are permitted in residential zones', $writes['zoning_reason']);
   }
 
   /**
@@ -171,32 +189,19 @@ class ValidateZoningActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
+    // The production logger call uses placeholder substitution; the
+    // resolved string ("ALLOWED" or "NOT ALLOWED") lives in the context
+    // array under '@result', not in the message template.
     $this->logger->expects($this->once())
       ->method('info')
-      ->with($this->stringContains('ALLOWED'));
+      ->with(
+        $this->stringContains('Zoning validation'),
+        $this->callback(function ($context) {
+          return ($context['@result'] ?? '') === 'ALLOWED';
+        })
+      );
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -221,44 +226,33 @@ class ValidateZoningActionTest extends UnitTestCase {
       ->method('validateConstructionType')
       ->willReturn($validationResult);
 
+    $writes = [];
     $this->submission->expects($this->exactly(3))
       ->method('setElementData')
-      ->withConsecutive(
-        ['zoning_allowed', FALSE],
-        ['zoning_zone_type', 'residential'],
-        ['zoning_reason', 'Factories are not permitted in residential zones']
-      );
+      ->willReturnCallback(function ($key, $value) use (&$writes) {
+        $writes[$key] = $value;
+      });
 
     $this->submission->expects($this->once())
       ->method('save');
 
+    // The placeholder-resolved value lives in the context array, not the
+    // message template.
     $this->logger->expects($this->once())
       ->method('info')
-      ->with($this->stringContains('NOT ALLOWED'));
+      ->with(
+        $this->stringContains('Zoning validation'),
+        $this->callback(function ($context) {
+          return ($context['@result'] ?? '') === 'NOT ALLOWED';
+        })
+      );
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
+
+    $this->assertFalse($writes['zoning_allowed']);
+    $this->assertSame('residential', $writes['zoning_zone_type']);
+    $this->assertSame('Factories are not permitted in residential zones', $writes['zoning_reason']);
   }
 
   /**
@@ -279,28 +273,7 @@ class ValidateZoningActionTest extends UnitTestCase {
       ->method('error')
       ->with($this->stringContains('Missing address'));
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 
@@ -333,28 +306,7 @@ class ValidateZoningActionTest extends UnitTestCase {
     $this->submission->expects($this->once())
       ->method('save');
 
-    $actionMock = $this->getMockBuilder(ValidateZoningAction::class)
-      ->setConstructorArgs([
-        $this->action->getConfiguration(),
-        'aabenforms_validate_zoning',
-        ['provider' => 'aabenforms_workflows'],
-        $this->createMock(EntityTypeManagerInterface::class),
-        $this->createMock(TokenInterface::class),
-        $this->createMock(AccountProxyInterface::class),
-        $this->createMock(TimeInterface::class),
-        $this->createMock(EcaState::class),
-        $this->logger,
-      ])
-      ->onlyMethods(['getSubmission'])
-      ->getMock();
-
-    $actionMock->method('getSubmission')->willReturn($this->submission);
-
-    $reflection = new \ReflectionClass($actionMock);
-    $property = $reflection->getProperty('gisService');
-    $property->setAccessible(TRUE);
-    $property->setValue($actionMock, $this->gisService);
-
+    $actionMock = $this->createActionMock($this->submission);
     $actionMock->execute($this->submission);
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -193,7 +193,7 @@ class ApprovalTokenServiceTest extends UnitTestCase {
   }
 
   /**
-   * generateToken emits an info log naming the submission and parent.
+   * GenerateToken emits an info log naming the submission and parent.
    */
   public function testGenerateTokenLogsInfo(): void {
     $this->logger->expects($this->once())

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -34,6 +34,13 @@ class ApprovalTokenServiceTest extends UnitTestCase {
   protected string $key = 'unit-test-key-not-secret';
 
   /**
+   * The mock logger - exposed so individual tests can assert on log calls.
+   *
+   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $logger;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -42,9 +49,9 @@ class ApprovalTokenServiceTest extends UnitTestCase {
     $private_key = $this->createMock(PrivateKey::class);
     $private_key->method('get')->willReturn($this->key);
 
-    $logger = $this->createMock(LoggerInterface::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
     $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
-    $logger_factory->method('get')->willReturn($logger);
+    $logger_factory->method('get')->willReturn($this->logger);
 
     $this->service = new ApprovalTokenService($private_key, $logger_factory);
   }
@@ -183,6 +190,61 @@ class ApprovalTokenServiceTest extends UnitTestCase {
     $this->assertFalse($this->service->isTokenExpired('!!!not-base64!!!'));
     $this->assertFalse($this->service->isTokenExpired(base64_encode('no-colon')));
     $this->assertFalse($this->service->isTokenExpired(base64_encode('hash:not-numeric')));
+  }
+
+  /**
+   * generateToken emits an info log naming the submission and parent.
+   */
+  public function testGenerateTokenLogsInfo(): void {
+    $this->logger->expects($this->once())
+      ->method('info')
+      ->with(
+        $this->stringContains('Generated approval token'),
+        $this->callback(function ($context) {
+          return ($context['@sid'] ?? NULL) === 42 && ($context['@parent'] ?? NULL) === 1;
+        })
+      );
+
+    $this->service->generateToken(42, 1);
+  }
+
+  /**
+   * Successful validation emits the success info log.
+   *
+   * Sets the expectation before any service calls so PHPUnit catches both
+   * the generate-time and validate-time info logs.
+   */
+  public function testValidateTokenSuccessLogsInfo(): void {
+    $info_calls = [];
+    $this->logger->method('info')->willReturnCallback(
+      function ($message, $context) use (&$info_calls) {
+        $info_calls[] = $message;
+      }
+    );
+
+    $token = $this->service->generateToken(42, 1);
+    $this->assertTrue($this->service->validateToken(42, 1, $token));
+
+    $this->assertCount(2, $info_calls);
+    $this->assertStringContainsString('Generated approval token', $info_calls[0]);
+    $this->assertStringContainsString('validated successfully', $info_calls[1]);
+  }
+
+  /**
+   * HMAC mismatch (well-formed token, wrong key/payload) emits a warning.
+   */
+  public function testValidateTokenHmacMismatchLogsWarning(): void {
+    // Token is well-formed (parses, in-date) but the hash is bogus.
+    $tampered = base64_encode('deadbeefdeadbeef:' . time());
+
+    $this->logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        $this->stringContains('Token validation failed'),
+        $this->anything()
+      );
+
+    $this->assertFalse($this->service->validateToken(42, 1, $tampered));
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
@@ -168,7 +168,7 @@ class ParentCprVerifierTest extends UnitTestCase {
 
     $this->logger->expects($this->once())->method('warning');
     $this->auditLogger->expects($this->once())
-      ->method('logCprLookup')
+      ->method('logWorkflowAccess')
       ->with('wf-4', 'parent_approval_cpr_missing', 'failure', $this->anything());
 
     $this->assertSame(
@@ -210,7 +210,7 @@ class ParentCprVerifierTest extends UnitTestCase {
     $this->sessionManager->method('getCprFromSession')->willReturn('');
 
     $this->auditLogger->expects($this->once())
-      ->method('logCprLookup')
+      ->method('logWorkflowAccess')
       ->with($this->anything(), 'parent_approval_cpr_missing', $this->anything(), $this->anything());
 
     $this->assertSame(

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the parent-approval CPR-match security gate.
+ *
+ * Locks in the four-way result protocol (match / mismatch / missing MitID CPR
+ * / missing expected CPR), the digit-only normalisation that lets a hyphenated
+ * input compare equal to a raw input, and the audit-log shape that hashes
+ * both CPRs on mismatch so an investigator can detect "same wrong CPR being
+ * retried" without the raw values ever landing in the audit table.
+ *
+ * Issue #54.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\ParentCprVerifier
+ * @group aabenforms_workflows
+ */
+class ParentCprVerifierTest extends UnitTestCase {
+
+  /**
+   * The verifier under test.
+   */
+  protected ParentCprVerifier $verifier;
+
+  /**
+   * Mock MitID session manager.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $sessionManager;
+
+  /**
+   * Mock audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $auditLogger;
+
+  /**
+   * Mock logger.
+   *
+   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->sessionManager = $this->createMock(MitIdSessionManager::class);
+    $this->auditLogger = $this->createMock(AuditLogger::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $logger_factory->method('get')->willReturn($this->logger);
+
+    $this->verifier = new ParentCprVerifier(
+      $this->sessionManager,
+      $this->auditLogger,
+      $logger_factory,
+    );
+  }
+
+  /**
+   * Builds a webform submission mock returning the given parent_<N>_cpr.
+   */
+  protected function submission(int $parent_number, ?string $cpr, int $sid = 42, string $uuid = 'sub-uuid-x'): WebformSubmissionInterface {
+    $submission = $this->createMock(WebformSubmissionInterface::class);
+    $submission->method('getElementData')
+      ->willReturnCallback(function (string $field) use ($parent_number, $cpr) {
+        return $field === "parent{$parent_number}_cpr" ? $cpr : NULL;
+      });
+    $submission->method('id')->willReturn($sid);
+    $submission->method('uuid')->willReturn($uuid);
+    return $submission;
+  }
+
+  /**
+   * @covers ::verify
+   */
+  public function testVerifyReturnsMatchOnEqualDigits(): void {
+    $this->sessionManager->method('getCprFromSession')
+      ->with('wf-1')
+      ->willReturn('0101001234');
+
+    $this->logger->expects($this->once())->method('info');
+    $this->auditLogger->expects($this->once())
+      ->method('logCprLookup')
+      ->with('0101001234', 'parent_approval_cpr_match', 'success', $this->anything());
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MATCH,
+      $this->verifier->verify($this->submission(1, '0101001234'), 1, 'wf-1'),
+    );
+  }
+
+  /**
+   * Hyphenated input on one side and digits-only on the other still match.
+   *
+   * @covers ::verify
+   * @covers ::normaliseCpr
+   */
+  public function testVerifyReturnsMatchAfterNormalisation(): void {
+    $this->sessionManager->method('getCprFromSession')->willReturn('010100-1234');
+
+    $this->auditLogger->expects($this->once())
+      ->method('logCprLookup')
+      ->with('0101001234', 'parent_approval_cpr_match', 'success', $this->anything());
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MATCH,
+      $this->verifier->verify($this->submission(2, '0101001234'), 2, 'wf-2'),
+    );
+  }
+
+  /**
+   * Mismatch: both CPRs present but different - audit log records hashes only.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyReturnsMismatchAndLogsHashedAudit(): void {
+    $this->sessionManager->method('getCprFromSession')->willReturn('1212129999');
+
+    $captured_context = NULL;
+    $this->auditLogger->expects($this->once())
+      ->method('logCprLookup')
+      ->willReturnCallback(
+        function ($cpr, $purpose, $status, $context) use (&$captured_context) {
+          $captured_context = ['cpr' => $cpr, 'purpose' => $purpose, 'status' => $status, 'context' => $context];
+        }
+      );
+    $this->logger->expects($this->once())->method('warning');
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MISMATCH,
+      $this->verifier->verify($this->submission(1, '0101001234'), 1, 'wf-3'),
+    );
+
+    $this->assertSame('parent_approval_cpr_mismatch', $captured_context['purpose']);
+    $this->assertSame('failure', $captured_context['status']);
+    // Hashed values land in the context; raw CPRs must NEVER appear there.
+    $this->assertSame(hash('sha256', '0101001234'), $captured_context['context']['expected_hash']);
+    $this->assertSame(hash('sha256', '1212129999'), $captured_context['context']['asserted_hash']);
+    $this->assertArrayNotHasKey('expected', $captured_context['context']);
+    $this->assertArrayNotHasKey('asserted', $captured_context['context']);
+  }
+
+  /**
+   * MitID session has no CPR claim - upstream IdP failure.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyReturnsMissingMitidCprWhenSessionEmpty(): void {
+    $this->sessionManager->method('getCprFromSession')->willReturn(NULL);
+
+    $this->logger->expects($this->once())->method('warning');
+    $this->auditLogger->expects($this->once())
+      ->method('logCprLookup')
+      ->with('wf-4', 'parent_approval_cpr_missing', 'failure', $this->anything());
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MISSING_MITID_CPR,
+      $this->verifier->verify($this->submission(1, '0101001234'), 1, 'wf-4'),
+    );
+  }
+
+  /**
+   * Submission lacks parent_<N>_cpr - configuration error.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyReturnsMissingExpectedCprWhenSubmissionLacksField(): void {
+    $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
+
+    $this->logger->expects($this->once())->method('error');
+    $this->auditLogger->expects($this->once())
+      ->method('logCprLookup')
+      ->with('0101001234', 'parent_approval_cpr_missing_expected', 'failure', $this->anything());
+
+    // submission(1, NULL) returns NULL for parent1_cpr.
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR,
+      $this->verifier->verify($this->submission(1, NULL), 1, 'wf-5'),
+    );
+  }
+
+  /**
+   * Empty asserted CPR (empty string from session) routes to missing-MitID,
+   * not to mismatch - the empty value is treated as "no claim", matching
+   * the controller's documented UX path.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyTreatsEmptyAssertedAsMissing(): void {
+    $this->sessionManager->method('getCprFromSession')->willReturn('');
+
+    $this->auditLogger->expects($this->once())
+      ->method('logCprLookup')
+      ->with($this->anything(), 'parent_approval_cpr_missing', $this->anything(), $this->anything());
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MISSING_MITID_CPR,
+      $this->verifier->verify($this->submission(1, '0101001234'), 1, 'wf-6'),
+    );
+  }
+
+  /**
+   * @covers ::normaliseCpr
+   */
+  public function testNormaliseCprStripsHyphens(): void {
+    $this->assertSame('0101001234', $this->verifier->normaliseCpr('010100-1234'));
+  }
+
+  /**
+   * @covers ::normaliseCpr
+   */
+  public function testNormaliseCprStripsWhitespace(): void {
+    $this->assertSame('0101001234', $this->verifier->normaliseCpr(' 0101 00 1234 '));
+  }
+
+  /**
+   * Leading zeros are preserved - CPRs starting with '0101' are valid.
+   *
+   * @covers ::normaliseCpr
+   */
+  public function testNormaliseCprPreservesLeadingZeros(): void {
+    $cpr = '0101501234';
+    $normalised = $this->verifier->normaliseCpr($cpr);
+    $this->assertSame($cpr, $normalised);
+    $this->assertSame('0', $normalised[0]);
+  }
+
+  /**
+   * @covers ::normaliseCpr
+   */
+  public function testNormaliseCprReturnsEmptyForOnlyNonDigits(): void {
+    $this->assertSame('', $this->verifier->normaliseCpr('---'));
+    $this->assertSame('', $this->verifier->normaliseCpr(''));
+  }
+
+  /**
+   * Result constants are stable strings; the controller switches on them.
+   */
+  public function testResultConstantsAreStable(): void {
+    $this->assertSame('match', ParentCprVerifier::RESULT_MATCH);
+    $this->assertSame('mismatch', ParentCprVerifier::RESULT_MISMATCH);
+    $this->assertSame('missing_mitid_cpr', ParentCprVerifier::RESULT_MISSING_MITID_CPR);
+    $this->assertSame('missing_expected_cpr', ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
@@ -198,9 +198,11 @@ class ParentCprVerifierTest extends UnitTestCase {
   }
 
   /**
-   * Empty asserted CPR (empty string from session) routes to missing-MitID,
-   * not to mismatch - the empty value is treated as "no claim", matching
-   * the controller's documented UX path.
+   * Empty asserted CPR routes to missing-MitID, not to mismatch.
+   *
+   * An empty session value is treated as "no claim" rather than a competing
+   * claim that disagrees with the parent CPR, matching the controller's
+   * documented UX path.
    *
    * @covers ::verify
    */

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
@@ -291,9 +291,10 @@ XML;
   }
 
   /**
-   * Service + user tasks of every recognised type are returned; non-matching
-   * tasks ('process data') are dropped because determineActionType returns
-   * 'none'.
+   * Service + user tasks of every recognised type are returned.
+   *
+   * Non-matching tasks ('process data') are dropped because
+   * determineActionType returns 'none'.
    *
    * @covers ::getConfigurableActions
    * @covers ::determineActionType

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/WorkflowTemplateMetadataTest.php
@@ -1,0 +1,573 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_workflows\Service\BpmnTemplateManager;
+use Drupal\aabenforms_workflows\Service\WorkflowTemplateMetadata;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for WorkflowTemplateMetadata service.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\WorkflowTemplateMetadata
+ * @group aabenforms_workflows
+ */
+class WorkflowTemplateMetadataTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   */
+  protected WorkflowTemplateMetadata $sut;
+
+  /**
+   * Mock BPMN template manager.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\BpmnTemplateManager|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $templateManager;
+
+  /**
+   * Mock logger.
+   *
+   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->templateManager = $this->createMock(BpmnTemplateManager::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->logger);
+
+    $this->sut = new WorkflowTemplateMetadata($this->templateManager, $loggerFactory);
+  }
+
+  /**
+   * Builds a SimpleXMLElement BPMN document for fixtures.
+   *
+   * @param string $process_body
+   *   Inner XML for the bpmn:process element.
+   * @param string $prefix
+   *   Either 'bpmn' or 'bpmn2', so we can exercise both namespace prefixes.
+   * @param string|null $namespace
+   *   Override the namespace URI; defaults to the canonical BPMN one.
+   */
+  protected function bpmn(string $process_body, string $prefix = 'bpmn', ?string $namespace = NULL): \SimpleXMLElement {
+    $ns = $namespace ?? 'http://www.omg.org/spec/BPMN/20100524/MODEL';
+    // The id attribute on <definitions> matters more than it looks: SimpleXML's
+    // (bool) cast on a root element with only namespaced children evaluates to
+    // FALSE - production's `if (!$xml) return [];` would early-return on every
+    // fixture without it. Real BPMN files always carry id + targetNamespace,
+    // which is why production never hit this. Mirror that here.
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<{$prefix}:definitions xmlns:{$prefix}="{$ns}" id="Definitions_test" targetNamespace="http://aabenforms.dk/test">
+  <{$prefix}:process id="Process_1" name="Test Process">
+    {$process_body}
+  </{$prefix}:process>
+</{$prefix}:definitions>
+XML;
+    return simplexml_load_string($xml);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyForNullId(): void {
+    $this->templateManager->expects($this->never())->method('loadTemplate');
+    $this->assertSame([], $this->sut->getTemplateParameters(NULL));
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyForEmptyId(): void {
+    $this->templateManager->expects($this->never())->method('loadTemplate');
+    $this->assertSame([], $this->sut->getTemplateParameters(''));
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyWhenLoadTemplateReturnsNull(): void {
+    $this->templateManager->method('loadTemplate')->willReturn(NULL);
+    $this->assertSame([], $this->sut->getTemplateParameters('any_id'));
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersReturnsEmptyWhenNoBpmnNamespace(): void {
+    // A document with no bpmn or bpmn2 namespace registered.
+    $xml = simplexml_load_string('<root><child>x</child></root>');
+    $this->templateManager->method('loadTemplate')->willReturn($xml);
+    $this->assertSame([], $this->sut->getTemplateParameters('weird_template'));
+  }
+
+  /**
+   * Parameters declared in documentation are extracted via the bpmn prefix.
+   *
+   * Also covers the parseOptions helper through a select-type parameter.
+   *
+   * @covers ::getTemplateParameters
+   * @covers ::parseOptions
+   * @covers ::addDefaultParameters
+   */
+  public function testGetTemplateParametersExtractsFromDocumentationBpmnNs(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      Description.
+      <parameters>
+        <parameter id="topic" label="Topic" type="text" required="true" default="hello" description="The subject"/>
+        <parameter id="severity" label="Severity" type="select" required="false" default="low">
+          <options>
+            <option value="low">Low</option>
+            <option value="high">High</option>
+          </options>
+        </parameter>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body, 'bpmn'));
+
+    $params = $this->sut->getTemplateParameters('unknown_id');
+
+    // The unknown id only adds the workflow_label default, plus the two from the doc.
+    $this->assertArrayHasKey('topic', $params);
+    $this->assertArrayHasKey('severity', $params);
+    $this->assertArrayHasKey('workflow_label', $params);
+    $this->assertSame('Topic', $params['topic']['label']);
+    $this->assertSame('text', $params['topic']['type']);
+    $this->assertTrue($params['topic']['required']);
+    $this->assertSame('hello', $params['topic']['default']);
+    $this->assertSame('The subject', $params['topic']['description']);
+    $this->assertSame([], $params['topic']['options']);
+    $this->assertFalse($params['severity']['required']);
+    $this->assertSame(['low' => 'Low', 'high' => 'High'], $params['severity']['options']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   */
+  public function testGetTemplateParametersWorksWithBpmn2Prefix(): void {
+    $body = <<<XML
+    <bpmn2:documentation>
+      <parameters>
+        <parameter id="x" label="X" type="text" required="false"/>
+      </parameters>
+    </bpmn2:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')
+      ->willReturn($this->bpmn($body, 'bpmn2'));
+
+    $params = $this->sut->getTemplateParameters('unknown_id');
+    $this->assertArrayHasKey('x', $params);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::addDefaultParameters
+   * @covers ::getBuildingPermitDefaults
+   */
+  public function testGetTemplateParametersAddsBuildingPermitDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('building_permit');
+
+    $expected_keys = [
+      'workflow_label',
+      'applicant_email_field',
+      'cpr_field',
+      'address_field',
+      'caseworker_email',
+      'approval_deadline_days',
+      'sbsys_integration',
+    ];
+    foreach ($expected_keys as $key) {
+      $this->assertArrayHasKey($key, $params, "Missing $key");
+    }
+    $this->assertSame('integer', $params['approval_deadline_days']['type']);
+    $this->assertSame('boolean', $params['sbsys_integration']['type']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getContactFormDefaults
+   */
+  public function testGetTemplateParametersAddsContactFormDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('contact_form');
+
+    $this->assertArrayHasKey('submitter_email_field', $params);
+    $this->assertArrayHasKey('recipient_email', $params);
+    $this->assertArrayHasKey('auto_reply', $params);
+    $this->assertArrayHasKey('confirmation_message', $params);
+    $this->assertSame('boolean', $params['auto_reply']['type']);
+    $this->assertSame('textarea', $params['confirmation_message']['type']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getCompanyVerificationDefaults
+   */
+  public function testGetTemplateParametersAddsCompanyVerificationDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('company_verification');
+
+    $this->assertArrayHasKey('cvr_field', $params);
+    $this->assertArrayHasKey('contact_email_field', $params);
+    $this->assertArrayHasKey('verification_email', $params);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getFoiRequestDefaults
+   */
+  public function testGetTemplateParametersAddsFoiRequestDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('foi_request');
+
+    $this->assertArrayHasKey('requester_email_field', $params);
+    $this->assertArrayHasKey('foi_officer_email', $params);
+    $this->assertArrayHasKey('response_deadline_days', $params);
+    $this->assertSame('integer', $params['response_deadline_days']['type']);
+  }
+
+  /**
+   * @covers ::getTemplateParameters
+   * @covers ::getAddressChangeDefaults
+   */
+  public function testGetTemplateParametersAddsAddressChangeDefaults(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('address_change');
+
+    $this->assertArrayHasKey('cpr_field', $params);
+    $this->assertArrayHasKey('new_address_field', $params);
+    $this->assertArrayHasKey('notification_email', $params);
+  }
+
+  /**
+   * Unknown template id only adds the common workflow_label parameter.
+   *
+   * @covers ::getTemplateParameters
+   * @covers ::addDefaultParameters
+   */
+  public function testGetTemplateParametersUnknownIdAddsOnlyWorkflowLabel(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $params = $this->sut->getTemplateParameters('not_a_template');
+
+    $this->assertSame(['workflow_label'], array_keys($params));
+    $this->assertTrue($params['workflow_label']['required']);
+  }
+
+  /**
+   * @covers ::getConfigurableActions
+   */
+  public function testGetConfigurableActionsReturnsEmptyWhenLoadTemplateFails(): void {
+    $this->templateManager->method('loadTemplate')->willReturn(NULL);
+    $this->assertSame([], $this->sut->getConfigurableActions('any'));
+  }
+
+  /**
+   * @covers ::getConfigurableActions
+   */
+  public function testGetConfigurableActionsReturnsEmptyForNoNamespace(): void {
+    $xml = simplexml_load_string('<definitions><process/></definitions>');
+    $this->templateManager->method('loadTemplate')->willReturn($xml);
+    $this->assertSame([], $this->sut->getConfigurableActions('any'));
+  }
+
+  /**
+   * Service + user tasks of every recognised type are returned; non-matching
+   * tasks ('process data') are dropped because determineActionType returns
+   * 'none'.
+   *
+   * @covers ::getConfigurableActions
+   * @covers ::determineActionType
+   * @covers ::getActionConfigurableFields
+   */
+  public function testGetConfigurableActionsClassifiesTasks(): void {
+    $body = <<<XML
+    <bpmn:serviceTask id="t_email" name="Send notification email"/>
+    <bpmn:serviceTask id="t_lookup" name="Lookup citizen data"/>
+    <bpmn:serviceTask id="t_audit" name="Log audit entry"/>
+    <bpmn:userTask id="t_approval" name="Review and approval"/>
+    <bpmn:userTask id="t_auth" name="MitID auth check"/>
+    <bpmn:serviceTask id="t_skip" name="Process data crunching"/>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $actions = $this->sut->getConfigurableActions('any');
+
+    $this->assertArrayHasKey('t_email', $actions);
+    $this->assertArrayHasKey('t_lookup', $actions);
+    $this->assertArrayHasKey('t_audit', $actions);
+    $this->assertArrayHasKey('t_approval', $actions);
+    $this->assertArrayHasKey('t_auth', $actions);
+    // 'Process data' contains none of the trigger keywords; should be skipped.
+    $this->assertArrayNotHasKey('t_skip', $actions);
+
+    $this->assertSame('email', $actions['t_email']['type']);
+    $this->assertSame('data_lookup', $actions['t_lookup']['type']);
+    $this->assertSame('audit', $actions['t_audit']['type']);
+    $this->assertSame('approval', $actions['t_approval']['type']);
+    $this->assertSame('authentication', $actions['t_auth']['type']);
+
+    // Email type exposes 3 configurable fields, approval exposes 2, others 0.
+    $this->assertSame(['subject', 'body', 'recipient'], array_keys($actions['t_email']['configurable_fields']));
+    $this->assertSame(['page_title', 'instructions'], array_keys($actions['t_approval']['configurable_fields']));
+    $this->assertSame([], $actions['t_lookup']['configurable_fields']);
+    $this->assertSame([], $actions['t_audit']['configurable_fields']);
+    $this->assertSame([], $actions['t_auth']['configurable_fields']);
+  }
+
+  /**
+   * @covers ::getConfigurableActions
+   */
+  public function testGetConfigurableActionsReturnsEmptyForUnnamedTasks(): void {
+    // Tasks without trigger keywords resolve to 'none' and are dropped.
+    $body = '<bpmn:serviceTask id="t1" name="Crunch numbers"/>';
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+    $this->assertSame([], $this->sut->getConfigurableActions('any'));
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   * @covers ::t
+   */
+  public function testValidateConfigurationFlagsMissingRequiredParameter(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="recipient_email" label="Recipient" type="email" required="true"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', ['webform_id' => 'wf_1']);
+
+    $this->assertNotEmpty($errors);
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Recipient', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationFlagsMissingWebformId(): void {
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn(''));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'parameters' => ['workflow_label' => 'Test'],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Webform must be selected', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationFlagsInvalidEmail(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="contact" label="Contact" type="email" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'contact' => 'not-an-email',
+      ],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Invalid email', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationFlagsInvalidInteger(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'days' => 'abc',
+      ],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Invalid integer', $combined);
+  }
+
+  /**
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationAcceptsValidPayload(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="contact" label="Contact" type="email" required="true"/>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'contact' => 'a@b.dk',
+        'days' => '7',
+      ],
+    ]);
+
+    $this->assertSame([], $errors);
+  }
+
+  /**
+   * Empty parameter values for typed fields skip the type validation branch.
+   *
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationSkipsEmptyTypedValues(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="contact" label="Contact" type="email" required="false"/>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        'contact' => '',
+        'days' => '',
+      ],
+    ]);
+
+    $this->assertSame([], $errors);
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewReturnsEmptyForUnknownTemplate(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'other' => ['description' => 'Other'],
+    ]);
+    $this->assertSame([], $this->sut->getTemplatePreview('missing'));
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewReturnsEmptyWhenLoadTemplateFails(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'building_permit' => ['description' => 'Building permit flow'],
+    ]);
+    $this->templateManager->method('loadTemplate')->willReturn(NULL);
+    $this->assertSame([], $this->sut->getTemplatePreview('building_permit'));
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewReturnsEmptyForNoNamespace(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'building_permit' => ['description' => 'Building permit flow'],
+    ]);
+    $xml = simplexml_load_string('<definitions/>');
+    $this->templateManager->method('loadTemplate')->willReturn($xml);
+    $this->assertSame([], $this->sut->getTemplatePreview('building_permit'));
+  }
+
+  /**
+   * @covers ::getTemplatePreview
+   */
+  public function testGetTemplatePreviewBuildsStepsAndDescription(): void {
+    $this->templateManager->method('getAvailableTemplates')->willReturn([
+      'building_permit' => ['description' => 'Building permit flow'],
+    ]);
+    $body = <<<XML
+    <bpmn:serviceTask id="t1" name="Send acknowledgement"/>
+    <bpmn:userTask id="t2" name="Caseworker review"/>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $preview = $this->sut->getTemplatePreview('building_permit');
+
+    $this->assertSame('Building permit flow', $preview['description']);
+    $this->assertNull($preview['diagram']);
+    $this->assertCount(2, $preview['steps']);
+    $this->assertSame(1, $preview['steps'][0]['step']);
+    $this->assertSame('Send acknowledgement', $preview['steps'][0]['name']);
+    $this->assertSame('serviceTask', $preview['steps'][0]['type']);
+    $this->assertSame(2, $preview['steps'][1]['step']);
+    $this->assertSame('Caseworker review', $preview['steps'][1]['name']);
+    $this->assertSame('userTask', $preview['steps'][1]['type']);
+  }
+
+  /**
+   * Float values are rejected by the integer check (cast to int loses data).
+   *
+   * @covers ::validateConfiguration
+   */
+  public function testValidateConfigurationRejectsFloatForInteger(): void {
+    $body = <<<XML
+    <bpmn:documentation>
+      <parameters>
+        <parameter id="days" label="Days" type="integer" required="false"/>
+      </parameters>
+    </bpmn:documentation>
+XML;
+    $this->templateManager->method('loadTemplate')->willReturn($this->bpmn($body));
+
+    $errors = $this->sut->validateConfiguration('any', [
+      'webform_id' => 'wf_1',
+      'parameters' => [
+        'workflow_label' => 'Test',
+        // is_numeric is TRUE but intval(7.5) != '7.5' so this should error.
+        'days' => '7.5',
+      ],
+    ]);
+
+    $combined = implode("\n", $errors);
+    $this->assertStringContainsString('Invalid integer', $combined);
+  }
+
+}


### PR DESCRIPTION
Branched from \`coverage/big-push\` (PR #60). Three coordinated commits, each meaningful on its own.

## 1. Issue #54: parent-approval CPR-match security gate (commit f3f3e0e)

Without this gate, any holder of an approval-token URL can authenticate with any MitID account and approve another family's submission. End-to-end fix:

- New \`ParentCprVerifier\` service (230 LoC) with a four-way result protocol: match / mismatch / missing-MitID-CPR / missing-expected-CPR.
- Constant-time \`hash_equals\` after digit-only normalisation - hyphenated CPRs (\`010100-1234\`) compare equal to digit-only (\`0101001234\`); leading zeros preserved.
- Mismatch audit log records sha256 hashes of both CPRs in the context array - raw values never persist. Lets investigators detect "same wrong CPR being retried" without exposing the data.
- \`ParentApprovalController\` wires the service into the post-MitID handoff. Mismatch returns 403 with sparse Danish UX text; missing-MitID-CPR returns 502; moderation_state stays at \`awaiting_parent\` on every failure path.
- 11 unit tests, 53 assertions, locking in normalisation behaviour, audit-row shape, result-constant stability.

## 2. WorkflowTemplateInstantiator kernel coverage (commit 731a2b3)

The single biggest 0%-coverage target in the project (790 LoC). 11 kernel tests, 128 assertions, exercising real BPMN templates from \`workflows/\`:

- \`instantiate()\` for \`contact_form\` (simple) and \`building_permit\` (gateways + 22 service tasks).
- Validation gate for unknown templates, missing required parameters.
- BPMN XML override path (wizard-edited model) parses through the walker; malformed override surfaces a typed error.
- \`deleteInstance()\` cascades to both \`template_instance.<id>\` and \`eca.eca.<id>\` configs.
- \`getInstances()\` round-trip.
- \`generateEmailTemplates()\` persists action subject/body/recipient.

Notes:
- \`strictConfigSchema = FALSE\` because the instantiator emits ECA action configs whose shape lives in bpmn_io / modeler_api runtime, not static schema.
- The ConfigFactory cache caveat is documented in the test - post-delete assertions go through \`config.storage->exists()\` to bypass the cache.

## 3. CI coverage gate + docs/TESTING.md (commit eb24a45)

\`ci.yml\` gains an \"Enforce minimum coverage threshold\" step that fails the job if Line coverage drops below 20%. Threshold is intentionally set at the current floor; bump in lockstep with team agreement, never lower.

\`docs/TESTING.md\` codifies the methodology built across PRs #59, #60, and this one:

- Test-rot triage (the 4 buckets: PHPUnit 11 deprecations, signature drift, misdiagnosed skip, genuine refactor).
- Multi-event-type service test pattern.
- The \`(bool) SimpleXMLElement\` footgun.
- ECA 3.1+ kernel-test \`modeler_api\` requirement.
- Setter-injected execution collector.
- Before-you-skip checklist.

## Suite delta

| | Before this PR | After |
|---|---:|---:|
| Total tests | 323 | **402** |
| Skipped | 46 | **28** |
| Assertions | 1177 | **1685** |
| Largest 0% file | WorkflowTemplateInstantiator (790 LoC) | **covered** |
| CI coverage gate | none | **20% floor** |

## What's NOT in this PR

- **Containerized Playwright auth unblock** (Agent 2 of the original five-agent plan) - hit the agent usage limit before producing output. Deferred to a follow-up.
- **PHPUnit 11 deprecation sweep** (Agent 4) - same. The 253 deprecations are still there but harmless until PHPUnit 12. Deferred.

## Test plan

- [x] \`ddev exec ./vendor/bin/phpunit -c phpunit.xml --filter ParentCprVerifierTest\` - 11/11 / 53 assertions
- [x] \`ddev exec ./vendor/bin/phpunit -c phpunit.xml --filter WorkflowTemplateInstantiatorTest\` - 11/11 / 128 assertions
- [x] Full \`unit,kernel\` suite - 402 / 1685 / 0 failures / 28 skipped
- [ ] CI runs PHPCS, PHPStan, PHPUnit, both Composer matrix runs, new coverage threshold step
- [ ] Coverage ≥ 20% on the new gate