### PR TITLE
Pin Composer to 2.9.8 in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: composer:v2
+          tools: composer:2.9.8
           coverage: none
 
       - name: Get composer cache directory
@@ -87,7 +87,7 @@ jobs:
         with:
           php-version: 8.4
           extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql, dom, filter, gd, json, pdo, mysql
-          tools: composer:v2
+          tools: composer:2.9.8
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -25,7 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.4
-          tools: composer:v2
+          tools: composer:2.9.8
           coverage: none
 
       - name: Cache dependencies
@@ -55,7 +55,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.4
-          tools: composer:v2
+          tools: composer:2.9.8
           coverage: none
 
       - name: Install Dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          tools: composer:v2
+          tools: composer:2.9.8
 
       - name: Run Composer Audit
         run: composer audit
@@ -35,7 +35,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          tools: composer:v2
+          tools: composer:2.9.8
 
       - name: Check for outdated Drupal packages
         run: composer outdated 'drupal/*' --direct


### PR DESCRIPTION
## Summary
- Pin `tools: composer:2.9.8` (was `composer:v2`) in `ci.yml`, `coding-standards.yml`, `security.yml`
- Mitigates the Composer GitHub Actions token-disclosure issue fixed in 2.9.8 / 2.2.28: https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/

## Why pin instead of leaving the v2 alias?
`composer:v2` floats to the latest 2.x via shivammathur/setup-php. Once 2.9.8 is the latest tag, the floating alias picks it up automatically — but pinning makes the fixed-version intent reviewable and prevents a future regression from silently downgrading our exposure surface.

## Test plan
- [ ] CI runs green on this PR (ci.yml + coding-standards.yml fire on PR)
- [ ] Verify the resolved Composer version in the "Setup PHP" step logs reads `Composer version 2.9.8`
- [ ] Next scheduled security.yml run completes without error