### PR TITLE
Close the execution-replay PII bleed (least-privilege + cron self-heal)

### DIFF
--- a/config/sync/user.role.case_worker.yml
+++ b/config/sync/user.role.case_worker.yml
@@ -18,8 +18,6 @@ permissions:
   - 'administer workflows'
   - 'edit any webform submission'
   - 'modeler api collection eca'
-  - 'modeler api replay eca'
-  - 'modeler api test eca'
   - 'modeler api view eca'
   - 'modeler api view eca with workflow_modeler'
   - 'use text format webform_default'

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -128,3 +128,30 @@ function aabenforms_workflows_theme(array $existing, string $type, string $theme
     ],
   ];
 }
+
+/**
+ * Implements hook_cron().
+ *
+ * Self-heals an abandoned ECA execution-replay capture. When a tester arms
+ * replay (eca.token_browser::initTesting) the GLOBAL state flag
+ * _eca_internal_debug_mode is set TRUE, and while it is on every ECA run
+ * records its token data - including citizen CPR - into a cross-user shared
+ * tempstore. The contrib token browser only disarms while the tester's UI
+ * keeps polling; an abandoned browser tab leaves capture on indefinitely.
+ * Reset it once the arming is older than a short TTL so citizen PII is not
+ * recorded into a shared store unattended.
+ */
+function aabenforms_workflows_cron(): void {
+  $state = \Drupal::state();
+  if (!$state->get('_eca_internal_debug_mode', FALSE)) {
+    return;
+  }
+  // 15 minutes, matching the MitID session TTL.
+  $ttl = 900;
+  $started = (int) $state->get('_eca_internal_debug_test_started', 0);
+  if ($started === 0 || (\Drupal::time()->getRequestTime() - $started) > $ttl) {
+    $state->set('_eca_internal_debug_mode', FALSE);
+    $state->delete('_eca_internal_debug_test_started');
+    \Drupal::logger('aabenforms_workflows')->warning('Reset a stale ECA replay capture: debug mode was left armed, so citizen PII is no longer being recorded to the shared replay store.');
+  }
+}


### PR DESCRIPTION
## Summary
Closes the **execution-replay PII bleed** - the highest-severity privacy finding from the security pressure test.

## The exposure
While ECA replay is armed, the **global** state flag `_eca_internal_debug_mode` makes **every** workflow run record its token data - including citizen **CPR and IP** - into a **cross-user shared tempstore**, and the contrib `eca.token_browser` only disarms while the tester's UI keeps polling. Two real exposures: `case_worker` could arm it, and an abandoned browser tab left capture **on indefinitely**.

## Fix
- **Least privilege:** remove `modeler api replay eca` + `modeler api test eca` from the `case_worker` role (keeps `view`/`collection`), so only admins can arm or read replay captures.
- **Self-heal:** `aabenforms_workflows_cron()` resets an abandoned capture - if debug mode has been armed > 15 min, it clears the flag and stops recording PII to the shared store.

## Verification
- `case_worker` no longer holds replay/test (confirmed via `hasPermission`); still has `view`.
- An "armed 20 minutes ago" debug flag is reset by `drush cron` (verified).
- phpcs `--standard=Drupal --warning-severity=0` clean.

## Deferred (documented, not rushed)
The verified items below need a careful new subsystem with their own tests, so they're scoped to a focused follow-up rather than risked at the tail of this sweep:
- **SF1520/SF1530 outage DoS** -> circuit breaker / negative cache (the client already has `connect_timeout: 10`; the 36s block was retries x timeout).
- **Digital Post idempotency** (dedupe key) + **recipient-from-verified-session**.
- **Deep redaction** of the contrib `eca.token_browser` shared store needs an upstream patch.
