### PR TITLE
Stop the audit log recording unverified work as done (token resolution + MitID fail-closed)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -115,3 +115,6 @@ aabenforms_workflows.settings:
     require_parent_cpr_match:
       type: boolean
       label: 'Fail closed when a parent-approval submission has no expected CPR to verify against'
+    allow_mitid_demo_mode:
+      type: boolean
+      label: 'Allow MitID validation to pass without a real session (demo only; default off)'

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AabenFormsActionBase.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AabenFormsActionBase.php
@@ -150,6 +150,19 @@ abstract class AabenFormsActionBase extends ActionBase implements ContainerFacto
    *   The token value, or the default.
    */
   protected function getTokenValue(string $fieldKey, string $default): string {
+    // A bracketed reference such as '[parent1_session:cpr]' is an ECA token
+    // that must be RESOLVED via replacement against the token environment.
+    // The previous code passed the literal bracketed string to getTokenData()
+    // as a data-bag key, so these always missed: CPR/CVR lookups silently
+    // received an empty value and never called Serviceplatformen, while still
+    // recording a "completed" step. Bare keys keep their direct-lookup
+    // behaviour below (getOrReplace would wrongly return the literal name for
+    // an unset bare token, breaking empty() guards).
+    if (str_contains($fieldKey, '[')) {
+      $replaced = $this->tokenService->replaceClear($fieldKey, []);
+      $replaced = is_string($replaced) ? trim($replaced) : '';
+      return $replaced !== '' ? $replaced : $default;
+    }
     $value = $this->tokenService->getTokenData($fieldKey);
     if (is_string($value)) {
       return $value;

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
@@ -100,9 +100,9 @@ class CprLookupAction extends AabenFormsActionBase {
     $cpr = $cpr ? preg_replace('/[^0-9]/', '', $cpr) : '';
 
     if (empty($cpr)) {
-      $this->log('CPR lookup: No CPR provided - demo mode', [], 'info');
+      $this->log('CPR lookup skipped: no CPR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
-      $this->recordStep('CPR Registry Lookup', 'Personal data retrieved from the national CPR registry (SF1520)');
+      $this->recordStep('CPR Registry Lookup', 'Skipped - no CPR available to look up', 'skipped');
       return;
     }
 
@@ -129,7 +129,7 @@ class CprLookupAction extends AabenFormsActionBase {
           'cpr' => substr($cpr, 0, 6) . 'XXXX',
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
-        $this->recordStep('CPR Registry Lookup', 'Personal data retrieved from the national CPR registry (SF1520)');
+        $this->recordStep('CPR Registry Lookup', 'No person found in the national CPR registry (SF1520)', 'failed');
         return;
       }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -4,6 +4,7 @@ namespace Drupal\aabenforms_workflows\Plugin\Action;
 
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\eca\Attribute\EcaAction;
@@ -31,12 +32,48 @@ class MitIdValidateAction extends AabenFormsActionBase {
   protected MitIdSessionManager $sessionManager;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->sessionManager = $container->get('aabenforms_mitid.session_manager');
+    $instance->configFactory = $container->get('config.factory');
     return $instance;
+  }
+
+  /**
+   * Whether MitID demo mode (pass with no real session) is permitted.
+   *
+   * Default is FALSE: without a verified session the action fails CLOSED so
+   * the audit trail never records an unverified identity as "verified".
+   */
+  protected function demoModeAllowed(): bool {
+    return (bool) ($this->configFactory->get('aabenforms_workflows.settings')->get('allow_mitid_demo_mode') ?? FALSE);
+  }
+
+  /**
+   * Records the "no valid MitID session" outcome, fail-closed by default.
+   *
+   * @param string $context
+   *   Short reason for logging.
+   */
+  protected function recordNoSession(string $context): void {
+    if ($this->demoModeAllowed()) {
+      $this->log('MitID validation: ' . $context . ' - demo mode (allow_mitid_demo_mode on)', [], 'info');
+      $this->setTokenValue($this->configuration['result_token'], TRUE);
+      $this->recordStep('MitID Identity Validation', 'Demo mode: identity was NOT verified (no MitID session)', 'completed');
+      return;
+    }
+    $this->log('MitID validation failed: ' . $context . ' (demo mode off)', [], 'warning');
+    $this->setTokenValue($this->configuration['result_token'], FALSE);
+    $this->recordStep('MitID Identity Validation', 'No valid MitID session - identity could not be verified', 'failed');
   }
 
   /**
@@ -98,9 +135,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
     $workflowId = $this->getTokenValue($this->configuration['workflow_id_token'] ?? 'workflow_id', '');
 
     if (empty($workflowId)) {
-      $this->log('MitID validation: No workflow ID - demo mode', [], 'info');
-      $this->setTokenValue($this->configuration['result_token'], TRUE);
-      $this->recordStep('MitID Identity Validation', 'Citizen identity verified via NemID/MitID national eID');
+      $this->recordNoSession('no workflow id in context');
       return;
     }
 
@@ -109,11 +144,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
       $sessionData = $this->sessionManager->getSession($workflowId);
 
       if (empty($sessionData)) {
-        $this->log('MitID validation: No session found - demo mode for workflow {workflow_id}', [
-          'workflow_id' => $workflowId,
-        ], 'info');
-        $this->setTokenValue($this->configuration['result_token'], TRUE);
-        $this->recordStep('MitID Identity Validation', 'Citizen identity verified via NemID/MitID national eID');
+        $this->recordNoSession('no session for workflow ' . $workflowId);
         return;
       }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -291,10 +291,9 @@ class CprLookupActionTest extends UnitTestCase {
    */
   public function testMissingCpr(): void {
     // Don't set CPR token.
-    // Demo-mode info log, never warning.
+    // Honest "skipped" outcome: warning log, no false-success info, and the
+    // step is recorded as skipped rather than "retrieved from the registry".
     $this->logger->expects($this->once())
-      ->method('info');
-    $this->logger->expects($this->never())
       ->method('warning');
 
     // Serviceplatformen should NOT be called.

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
@@ -6,6 +6,8 @@ use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\MitIdValidateAction;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -148,6 +150,15 @@ class MitIdValidateActionTest extends UnitTestCase {
     $sessionManagerProperty = $reflectionClass->getProperty('sessionManager');
     $sessionManagerProperty->setAccessible(TRUE);
     $sessionManagerProperty->setValue($this->action, $this->sessionManager);
+
+    // Inject a config factory with MitID demo mode OFF (fail-closed default).
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturn(FALSE);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+    $configFactoryProperty = $reflectionClass->getProperty('configFactory');
+    $configFactoryProperty->setAccessible(TRUE);
+    $configFactoryProperty->setValue($this->action, $configFactory);
   }
 
   /**
@@ -223,9 +234,8 @@ class MitIdValidateActionTest extends UnitTestCase {
   /**
    * Tests validation with missing MitID session.
    *
-   * Production code treats a missing session as "demo mode": logs at INFO,
-   * sets the result token to TRUE, and records a successful step. The earlier
-   * shape (warning + FALSE) was changed when demo-mode fallback was added.
+   * With demo mode OFF (the default), a missing session fails CLOSED: warning
+   * log, result token FALSE, and a failed step - never a false "verified".
    *
    * @covers ::execute
    */
@@ -241,17 +251,15 @@ class MitIdValidateActionTest extends UnitTestCase {
       ->with($workflowId)
       ->willReturn(NULL);
 
-    // Demo-mode fallback: info log, no warning.
+    // Fail-closed: warning log, never a false-success info.
     $this->logger->expects($this->once())
-      ->method('info');
-    $this->logger->expects($this->never())
       ->method('warning');
 
     // Execute action.
     $this->action->execute();
 
-    // Verify result is TRUE (demo mode).
-    $this->assertTrue($this->tokenStorage['mitid_valid']);
+    // Verify result is FALSE (fail closed).
+    $this->assertFalse($this->tokenStorage['mitid_valid']);
   }
 
   /**
@@ -345,17 +353,16 @@ class MitIdValidateActionTest extends UnitTestCase {
   /**
    * Tests validation without workflow ID.
    *
-   * Missing workflow ID falls into demo mode: info log, result token TRUE,
-   * and the session manager is never consulted.
+   * With demo mode OFF (the default), a missing workflow id fails CLOSED:
+   * warning log, result token FALSE, and the session manager is never
+   * consulted.
    *
    * @covers ::execute
    */
   public function testMissingWorkflowId(): void {
     // Don't set workflow_id token (simulate missing context).
-    // Demo-mode info log, no warning.
+    // Fail-closed: warning, no false-success info.
     $this->logger->expects($this->once())
-      ->method('info');
-    $this->logger->expects($this->never())
       ->method('warning');
 
     // Session manager should NOT be called.
@@ -365,8 +372,8 @@ class MitIdValidateActionTest extends UnitTestCase {
     // Execute action.
     $this->action->execute();
 
-    // Verify result is TRUE (demo mode).
-    $this->assertTrue($this->tokenStorage['mitid_valid']);
+    // Verify result is FALSE (fail closed).
+    $this->assertFalse($this->tokenStorage['mitid_valid']);
   }
 
   /**


### PR DESCRIPTION
## Summary
Stops the audit log recording **unverified work as done** - two verified audit-integrity defects from the security pressure test. (Second of the security-sweep PRs; follows the consent-gate PR.)

## Defects fixed
**Token resolution (F).** `AabenFormsActionBase::getTokenValue()` passed a literal bracketed token (`[parent1_session:cpr]`, `[webform_submission:values:cpr:raw]`) to `getTokenData()` as a *data-bag key*, so it always missed. Result: CPR/CVR lookups received an empty value, **never called Serviceplatformen (SF1520/SF1530)**, yet still recorded a `completed` step claiming *"Personal data retrieved from the national CPR registry"*. Now bracketed tokens resolve via `replaceClear()`; bare keys keep direct lookup (`getOrReplace` would return the literal name for an unset bare token and break `empty()` guards). Proven: `[pt_session:cpr]` -> the CPR.

**MitID fail-closed (D).** `MitIdValidateAction` reported *"identity verified"* (result `TRUE`, completed step) whenever there was **no session** ("demo mode"). It now **fails closed** by default (`FALSE`, failed step). The soft demo path is gated behind a new `aabenforms_workflows.settings: allow_mitid_demo_mode` (**default off**) and even then labels the step honestly ("Demo mode: identity was NOT verified").

**Honest lookup steps.** `CprLookupAction` records `skipped` when there's no CPR to look up and `failed` when the registry returns no person, instead of always claiming a successful retrieval.

## Verification
- Full action unit suite green (**81 tests**) incl. updated MitID (fail-closed) + CPR (honest-skip) expectations; broader Unit suite green (157).
- `replaceClear('[pt_session:cpr]')` -> `0804951236` confirmed live.
- phpcs `--standard=Drupal --warning-severity=0` clean.

## Notes
- Demo journeys that relied on demo-mode MitID passing must now use a real Keycloak/MitID session **or** set `allow_mitid_demo_mode: true` locally.
- The base-class `getTokenValue` change touches every action plugin; gated on the full action suite (no regressions).
- Digital Post recipient-from-session hardening is folded into the resilience PR.
