### PR TITLE
Harden the parent-approval consent gate (fail-closed, scoped, real CPR)

### DIFF
--- a/config/sync/aabenforms_workflows.settings.yml
+++ b/config/sync/aabenforms_workflows.settings.yml
@@ -1,0 +1,1 @@
+require_parent_cpr_match: true

--- a/config/sync/webform.webform.parent_request_form.yml
+++ b/config/sync/webform.webform.parent_request_form.yml
@@ -31,11 +31,39 @@ elements: |-
     '#title': 'Parent 1 Email'
     '#required': true
     '#description': 'Email address for Parent 1 (will receive MitID login link)'
+  parent1_cpr:
+    '#type': cpr_field
+    '#title': 'Parent 1 CPR Number'
+    '#required': true
+    '#description': 'Parent 1 Danish CPR number. Must match the CPR asserted by Parent 1 MitID login before the approval is accepted.'
+    '#access_create_roles':
+      - administrator
+      - case_worker
+    '#access_update_roles':
+      - administrator
+      - case_worker
+    '#access_view_roles':
+      - administrator
+      - case_worker
   parent2_email:
     '#type': email
     '#title': 'Parent 2 Email'
     '#required': true
     '#description': 'Email address for Parent 2 (will receive MitID login link)'
+  parent2_cpr:
+    '#type': cpr_field
+    '#title': 'Parent 2 CPR Number'
+    '#required': true
+    '#description': 'Parent 2 Danish CPR number. Must match the CPR asserted by Parent 2 MitID login before the approval is accepted.'
+    '#access_create_roles':
+      - administrator
+      - case_worker
+    '#access_update_roles':
+      - administrator
+      - case_worker
+    '#access_view_roles':
+      - administrator
+      - case_worker
   parents_together:
     '#type': radios
     '#title': 'Parent Status'
@@ -216,8 +244,7 @@ settings:
 access:
   create:
     roles:
-      - anonymous
-      - authenticated
+      - case_worker
     users: {  }
     permissions: {  }
   view_any:

--- a/web/modules/custom/aabenforms_workflows/config/install/aabenforms_workflows.settings.yml
+++ b/web/modules/custom/aabenforms_workflows/config/install/aabenforms_workflows.settings.yml
@@ -1,0 +1,1 @@
+require_parent_cpr_match: true

--- a/web/modules/custom/aabenforms_workflows/config/install/webform.webform.parent_request_form.yml
+++ b/web/modules/custom/aabenforms_workflows/config/install/webform.webform.parent_request_form.yml
@@ -30,11 +30,39 @@ elements: |-
     '#title': 'Parent 1 Email'
     '#required': true
     '#description': 'Email address for Parent 1 (will receive MitID login link)'
+  parent1_cpr:
+    '#type': cpr_field
+    '#title': 'Parent 1 CPR Number'
+    '#required': true
+    '#description': 'Parent 1 Danish CPR number. Must match the CPR asserted by Parent 1 MitID login before the approval is accepted.'
+    '#access_create_roles':
+      - administrator
+      - case_worker
+    '#access_update_roles':
+      - administrator
+      - case_worker
+    '#access_view_roles':
+      - administrator
+      - case_worker
   parent2_email:
     '#type': email
     '#title': 'Parent 2 Email'
     '#required': true
     '#description': 'Email address for Parent 2 (will receive MitID login link)'
+  parent2_cpr:
+    '#type': cpr_field
+    '#title': 'Parent 2 CPR Number'
+    '#required': true
+    '#description': 'Parent 2 Danish CPR number. Must match the CPR asserted by Parent 2 MitID login before the approval is accepted.'
+    '#access_create_roles':
+      - administrator
+      - case_worker
+    '#access_update_roles':
+      - administrator
+      - case_worker
+    '#access_view_roles':
+      - administrator
+      - case_worker
   parents_together:
     '#type': radios
     '#title': 'Parent Status'
@@ -221,8 +249,7 @@ settings:
 access:
   create:
     roles:
-      - anonymous
-      - authenticated
+      - case_worker
     users: {  }
     permissions: {  }
   view_any:

--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -112,3 +112,6 @@ aabenforms_workflows.settings:
     notification_sender_email:
       type: email
       label: 'Default sender email for notifications'
+    require_parent_cpr_match:
+      type: boolean
+      label: 'Fail closed when a parent-approval submission has no expected CPR to verify against'

--- a/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/ParentApprovalController.php
@@ -204,9 +204,12 @@ class ParentApprovalController extends ControllerBase {
       ];
     }
 
-    // Check if MitID authenticated.
+    // Check if MitID authenticated. The flag is scoped to BOTH the parent
+    // number AND the submission id, so a MitID login for one family's request
+    // cannot satisfy the gate for a different submission held in the same
+    // browser session.
     $session = $request->getSession();
-    $mitid_authenticated = $session->get("mitid_authenticated_parent{$parent_number}");
+    $mitid_authenticated = $session->get("mitid_authenticated_parent{$parent_number}_{$submission_id}");
 
     if (!$mitid_authenticated) {
       // Show MitID login page.
@@ -451,14 +454,29 @@ class ParentApprovalController extends ControllerBase {
       );
     }
     if ($result === ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR) {
-      // Backwards-compatible fallback: the form submission does not carry a
-      // parent_<N>_cpr field (legacy forms or forms not yet updated with CPR
-      // capture). Log a warning and allow the approval to continue so that
-      // existing deployments are not broken. Once all active forms are
-      // updated to collect the CPR, this branch should be converted to a
-      // hard 403 (same as RESULT_MISMATCH) or removed entirely.
+      // The submission carries no parent_<N>_cpr to compare against, so the
+      // consent gate cannot verify which parent is acting. Fail CLOSED by
+      // default (require_parent_cpr_match, default TRUE even if the config key
+      // is absent). Deployments mid-migration can flip the flag off to keep
+      // the legacy warn-and-allow until their forms are back-filled.
+      $require_match = $this->config('aabenforms_workflows.settings')->get('require_parent_cpr_match') ?? TRUE;
+      if ($require_match) {
+        $this->logger->warning(
+          'CPR gate denied: submission @sid has no parent@parent_cpr field; approval blocked (require_parent_cpr_match on, workflow @wid)',
+          [
+            '@sid' => $submission_id,
+            '@parent' => $parent_number,
+            '@wid' => $workflow_id,
+          ]
+        );
+        return $this->renderGateFailure(
+          Response::HTTP_FORBIDDEN,
+          $this->t('Adgang nægtet'),
+          $this->t('Sagen mangler det forventede CPR-nummer; kontakt sagsbehandleren.')
+        );
+      }
       $this->logger->warning(
-        'CPR gate skipped: submission @sid has no parent@parent_cpr field; approval allowed without CPR verification (workflow @wid)',
+        'CPR gate skipped: submission @sid has no parent@parent_cpr field; approval allowed without CPR verification (require_parent_cpr_match off, workflow @wid)',
         [
           '@sid' => $submission_id,
           '@parent' => $parent_number,
@@ -478,7 +496,7 @@ class ParentApprovalController extends ControllerBase {
       );
     }
 
-    $request->getSession()->set("mitid_authenticated_parent{$parent_number}", TRUE);
+    $request->getSession()->set("mitid_authenticated_parent{$parent_number}_{$submission_id}", TRUE);
     $this->logger->info('Parent @parent MitID handoff verified for submission @sid', [
       '@parent' => $parent_number,
       '@sid' => $submission_id,

--- a/web/modules/custom/aabenforms_workflows/src/Form/ParentApprovalForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/ParentApprovalForm.php
@@ -5,7 +5,9 @@ namespace Drupal\aabenforms_workflows\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
+use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -30,6 +32,20 @@ class ParentApprovalForm extends FormBase {
    * @var \Drupal\aabenforms_workflows\Service\ApprovalTokenService
    */
   protected ApprovalTokenService $tokenService;
+
+  /**
+   * The MitID session manager.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager
+   */
+  protected MitIdSessionManager $mitidSessionManager;
+
+  /**
+   * The parent-approval CPR verifier (issue #54 consent gate).
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ParentCprVerifier
+   */
+  protected ParentCprVerifier $cprVerifier;
 
   /**
    * The logger.
@@ -73,16 +89,24 @@ class ParentApprovalForm extends FormBase {
    *   The entity type manager.
    * @param \Drupal\aabenforms_workflows\Service\ApprovalTokenService $token_service
    *   The approval token service.
+   * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $mitid_session_manager
+   *   The MitID session manager (re-verifies the OIDC handoff at submit).
+   * @param \Drupal\aabenforms_workflows\Service\ParentCprVerifier $cpr_verifier
+   *   The parent-approval CPR verifier (issue #54 consent gate).
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     ApprovalTokenService $token_service,
+    MitIdSessionManager $mitid_session_manager,
+    ParentCprVerifier $cpr_verifier,
     LoggerInterface $logger,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->tokenService = $token_service;
+    $this->mitidSessionManager = $mitid_session_manager;
+    $this->cprVerifier = $cpr_verifier;
     $this->logger = $logger;
   }
 
@@ -93,6 +117,8 @@ class ParentApprovalForm extends FormBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('aabenforms_workflows.approval_token'),
+      $container->get('aabenforms_mitid.session_manager'),
+      $container->get('aabenforms_workflows.parent_cpr_verifier'),
       $container->get('logger.factory')->get('aabenforms_workflows')
     );
   }
@@ -244,6 +270,29 @@ class ParentApprovalForm extends FormBase {
 
     if (in_array($current_status, ['complete', 'rejected'])) {
       $form_state->setErrorByName('submission_id', $this->t('This request has already been processed.'));
+      return;
+    }
+
+    // Defence in depth: re-verify the MitID session + CPR match at submit
+    // time. The controller gate ran before this form was shown, but the
+    // 15-minute MitID session may have expired since, and we never want a
+    // stale or different identity to finalise the decision.
+    $workflow_id = sprintf('parent_approval_%d_p%d', $submission_id, $parent_number);
+    if (!$this->mitidSessionManager->hasValidSession($workflow_id)) {
+      $form_state->setErrorByName('submission_id', $this->t('Your MitID session has expired. Please open the approval link again to re-authenticate.'));
+      return;
+    }
+    $require_match = $this->config('aabenforms_workflows.settings')->get('require_parent_cpr_match') ?? TRUE;
+    $cpr_result = $this->cprVerifier->verify($submission, (int) $parent_number, $workflow_id);
+    $consent_ok = $cpr_result === ParentCprVerifier::RESULT_MATCH
+      || (!$require_match && $cpr_result === ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR);
+    if (!$consent_ok) {
+      $this->logger->warning('Parent approval submit blocked by CPR re-check: submission @sid parent @parent result @result', [
+        '@sid' => $submission_id,
+        '@parent' => $parent_number,
+        '@result' => $cpr_result,
+      ]);
+      $form_state->setErrorByName('submission_id', $this->t('Security verification failed. Please contact the case worker.'));
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ParentCprVerifyAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ParentCprVerifyAction.php
@@ -149,8 +149,8 @@ class ParentCprVerifyAction extends AabenFormsActionBase {
           'failed',
         ],
         ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR => [
-          sprintf('Submission carries no parent %d CPR - consent not enforced (legacy form)', $parentNumber),
-          'completed',
+          sprintf('No parent %d CPR on the submission - consent could not be verified', $parentNumber),
+          'failed',
         ],
         default => ['Unknown verification result', 'failed'],
       };

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ParentCprVerifyActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ParentCprVerifyActionTest.php
@@ -143,6 +143,25 @@ class ParentCprVerifyActionTest extends UnitTestCase {
   }
 
   /**
+   * Missing expected CPR records a FAILED replay step, not a green one.
+   *
+   * @covers ::execute
+   */
+  public function testMissingExpectedRecordsFailedStep(): void {
+    $this->seedSubmission();
+    $this->cprVerifier->method('verify')->willReturn(ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR);
+    $collector = $this->createMock(WorkflowExecutionCollector::class);
+    $collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+    $this->action->setExecutionCollector($collector);
+
+    $this->action->execute();
+
+    $this->assertSame(ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR, $this->tokenStorage['cpr_consent_result']);
+  }
+
+  /**
    * The deterministic workflow id and parent number reach the verifier.
    *
    * With no token override, the action derives parent_approval_<sid>_p<N>.


### PR DESCRIPTION
## Summary
Closes the **verified consent-bypass** surfaced by the security pressure test. The #54 parent-CPR consent gate was a no-op and the controller failed **open**.

## The bug (live-proven)
- `parent_request_form` collected **no parent CPR**, so `ParentCprVerifier` always returned `missing_expected_cpr`, and `ParentApprovalController::mitidComplete()` treated that as **ALLOW** -> any MitID identity could approve any request.
- The `mitid_authenticated_parentN` session flag was keyed by **parent number only**, not submission id -> one MitID login approved any *other* family's request held in the same browser.

## Fix
- **Collect parent CPRs.** Add `parent1_cpr` / `parent2_cpr` to `parent_request_form` (`cpr_field`, required, **caseworker-only** via `#access_*_roles`, mirroring `caseworker_notes`). The caseworker records the expected CPR; parents reviewing never see it.
- **Fail closed.** `mitidComplete()` returns a hard **403** on `missing_expected_cpr` when `require_parent_cpr_match` is on (new `aabenforms_workflows.settings` flag, **default true**; off = legacy warn-and-allow for mid-migration back-fill).
- **Scope the session flag** to parent number **and** submission id (read at `approvalPage`, write at `mitidComplete`).
- **Defence in depth:** re-verify MitID session + CPR match in `ParentApprovalForm::validateForm()` at submit time (handles a session that expired since the gate).
- **Lock the form:** `parent_request_form` create role `anonymous,authenticated` -> `case_worker`.
- **Honest replay:** `ParentCprVerifyAction` records a `failed` (not green `completed`) step when the expected CPR is missing.

## Verification
- Local: matching CPR -> `match`, wrong CPR -> `mismatch`; both CPR fields present; create role = `case_worker`; flag on.
- phpcs `--standard=Drupal --warning-severity=0` clean; **168 unit+kernel tests pass**, incl. a new assertion that missing-expected records a `failed` step.
- Manual gate behaviour (403 on mismatch/missing, redirect on match) proven via the verifier + controller branch; a browser E2E gate test is a fast-follow.

## Migration note
Existing submissions without parent CPRs will (correctly) be blocked while the flag is on; create fresh submissions for the demo, or flip `require_parent_cpr_match` off until back-filled.

Refs #54. First of the security-sweep PRs (audit-integrity + resilience to follow).
