### PR TITLE
Adopt ECA Workflow Modeler (drupal/modeler) for all 18 flows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "drupal/jsonapi_extras": "^3.0",
         "drupal/jsonapi_frontend_webform": "^1.0",
         "drupal/key": "^1.22",
+        "drupal/modeler": "^1.0",
         "drupal/openid_connect": "^3.0@alpha",
         "drupal/real_aes": "^2.6",
         "drupal/redis": "^1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a71a20d1fbc1b77fd854ebb342b7ed47",
+    "content-hash": "e1e0090021870f46b40799b48ddc9210",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2346,6 +2346,61 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/key",
                 "issues": "http://drupal.org/project/key"
+            }
+        },
+        {
+            "name": "drupal/modeler",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/modeler.git",
+                "reference": "1.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/modeler-1.0.3.zip",
+                "reference": "1.0.3",
+                "shasum": "d66db9681924f0c8746bf1d10cb25efac5362e3c"
+            },
+            "require": {
+                "drupal/core": "^11.3 || ^12.0",
+                "drupal/modeler_api": "^1.1",
+                "php": ">=8.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.3",
+                    "datestamp": "1776351695",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "boromino",
+                    "homepage": "https://www.drupal.org/user/859722"
+                },
+                {
+                    "name": "danielspeicher",
+                    "homepage": "https://www.drupal.org/user/3621778"
+                },
+                {
+                    "name": "jurgenhaas",
+                    "homepage": "https://www.drupal.org/user/168924"
+                }
+            ],
+            "description": "A modern, React Flow based modeler for Drupal that integrates into Modeler API and supports platforms like ECA, AI Agents, etc.",
+            "homepage": "https://www.drupal.org/project/modeler",
+            "support": {
+                "source": "https://drupal.org/project/modeler",
+                "issues": "https://drupal.org/project/issues/modeler"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -31,6 +31,7 @@ module:
   jsonapi_frontend: 0
   jsonapi_frontend_webform: 0
   key: 0
+  modeler: 0
   modeler_api: 0
   mysql: 0
   node: 0

--- a/config/sync/eca.eca.address_change_flow.yml
+++ b/config/sync/eca.eca.address_change_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: address_change_flow
 id: address_change_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.association_booking_flow.yml
+++ b/config/sync/eca.eca.association_booking_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: association_booking_flow
 id: association_booking_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -11,7 +11,7 @@ dependencies:
     - modeler_api
 third_party_settings:
   modeler_api:
-    modeler_id: fallback
+    modeler_id: workflow_modeler
     label: building_permit_flow
 id: building_permit_flow
 weight: 0

--- a/config/sync/eca.eca.caseworker_review_flow.yml
+++ b/config/sync/eca.eca.caseworker_review_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: caseworker_review_flow
 id: caseworker_review_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.citizen_service_application_flow.yml
+++ b/config/sync/eca.eca.citizen_service_application_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: citizen_service_application_flow
 id: citizen_service_application_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.company_verification_flow.yml
+++ b/config/sync/eca.eca.company_verification_flow.yml
@@ -11,7 +11,7 @@ dependencies:
     - modeler_api
 third_party_settings:
   modeler_api:
-    modeler_id: fallback
+    modeler_id: workflow_modeler
     label: company_verification_flow
 id: company_verification_flow
 weight: 0

--- a/config/sync/eca.eca.foi_request_flow.yml
+++ b/config/sync/eca.eca.foi_request_flow.yml
@@ -10,7 +10,7 @@ dependencies:
     - modeler_api
 third_party_settings:
   modeler_api:
-    modeler_id: fallback
+    modeler_id: workflow_modeler
     label: foi_request_flow
 id: foi_request_flow
 weight: 0

--- a/config/sync/eca.eca.hr_onboarding_flow.yml
+++ b/config/sync/eca.eca.hr_onboarding_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: hr_onboarding_flow
 id: hr_onboarding_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.marriage_booking_flow.yml
+++ b/config/sync/eca.eca.marriage_booking_flow.yml
@@ -11,7 +11,7 @@ dependencies:
     - modeler_api
 third_party_settings:
   modeler_api:
-    modeler_id: fallback
+    modeler_id: workflow_modeler
     label: marriage_booking_flow
 id: marriage_booking_flow
 weight: 0

--- a/config/sync/eca.eca.med_election_nomination_flow.yml
+++ b/config/sync/eca.eca.med_election_nomination_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: med_election_nomination_flow
 id: med_election_nomination_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.med_election_voting_flow.yml
+++ b/config/sync/eca.eca.med_election_voting_flow.yml
@@ -6,6 +6,11 @@ dependencies:
     - aabenforms_workflows
     - eca_base
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: med_election_voting_flow
 id: med_election_voting_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.mileage_expense_flow.yml
+++ b/config/sync/eca.eca.mileage_expense_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: mileage_expense_flow
 id: mileage_expense_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.parent1_approval_flow.yml
+++ b/config/sync/eca.eca.parent1_approval_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: parent1_approval_flow
 id: parent1_approval_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.parent2_approval_flow.yml
+++ b/config/sync/eca.eca.parent2_approval_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: parent2_approval_flow
 id: parent2_approval_flow
 weight: null
 template: null

--- a/config/sync/eca.eca.parent_dual_approval_working.yml
+++ b/config/sync/eca.eca.parent_dual_approval_working.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: parent_dual_approval_working
 id: parent_dual_approval_working
 weight: null
 template: null

--- a/config/sync/eca.eca.parent_submission_simple.yml
+++ b/config/sync/eca.eca.parent_submission_simple.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: parent_submission_simple
 id: parent_submission_simple
 weight: null
 template: null

--- a/config/sync/eca.eca.parking_permit_flow.yml
+++ b/config/sync/eca.eca.parking_permit_flow.yml
@@ -11,7 +11,7 @@ dependencies:
     - modeler_api
 third_party_settings:
   modeler_api:
-    modeler_id: fallback
+    modeler_id: workflow_modeler
     label: parking_permit_flow
 id: parking_permit_flow
 weight: 0

--- a/config/sync/eca.eca.phone_declaration_flow.yml
+++ b/config/sync/eca.eca.phone_declaration_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: phone_declaration_flow
 id: phone_declaration_flow
 weight: null
 template: null

--- a/config/sync/user.role.case_worker.yml
+++ b/config/sync/user.role.case_worker.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - aabenforms_core
     - aabenforms_workflows
+    - modeler_api
     - system
     - webform
 id: case_worker
@@ -16,5 +17,10 @@ permissions:
   - 'access webform api'
   - 'administer workflows'
   - 'edit any webform submission'
+  - 'modeler api collection eca'
+  - 'modeler api replay eca'
+  - 'modeler api test eca'
+  - 'modeler api view eca'
+  - 'modeler api view eca with workflow_modeler'
   - 'use text format webform_default'
   - 'view any webform submission'

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.info.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - webform:webform
   - modeler_api:modeler_api
   - bpmn_io:bpmn_io
+  - modeler:modeler


### PR DESCRIPTION
## Summary

Adopts **drupal/modeler 1.0.3** (the new React Flow "Workflow Modeler") as the default visual editor for all 18 ECA flows, replacing the implicit `fallback` editor. It coexists with `bpmn_io` via the Modeler API - the same models open in either tool.

This is **Phase 1** (core editor adoption) of the upgrade. Phases 2-3 (Playwright execution-replay coverage, public standalone-viewer diagrams, Recipe-export template library) follow in separate PRs.

### Why this fits us
- Our 18 flows are all hand-authored `modeler_id: fallback` YAML with **no stored diagram**. `bpmn_io` needs stored diagram XML; the Workflow Modeler auto-lays-out from the ECA graph via upstream conversion, so it is a strictly better fit for exactly the flows we have.
- **Execution Replay with token inspection** is the headline debugging win for the hardest flows (`parent_dual_approval_working`, the Digital Post / NemLogin handoffs).
- Preconditions already met: Drupal 11.3.8 and `modeler_api` 1.1.2 satisfy the module's `^11.3` / `^1.1` requirements. Ships pre-built React assets, so no pipeline build step.

## Changes
- `composer.json` / `composer.lock`: require `drupal/modeler:^1.0`
- `core.extension.yml`: enable `modeler`
- 18 `eca.eca.*.yml`: set `third_party_settings.modeler_api.modeler_id: workflow_modeler` (+ `modeler_api` dep)
- `user.role.case_worker.yml`: grant `view` / `test` / `replay` (no `edit`); `administrator` keeps full access via `is_admin`
- `aabenforms_workflows.info.yml`: add `modeler` dependency

## Verification (DDEV)
- `drush config:status` clean; `modeler` enabled alongside `bpmn_io` and `eca_cm`
- All 18 models resolve to `workflow_modeler`
- `parent_dual_approval_working` renders with full auto-layout (dual-parent branches), **zero console errors**
- Execution Replay panel present; **Test** arms live capture
- `bpmn_io` still opens the same models (coexistence)
- `case_worker`: replay/test = yes, edit = no, `administer workflows` preserved
- **200 unit + kernel tests pass** (incl. kernel tests that install `aabenforms_workflows` with the new `modeler` dep)

## Note (pre-existing, out of scope)
`administer workflows` is referenced by 9 routes in `aabenforms_workflows` but is **not defined** by any `*.permissions.yml`, so it is an unregistered permission - those custom dashboard routes are currently admin-only regardless of role config. Preserved as-is here; worth a follow-up to define the permission.
