### PR TITLE
Make the #54 parent-CPR consent gate replayable (ECA action)

### DIFF
--- a/config/sync/eca.eca.parent1_approval_flow.yml
+++ b/config/sync/eca.eca.parent1_approval_flow.yml
@@ -44,6 +44,17 @@ actions:
       session_data_token: parent1_session
     successors:
       -
+        id: parent1_cpr_verify
+        condition: ''
+  parent1_cpr_verify:
+    label: 'Parent 1: Verify CPR Consent'
+    plugin: aabenforms_parent_cpr_verify
+    configuration:
+      parent_number: '1'
+      workflow_id_token: ''
+      result_token: parent1_cpr_consent
+    successors:
+      -
         id: parent1_cpr
         condition: ''
   parent1_cpr:

--- a/config/sync/eca.eca.parent2_approval_flow.yml
+++ b/config/sync/eca.eca.parent2_approval_flow.yml
@@ -44,6 +44,17 @@ actions:
       session_data_token: parent2_session
     successors:
       -
+        id: parent2_cpr_verify
+        condition: ''
+  parent2_cpr_verify:
+    label: 'Parent 2: Verify CPR Consent'
+    plugin: aabenforms_parent_cpr_verify
+    configuration:
+      parent_number: '2'
+      workflow_id_token: ''
+      result_token: parent2_cpr_consent
+    successors:
+      -
         id: parent2_cpr
         condition: ''
   parent2_cpr:

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ParentCprVerifyAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ParentCprVerifyAction.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: verify the MitID-asserted CPR matches the consenting parent.
+ *
+ * Wraps the authoritative parent-approval consent gate (ParentCprVerifier,
+ * issue #54) so the MATCH / MISMATCH decision runs inside the workflow and
+ * shows up as a token and a replay step. This does NOT replace the hard 403
+ * enforced in ParentApprovalController::mitidComplete() - it is the same
+ * decision surfaced into the flow for visibility and audit (defence in depth).
+ */
+#[Action(
+  id: 'aabenforms_parent_cpr_verify',
+  label: new TranslatableMarkup('Verify Parent CPR Consent'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Verifies the MitID-asserted CPR equals the expected parent CPR (issue #54 consent gate) and records the decision as a token and replay step.'),
+  version_introduced: '2.1.0',
+)]
+class ParentCprVerifyAction extends AabenFormsActionBase {
+
+  /**
+   * The parent-approval CPR verifier (issue #54 consent gate).
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ParentCprVerifier
+   */
+  protected ParentCprVerifier $cprVerifier;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->cprVerifier = $container->get('aabenforms_workflows.parent_cpr_verifier');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      // Which parent this step verifies (1 or 2).
+      'parent_number' => '1',
+      // Optional token holding the MitID workflow id. Leave empty to derive
+      // the deterministic id the approval controller uses (recommended).
+      'workflow_id_token' => '',
+      // Token to store the verification result (one of ParentCprVerifier's
+      // RESULT_* constants: match / mismatch / missing_mitid_cpr /
+      // missing_expected_cpr).
+      'result_token' => 'cpr_consent_result',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['parent_number'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Parent number'),
+      '#description' => $this->t('Which parent this consent check verifies.'),
+      '#options' => ['1' => $this->t('Parent 1'), '2' => $this->t('Parent 2')],
+      '#default_value' => $this->configuration['parent_number'],
+      '#required' => TRUE,
+    ];
+
+    $form['workflow_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Workflow ID token (optional)'),
+      '#description' => $this->t('Token holding the MitID workflow id. Leave empty to derive parent_approval_&lt;sid&gt;_p&lt;N&gt; - the id the approval controller stores the session under.'),
+      '#default_value' => $this->configuration['workflow_id_token'],
+    ];
+
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Token to store the consent decision (match / mismatch / missing_mitid_cpr / missing_expected_cpr).'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['parent_number'] = $form_state->getValue('parent_number');
+    $this->configuration['workflow_id_token'] = $form_state->getValue('workflow_id_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $resultToken = $this->configuration['result_token'] ?? 'cpr_consent_result';
+    $parentNumber = (int) ($this->configuration['parent_number'] ?? 1);
+    $submission = $this->getSubmission();
+
+    if ($submission === NULL) {
+      // No submission in context (e.g. a cross-fired event). Do not fail open:
+      // record the gate as unverified rather than silently passing.
+      $this->log('Parent CPR consent: no submission in context - not verified', [], 'info');
+      $this->setTokenValue($resultToken, ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR);
+      $this->recordStep('Parent CPR Consent Check', 'No submission in context - consent not verified', 'failed');
+      return;
+    }
+
+    // Resolve the MitID workflow id. Prefer an explicit token override; else
+    // derive the deterministic id the approval controller uses, so we read the
+    // same session it stored. MUST stay in sync with
+    // ParentApprovalController::mitidLogin()/mitidComplete().
+    $workflowId = $this->getTokenValue($this->configuration['workflow_id_token'] ?? '', '');
+    if ($workflowId === '') {
+      $workflowId = sprintf('parent_approval_%d_p%d', (int) $submission->id(), $parentNumber);
+    }
+
+    try {
+      // ParentCprVerifier performs the comparison and writes the audit trail
+      // (hashed CPRs, never raw) for every outcome.
+      $result = $this->cprVerifier->verify($submission, $parentNumber, $workflowId);
+      $this->setTokenValue($resultToken, $result);
+
+      [$description, $status] = match ($result) {
+        ParentCprVerifier::RESULT_MATCH => [
+          sprintf('MitID-asserted CPR matches parent %d - consent verified', $parentNumber),
+          'completed',
+        ],
+        ParentCprVerifier::RESULT_MISMATCH => [
+          sprintf('MitID-asserted CPR does NOT match parent %d - consent denied', $parentNumber),
+          'failed',
+        ],
+        ParentCprVerifier::RESULT_MISSING_MITID_CPR => [
+          'MitID returned no CPR claim - consent cannot be verified',
+          'failed',
+        ],
+        ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR => [
+          sprintf('Submission carries no parent %d CPR - consent not enforced (legacy form)', $parentNumber),
+          'completed',
+        ],
+        default => ['Unknown verification result', 'failed'],
+      };
+      $this->recordStep('Parent CPR Consent Check', $description, $status);
+    }
+    catch (\Throwable $e) {
+      // verify() does not throw today, but never fail open: on any error treat
+      // the gate as a mismatch (deny) and surface it.
+      $this->handleError($e, 'Parent CPR Consent Check');
+      $this->setTokenValue($resultToken, ParentCprVerifier::RESULT_MISMATCH);
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ParentCprVerifyActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ParentCprVerifyActionTest.php
@@ -143,8 +143,9 @@ class ParentCprVerifyActionTest extends UnitTestCase {
   }
 
   /**
-   * With no token override, the deterministic workflow id is derived and the
-   * parent number is passed through to the verifier.
+   * The deterministic workflow id and parent number reach the verifier.
+   *
+   * With no token override, the action derives parent_approval_<sid>_p<N>.
    *
    * @covers ::execute
    */

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ParentCprVerifyActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ParentCprVerifyActionTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\ParentCprVerifyAction;
+use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * Tests the ParentCprVerifyAction ECA plugin (issue #54 consent gate).
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\ParentCprVerifyAction
+ * @group aabenforms_workflows
+ */
+class ParentCprVerifyActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\ParentCprVerifyAction
+   */
+  protected ParentCprVerifyAction $action;
+
+  /**
+   * Mock parent CPR verifier.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ParentCprVerifier|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $cprVerifier;
+
+  /**
+   * Mock logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $logger;
+
+  /**
+   * Mock ECA token services.
+   *
+   * @var \Drupal\eca\Token\TokenInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $tokenServices;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $this->logger = $this->createMock(LoggerChannelInterface::class);
+
+    $this->tokenServices = $this->createMock(EcaTokenInterface::class);
+    $this->tokenServices->method('getTokenData')
+      ->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $this->tokenServices->method('addTokenData')
+      ->willReturnCallback(function ($name, $value) {
+        $this->tokenStorage[$name] = $value;
+        return $this->tokenServices;
+      });
+
+    $this->cprVerifier = $this->createMock(ParentCprVerifier::class);
+
+    $configuration = [
+      'parent_number' => '1',
+      'workflow_id_token' => '',
+      'result_token' => 'cpr_consent_result',
+    ];
+
+    $this->action = new ParentCprVerifyAction(
+      $configuration,
+      'aabenforms_parent_cpr_verify',
+      [],
+      $entityTypeManager,
+      $this->tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $this->logger
+    );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $reflection = new \ReflectionProperty($this->action, 'cprVerifier');
+    $reflection->setAccessible(TRUE);
+    $reflection->setValue($this->action, $this->cprVerifier);
+  }
+
+  /**
+   * Builds a webform submission mock and puts it in the token environment.
+   */
+  protected function seedSubmission(int $id = 42): WebformSubmissionInterface {
+    $submission = $this->createMock(WebformSubmissionInterface::class);
+    $submission->method('id')->willReturn($id);
+    $this->tokenStorage['webform_submission'] = $submission;
+    return $submission;
+  }
+
+  /**
+   * A MATCH result is stored on the result token.
+   *
+   * @covers ::execute
+   */
+  public function testMatchStored(): void {
+    $this->seedSubmission();
+    $this->cprVerifier->method('verify')->willReturn(ParentCprVerifier::RESULT_MATCH);
+
+    $this->action->execute();
+
+    $this->assertSame(ParentCprVerifier::RESULT_MATCH, $this->tokenStorage['cpr_consent_result']);
+  }
+
+  /**
+   * A MISMATCH result is stored on the result token (consent denied).
+   *
+   * @covers ::execute
+   */
+  public function testMismatchStored(): void {
+    $this->seedSubmission();
+    $this->cprVerifier->method('verify')->willReturn(ParentCprVerifier::RESULT_MISMATCH);
+
+    $this->action->execute();
+
+    $this->assertSame(ParentCprVerifier::RESULT_MISMATCH, $this->tokenStorage['cpr_consent_result']);
+  }
+
+  /**
+   * With no token override, the deterministic workflow id is derived and the
+   * parent number is passed through to the verifier.
+   *
+   * @covers ::execute
+   */
+  public function testDerivesDeterministicWorkflowId(): void {
+    $submission = $this->seedSubmission(99);
+
+    $this->cprVerifier->expects($this->once())
+      ->method('verify')
+      ->with($submission, 1, 'parent_approval_99_p1')
+      ->willReturn(ParentCprVerifier::RESULT_MATCH);
+
+    $this->action->execute();
+  }
+
+  /**
+   * An explicit workflow_id token overrides the derived id.
+   *
+   * @covers ::execute
+   */
+  public function testWorkflowIdTokenOverride(): void {
+    $submission = $this->seedSubmission(99);
+    $this->tokenStorage['my_wid'] = 'explicit-wid';
+    $config = new \ReflectionProperty($this->action, 'configuration');
+    $config->setAccessible(TRUE);
+    $config->setValue($this->action, [
+      'parent_number' => '1',
+      'workflow_id_token' => 'my_wid',
+      'result_token' => 'cpr_consent_result',
+    ]);
+
+    $this->cprVerifier->expects($this->once())
+      ->method('verify')
+      ->with($submission, 1, 'explicit-wid')
+      ->willReturn(ParentCprVerifier::RESULT_MATCH);
+
+    $this->action->execute();
+  }
+
+  /**
+   * No submission in context: do not fail open - record as not verified.
+   *
+   * @covers ::execute
+   */
+  public function testNoSubmissionDoesNotFailOpen(): void {
+    $this->cprVerifier->expects($this->never())->method('verify');
+
+    $this->action->execute();
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR,
+      $this->tokenStorage['cpr_consent_result']
+    );
+  }
+
+  /**
+   * If the verifier throws, the gate is denied (mismatch), never failed open.
+   *
+   * @covers ::execute
+   */
+  public function testNeverFailsOpenOnException(): void {
+    $this->seedSubmission();
+    $this->cprVerifier->method('verify')
+      ->willThrowException(new \RuntimeException('boom'));
+    $this->logger->expects($this->once())->method('error');
+
+    $this->action->execute();
+
+    $this->assertSame(ParentCprVerifier::RESULT_MISMATCH, $this->tokenStorage['cpr_consent_result']);
+  }
+
+  /**
+   * Default configuration exposes the expected keys.
+   *
+   * @covers ::defaultConfiguration
+   */
+  public function testDefaultConfiguration(): void {
+    $defaults = $this->action->defaultConfiguration();
+    $this->assertSame('1', $defaults['parent_number']);
+    $this->assertSame('', $defaults['workflow_id_token']);
+    $this->assertSame('cpr_consent_result', $defaults['result_token']);
+  }
+
+}


### PR DESCRIPTION
## Summary
Make the **issue #54 parent-CPR consent gate replayable**: a new ECA action wraps the existing `ParentCprVerifier` so its MATCH / MISMATCH decision runs inside the parent-approval flow and shows up as a **token** and a **replay step** in the Workflow Modeler.

## What it does
- New action `aabenforms_parent_cpr_verify` (`ParentCprVerifyAction`) - thin wrapper over `aabenforms_workflows.parent_cpr_verifier`. Sets a `*_cpr_consent` result token (`match` / `mismatch` / `missing_mitid_cpr` / `missing_expected_cpr`) and records a `Parent CPR Consent Check` step with a human-readable decision + status (completed/failed).
- Wired into `parent1_approval_flow` and `parent2_approval_flow`, right after MitID validation (`parent_mitid -> parent_cpr_verify -> parent_cpr`).
- Derives the deterministic workflow id `parent_approval_<sid>_p<N>` the approval controller stores the session under (config token override supported).
- **Defence in depth, not a replacement:** the authoritative hard 403 stays in `ParentApprovalController::mitidComplete()`. This surfaces the same decision into the flow for visibility/audit. `ParentCprVerifier` already audit-logs hashed CPRs (never raw) for every outcome.
- **Never fails open:** on any verifier error the action records a `mismatch`.

## Tests
- 7 new unit tests: match / mismatch / derived workflow id / token override / no-submission-doesn't-fail-open / never-fail-open-on-exception / defaults.
- Full action + module kernel suite stays green (91 tests, 0 failures).
- Plugin discovered; both flows import cleanly; wiring verified.

## Heads-up (remaining #54 work)
`parent_request_form` does **not** yet collect `parent1_cpr`/`parent2_cpr`, so the gate currently resolves to `missing_expected_cpr` - i.e. it allows approval through **without** verifying consent. That legacy fallback is now **visible in the replay** instead of silent. Collecting those CPR fields (with PII `#access` control, per the issue) is the remaining part of #54; the action already renders MATCH/MISMATCH correctly the moment the fields land.

Refs #54.
