### PR TITLE
docs: rewrite README for clarity and honesty (plain style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,380 +1,105 @@
-# ÅbenForms Backend
+# AabenForms Backend
 
-**Headless Drupal 11 backend for Danish municipal workflow automation**
+Headless Drupal 11 backend for Danish municipal workflow automation.
 
-[![Drupal](https://img.shields.io/badge/Drupal-11.3.2-blue)](https://www.drupal.org)
+[![Drupal](https://img.shields.io/badge/Drupal-11-blue)](https://www.drupal.org)
 [![PHP](https://img.shields.io/badge/PHP-8.4-purple)](https://www.php.net)
-[![License](https://img.shields.io/badge/License-GPL--2.0-green)](LICENSE)
-
+[![License](https://img.shields.io/badge/License-GPL--2.0-green)](LICENSE.txt)
 [![CI](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml/badge.svg)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
 [![Coding Standards](https://github.com/madsnorgaard/aabenforms/actions/workflows/coding-standards.yml/badge.svg)](https://github.com/madsnorgaard/aabenforms/actions/workflows/coding-standards.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/madsnorgaard/aabenforms/main/.github/badges/coverage.json)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/madsnorgaard/aabenforms/main/.github/badges/tests.json)](https://github.com/madsnorgaard/aabenforms/actions/workflows/ci.yml)
 
-## Overview
+## Status
 
-ÅbenForms is a modular platform for Danish municipalities to automate citizen-facing workflows and integrate with government services (MitID, Serviceplatformen, case management systems).
+Pre-pilot POC. Live at https://api.aabenforms.dk with a Nuxt frontend at https://aabenforms.dk. MitID runs against a Keycloak mock; Serviceplatformen (CPR/CVR) and Digital Post run against test or mock endpoints, not live production integrations. For a claim-by-claim account of what works today versus what is demo or planned, see [docs/PROMISES-VS-VERIFIED.md](docs/PROMISES-VS-VERIFIED.md).
 
-**Status: POC / demo**. Live at https://api.aabenforms.dk with a Nuxt
-frontend at https://aabenforms.dk. Real MitID test-gateway
-registration with Digitaliseringsstyrelsen is a future phase; today
-the backend uses a Keycloak mock for local development and the
-frontend's MitID button is hidden in prod.
+## What it is
 
-This repository contains the **Drupal 11 backend** that provides:
-- ECA workflow engine (event-driven automation), editable in the visual **Workflow Modeler** (React Flow, `drupal/modeler`) with execution replay + token inspection
-- **18 municipal ECA flows** (parking / building / marriage / association permits, citizen service, FOI, address & phone change, company verification, dual-parent approval, HR onboarding, mileage, MED election, caseworker review)
-- ~21 ECA action plugins. **Real today:** MitID session validation, CPR (SF1520) + CVR (SF1530) lookup, Digital Post (SF1601, `fake_db`/`wiremock`), PDF, audit log, approval emails, parent-CPR consent gate. **Demo mocks (not production):** payment, SMS, GIS/zoning, payroll, calendar — clearly flagged in [`docs/PROMISES-VS-VERIFIED.md`](docs/PROMISES-VS-VERIFIED.md)
-- Modular Danish government integrations: `aabenforms_digital_post` SF1601 (`fake_db`/`wiremock` today; real MeMo + SOAP planned), MitID OIDC (Keycloak mock IdP today)
-- Custom Danish webform elements with server-side validation: CPR (format + modulus-11), CVR, DAWA address (client-side autocomplete against `api.dataforsyningen.dk`)
-- WireMock + Keycloak mock services bundled in DDEV for zero-config local development
-- Dynamic webforms with JSON:API exposure; domain-based multi-tenancy; GDPR-oriented CPR encryption + audit logging
-- Shared admin design tokens (`aabenforms_core/admin` library) so feature modules style consistently from one source of CSS variables
+A modular platform for Danish kommuner to automate citizen-facing workflows and connect to government services (MitID/NemLog-in, Serviceplatformen, Digital Post). Workflows are built in a visual editor and run as event-driven (ECA) flows.
 
-> **What is real vs. demo?** This is a pre-pilot POC. See [`docs/PROMISES-VS-VERIFIED.md`](docs/PROMISES-VS-VERIFIED.md) for an honest, verified claim-by-claim status, and the [Roadmap & backlog](#roadmap--backlog) below for what's next.
+Real today:
+
+- ECA workflow engine with a visual Workflow Modeler (`drupal/modeler`) and execution replay with token inspection
+- 18 municipal ECA flows (building and parking permits, marriage and association booking, citizen service, FOI, address and phone change, company verification, dual-parent approval, HR onboarding, mileage, MED election, caseworker review)
+- MitID OIDC sign-in against a Keycloak mock IdP; CPR (SF1520) and CVR (SF1530) lookup clients
+- Custom Danish webform elements with server-side validation: CPR (format and modulus-11), CVR, DAWA address autocomplete
+- Field-level CPR encryption and audit logging (in `aabenforms_core`)
+- Digital Post (SF1601) in `fake_db` and `wiremock` test modes
+
+Demo or mock, not production:
+
+- Payment, SMS, GIS/zoning, payroll and calendar actions are demo mocks
+- Digital Post has no live MeMo/SOAP transport yet; MitID has no live registration; Serviceplatformen needs client certificates before CPR/CVR run live
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                  ÅbenForms Platform                     │
-└─────────────────────────────────────────────────────────┘
-                           │
-        ┌──────────────────┼──────────────────┐
-        │                  │                  │
-┌───────▼────────┐  ┌──────▼──────┐  ┌───────▼────────┐
-│  Nuxt 3 UI     │  │  Drupal 11  │  │   VPS2 prod    │
-│  (Frontend)    │◄─┤  (Backend)  │  │  (Deployment)  │
-│                │  │             │  │                │
-│  - Multi-tenant│  │  - JSON:API │  │  - Docker      │
-│  - Form render │  │  - ECA      │  │  - Traefik TLS │
-│  - Workflows   │  │  - Webform  │  │  - MariaDB 11  │
-└────────────────┘  └─────────────┘  └────────────────┘
-                           │
-                           │ Serviceplatformen
-                           ▼
-               ┌───────────────────────┐
-               │  Danish Gov Services  │
-               │  - MitID (auth)       │
-               │  - CPR (person data)  │
-               │  - CVR (company data) │
-               │  - Digital Post       │
-               └───────────────────────┘
+Nuxt 3 frontend  ->  Drupal 11 backend (JSON:API, ECA, Webform)  ->  Danish gov services
+(aabenforms.dk)      (api.aabenforms.dk)                              MitID, CPR/CVR (Serviceplatformen), Digital Post
 ```
 
-## Quick Start
+Deployment is orchestrated by the `contabo-infrastructure` repo; a push to `main` rebuilds the Docker image on VPS2.
 
-### Prerequisites
-- DDEV installed
-- Docker running
-- Git configured
-
-### Installation
+## Quick start
 
 ```bash
-# Clone repository
 git clone https://github.com/madsnorgaard/aabenforms.git backend
 cd backend
-
-# Start DDEV
 ddev start
-
-# Install Drupal (already done if cloning)
-# ddev drush site:install aabenforms --account-pass=admin -y
-
-# Access admin UI
-ddev launch
-# Login: admin / admin
+ddev launch        # admin UI, login admin / admin
 ```
 
-### Local URLs
-- **Frontend**: https://aabenforms.ddev.site
-- **JSON:API**: https://aabenforms.ddev.site/jsonapi
-- **Mailpit**: https://aabenforms.ddev.site:8026
+Local URLs: site at https://aabenforms.ddev.site, JSON:API at `/jsonapi`, mail at `:8026`. `ddev start` also boots Keycloak (mock MitID) and WireMock (mock Serviceplatformen) for zero-config local development. The mock realm, test users, and the Keycloak re-import gotcha are documented in [docs/DDEV_MOCK_SERVICES_GUIDE.md](docs/DDEV_MOCK_SERVICES_GUIDE.md).
 
-### Local authentication (Keycloak mock realm)
+## Modules
 
-`ddev start` also boots a Keycloak container that imports a mock realm from
-`.ddev/mocks/keycloak/realms/danish-gov-test.json`. This stands in for MitID
-during local development.
+| Module | Status | What it does |
+| --- | --- | --- |
+| `aabenforms_core` | Active | Base services: Serviceplatformen client (SF1520/SF1530), AES-256 field encryption, audit logging, tenant resolver, workflow execution collector |
+| `aabenforms_workflows` | Active | ECA action plugins, the approval system, and the template wizard. Some actions (payment, SMS, GIS, payroll, calendar) are demo mocks |
+| `aabenforms_mitid` | Active | MitID OIDC sign-in, session management, CPR claim extraction |
+| `aabenforms_webform` | Active | Custom webform elements: CPR, CVR, DAWA address |
+| `aabenforms_tenant` | Active | Domain-based multi-tenancy (logical, single database) |
+| `aabenforms_digital_post` (+ `_eca`) | Partial | SF1601 Digital Post in `fake_db`/`wiremock`; real MeMo and SOAP transport are planned (issue #77) |
+| `aabenforms_nemlogin`, `aabenforms_sbsys`, `aabenforms_get_organized` | Planned | NemLog-in Erhverv and ESDH/case-system integrations (issues #79, #84-#86) |
 
-- Realm: `danish-gov-test` at http://localhost:8080
-- OIDC client: `aabenforms-backend` (redirect URIs cover localhost:3000 and
-  the DDEV hostnames)
-- 10 test users (password `test1234`): freja.nielsen, mikkel.jensen,
-  sofie.hansen, lars.andersen, emma.pedersen, karen.christensen,
-  protected.person, morten.rasmussen, ida.mortensen, peter.larsen
-- Client scopes: `ssn` (with a CPR user-attribute mapper emitting the `ssn`
-  claim, matching the real MitID contract) plus the re-declared built-ins
-  `profile`, `email`, `roles`, `web-origins`, `acr`, `role_list`.
+Encryption and GDPR audit logging are built into `aabenforms_core`. A retention and right-to-erasure subsystem does not exist yet and is tracked in issue #91.
 
-**Gotcha worth knowing about.** When a realm JSON declares top-level
-`clientScopes`, Keycloak's import replaces the auto-created built-in scope
-set. If the JSON only declares `ssn`, `profile`/`email`/`roles`/etc. vanish
-from the realm and OIDC discovery shrinks to three scopes. Every built-in
-that clients depend on must be redeclared alongside the custom scope. This
-cost a day of debugging on Apr 23, 2026.
+## Recent progress
 
-`MitIdOidcClient::getAuthorizationUrl()` defaults scope to `'openid ssn'`
-(`web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php:114`).
-Before the realm was updated, every login attempt in local dev got
-`invalid_scope` back from Keycloak.
+A security pass in June 2026 fixed issues found by a local pressure test, where some steps reported success while the underlying control did nothing:
 
-**Re-importing the realm after edits.** Keycloak runs with
-`start-dev --import-realm`, which imports a realm once per H2 data store.
-A plain `ddev restart` keeps the existing realm in place and silently
-ignores your changes. To force re-import, remove the container and let
-DDEV recreate it:
+- #68 parent-CPR consent gate: fail-closed, real caseworker CPR fields, submission-scoped session, re-verified at submit
+- #69 audit integrity: token resolution so CPR/CVR lookups actually run; MitID validation fails closed; honest step statuses
+- #70 execution-replay PII: least-privilege plus a cron self-heal so an armed replay cannot record citizen CPR to a shared store
+- #71 [docs/PROMISES-VS-VERIFIED.md](docs/PROMISES-VS-VERIFIED.md): the claim-vs-verified table
 
-```bash
-docker rm -f ddev-aabenforms-keycloak
-ddev start
-```
+## Roadmap
 
-Then verify the scopes are live:
+The backlog is in [GitHub issues](https://github.com/madsnorgaard/aabenforms/issues), grouped by label:
 
-```bash
-curl -s http://localhost:8080/realms/danish-gov-test/.well-known/openid-configuration \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['scopes_supported'])"
-```
-
-## Custom Modules
-
-### Phase 1: Core Platform  Complete
-| Module | Status | Description |
-|--------|--------|-------------|
-| `aabenforms_core` |  Active | Base services, utilities, Serviceplatformen client, encryption |
-| `aabenforms_tenant` |  Active | Multi-tenancy via Domain module |
-| `aabenforms_webform` |  Active | Custom form elements (CPR, CVR, DAWA address fields) |
-
-### Phase 2: Security & Authentication  Complete
-| Module | Status | Description |
-|--------|--------|-------------|
-| `aabenforms_mitid` |  Active | MitID OIDC integration, session management, CPR extraction |
-| `aabenforms_gdpr` |  Not a separate module | Field-level AES-256 encryption and GDPR audit logging are built directly into `aabenforms_core` (`EncryptionService`, `AuditLogger`). A standalone `aabenforms_gdpr` module with retention policies and right-to-erasure workflows is planned but does not yet exist. |
-
-### Phase 3: Complete Workflow System  Complete
-| Module | Status | Description |
-|--------|--------|-------------|
-| `aabenforms_workflows` |  Complete | **Full workflow automation platform:** |
-| | | • 13 BPMN 2.0 templates (see "BPMN Workflow Templates" below) |
-| | | • Visual workflow wizard (6-step template instantiation, modernized step bar) |
-| | | • Approval system with secure token-based access |
-| | | • 3 separate workflows for parallel parent approvals |
-| | | • Email notifications (SendApprovalEmailAction) |
-| | | • Custom ECA action plugins (MitID validate, CPR/CVR lookup, audit log, payment, SMS, PDF, calendar, GIS, zoning, reminders, `aabenforms_log` shim) |
-| | | • `hook_storage_transform_import` preserves wizard-created configs across `drush cim` |
-| | | • Municipal admin documentation under `docs/` |
-
-### Phase 4: Modular Danish Service Integrations (Current)
-| Module | Status | Description |
-|--------|--------|-------------|
-| `aabenforms_digital_post` |  Session 1 shipped | SF1601 Digital Post core. Plug-and-play on bare Drupal 11 with `drupal:key` + `aabenforms_core` only. Test modes `fake_db`/`wiremock`/`live_test`/`live`. Real SOAP transport in Session 2B. |
-| `aabenforms_digital_post_eca` |  Session 2A shipped | Submodule. ECA action plugin `aabenforms_digital_post_send`, ready for any BPMN template via `<aabenforms:ecaAction>`. |
-| `aabenforms_digital_post_webform` |  Session 3 | Submodule. Webform handler, keeps the core module webform-free. |
-| `aabenforms_digital_post_beskedfordeler` |  Session 3 | Submodule. Optional delivery-status receipts. |
-| `aabenforms_digital_post_os2web_key` |  Session 3 | Submodule. Bridge for sites already using `os2web_key` certificates. |
-| `aabenforms_nemlogin` |  Session 2C | Plug-and-play OIDC core (PKCE S256, ItkOidcClient, ClaimStore). |
-| `aabenforms_nemlogin_keycloak` |  Session 2C | Submodule. Keycloak preset for local dev. |
-| `aabenforms_mitid` |  deprecation track | Shim over `aabenforms_nemlogin` planned in Session 2C; full removal in Session 3. |
-| `aabenforms_cpr` |  Not a separate module | SF1520 CPR person lookup is a stub action plugin (`CprLookupAction`) inside `aabenforms_workflows`. A standalone `aabenforms_cpr` module with a production Serviceplatformen client is planned. |
-| `aabenforms_cvr` |  Not a separate module | SF1530 CVR company lookup is a stub action plugin (`CvrLookupAction`) inside `aabenforms_workflows`. A standalone `aabenforms_cvr` module is planned. |
-| `aabenforms_dawa` |  Not a separate module | DAWA address autocomplete is implemented as a `DawaAddressElement` webform element inside `aabenforms_webform`. A standalone `aabenforms_dawa` module with full API integration is planned. |
-| `aabenforms_sbsys` |  Planned | SBSYS case management integration |
-| `aabenforms_get_organized` |  Planned | GetOrganized ESDH document archiving |
-
-**Legend**:  Shipped |  In Progress |  Planned
-
-The Digital Post + NemLog-in rewrite plan is an explicit modular alternative to the heavier proprietary integration stacks. Goal: each integration installs cleanly on any modern Drupal 11 with at most one mainstream contrib module, with no deep vendor dependency chain.
-
-### Development Progress
-
-**Shipped:**
--  Dual parent approval system with parallel workflows
--  Secure token-based approval pages (HMAC-SHA256, 7-day expiry)
--  Visual workflow template wizard (no YAML required, modernized 6-step indicator)
--  13 BPMN templates (see "BPMN Workflow Templates" below)
--  ~20 ECA action plugins including `aabenforms_digital_post_send` and `aabenforms_log` shim
--  `aabenforms_digital_post` core + ECA bridge (Session 1 + 2A): SF1601 in `fake_db` on prod, write-through to `{aabenforms_digital_post_log}`
--  `aabenforms_core/admin` design tokens: one CSS-variable file feeding all admin styles
--  `hook_storage_transform_import` preserves wizard-created configs across `drush cim`
--  Keycloak mock realm with `ssn` client scope for local MitID development
--  GDPR-oriented data masking for separated parents
--  Automated test coverage via CI (see badges above for current numbers)
-
-**Recent progress — security hardening (Jun 2026):** a multi-agent local pressure test found several "green checkmarks" that were theatrical — the control reported success while doing nothing. Fixed in a staged sweep:
-- **#68** parent-CPR consent gate — fail-closed, real caseworker CPR fields, submission-scoped session, re-verify at submit (closes a consent bypass)
-- **#69** audit integrity — token resolution so CPR/CVR lookups actually fire; MitID validation fails closed; honest replay step statuses
-- **#70** execution-replay PII — least-privilege + cron self-heal so an armed replay can't record citizen CPR to a shared store
-- **#71** [`docs/PROMISES-VS-VERIFIED.md`](docs/PROMISES-VS-VERIFIED.md) — honest claim-vs-verified table
-
-## Roadmap & backlog
-
-The backlog lives in [GitHub issues](https://github.com/madsnorgaard/aabenforms/issues), grouped by theme:
-
-**🔒 Security — finish the sweep** ([`security`](https://github.com/madsnorgaard/aabenforms/labels/security))
-[#72](https://github.com/madsnorgaard/aabenforms/issues/72) Serviceplatformen circuit breaker (outage DoS) · [#73](https://github.com/madsnorgaard/aabenforms/issues/73) Digital Post idempotency + recipient-from-session · [#74](https://github.com/madsnorgaard/aabenforms/issues/74) replay PII redaction · [#75](https://github.com/madsnorgaard/aabenforms/issues/75) register `administer workflows` perm · [#54](https://github.com/madsnorgaard/aabenforms/issues/54) consent-gate kernel test
-
-**🔌 Productionise the real integrations** ([`integration`](https://github.com/madsnorgaard/aabenforms/labels/integration))
-[#76](https://github.com/madsnorgaard/aabenforms/issues/76) Serviceplatformen certs/enrollment → live SF1520/SF1530 · [#77](https://github.com/madsnorgaard/aabenforms/issues/77) SF1601 real MeMo + SOAP (live Digital Post) · [#78](https://github.com/madsnorgaard/aabenforms/issues/78) Beskedfordeler SF1461/SF1462 (receipts + case-completed events) · [#79](https://github.com/madsnorgaard/aabenforms/issues/79) MitID token validation + production registration + NemLog-in Erhverv · [#80](https://github.com/madsnorgaard/aabenforms/issues/80) DAWA server-side + Datafordeler/BBR
-
-**🧪 Replace demo mocks with real providers** ([`mocks`](https://github.com/madsnorgaard/aabenforms/labels/mocks))
-[#81](https://github.com/madsnorgaard/aabenforms/issues/81) payment (Nets/MobilePay) · [#82](https://github.com/madsnorgaard/aabenforms/issues/82) SMS (GatewayAPI/Cellcast) · [#83](https://github.com/madsnorgaard/aabenforms/issues/83) GIS/BBR zoning + neighbours
-
-**🏛️ Case-system / ESDH handoff — the differentiator** ([`esdh`](https://github.com/madsnorgaard/aabenforms/labels/esdh))
-[#84](https://github.com/madsnorgaard/aabenforms/issues/84) case-handoff module (adapter + transactional outbox) · [#85](https://github.com/madsnorgaard/aabenforms/issues/85) SF1470 journaling + KLE/FORM · [#86](https://github.com/madsnorgaard/aabenforms/issues/86) ESDH adapters (F2 / KMD Nova / Schultz / SAPA / GetOrganized / SBSYS)
-
-**⚙️ Advanced flow capabilities** ([`flows`](https://github.com/madsnorgaard/aabenforms/labels/flows))
-[#87](https://github.com/madsnorgaard/aabenforms/issues/87) SLA/deadline timers + escalation + reminders · [#88](https://github.com/madsnorgaard/aabenforms/issues/88) caseworker task inbox + parallel/join gateways + sub-processes · [#89](https://github.com/madsnorgaard/aabenforms/issues/89) appeals/klage + content_moderation + afgørelsesbrev generation · [#90](https://github.com/madsnorgaard/aabenforms/issues/90) persistent execution history + Recipe templates + standalone viewer
-
-**📋 Compliance & platform** ([`compliance`](https://github.com/madsnorgaard/aabenforms/labels/compliance))
-[#91](https://github.com/madsnorgaard/aabenforms/issues/91) GDPR retention + right-to-erasure · [#92](https://github.com/madsnorgaard/aabenforms/issues/92) WCAG 2.1 AA audit + NIS2/DPA/DPIA pack
-
-## Workflow System
-
-ÅbenForms provides a powerful visual workflow automation system for Danish municipal processes:
-
-### Key Features
-- **Pre-built Templates**: 13 BPMN templates for common use cases (building permits, parking permits, marriage booking, citizen service, address changes, FOI requests, company verification, contact form, HR onboarding, mileage expense, phone declaration, MED election, association booking)
-- **Visual Editor**: Create and modify workflows without programming
-- **Danish Integrations**: MitID authentication, CPR/CVR lookup, Digital Post notifications
-- **GDPR Compliant**: Automatic audit logging, encrypted CPR numbers, data retention policies
-
-### Quick Start
-1. Access workflow admin: `/admin/config/workflow/eca`
-2. Choose a template (Building Permit, Contact Form, etc.)
-3. Configure with the wizard (6 steps)
-4. Test with sample data
-5. Activate for production
-
-### Documentation
-- **[Municipal Admin Guide](docs/MUNICIPAL_ADMIN_GUIDE.md)** - Complete guide for non-technical administrators
-- **[Workflow Creation Tutorial](docs/tutorials/CREATE_APPROVAL_WORKFLOW.md)** - Step-by-step tutorial with examples
-- **[Approval Process Guide](docs/APPROVAL_PROCESS_GUIDE.md)** - End-to-end approval flow documentation
-- **[Workflow Templates Reference](docs/WORKFLOW_TEMPLATES.md)** - Detailed template specifications
-- **[Quick Reference Card](docs/QUICK_REFERENCE.md)** - One-page cheat sheet
-- **[Video Tutorial Script](docs/VIDEO_SCRIPT.md)** - 5-minute video guide
-
-### Testing Locally
-```bash
-# Create test workflow
-ddev drush aabenforms:create-test-workflow
-
-# Validate BPMN template
-ddev drush aabenforms:validate-template building_permit
-
-# Test approval flow
-ddev drush aabenforms:test-approval --workflow=daycare_enrollment
-```
+- Security ([`security`](https://github.com/madsnorgaard/aabenforms/labels/security)): circuit breaker #72, Digital Post idempotency #73, replay redaction #74, permission registration #75, consent-gate test #54
+- Productionise integrations ([`integration`](https://github.com/madsnorgaard/aabenforms/labels/integration)): Serviceplatformen certs #76, live Digital Post #77, Beskedfordeler #78, MitID production #79, DAWA + Datafordeler #80
+- Replace mocks ([`mocks`](https://github.com/madsnorgaard/aabenforms/labels/mocks)): payment #81, SMS #82, GIS/BBR #83
+- Case-system / ESDH handoff ([`esdh`](https://github.com/madsnorgaard/aabenforms/labels/esdh)): handoff module #84, SF1470 journaling #85, ESDH adapters #86
+- Advanced flows ([`flows`](https://github.com/madsnorgaard/aabenforms/labels/flows)): SLA and escalation #87, task inbox and gateways #88, appeals and letters #89, persistent history and templates #90
+- Compliance ([`compliance`](https://github.com/madsnorgaard/aabenforms/labels/compliance)): GDPR retention/erasure #91, WCAG and NIS2/DPA #92
 
 ## Development
 
-### Common Commands
 ```bash
-# Clear cache
-ddev drush cr
-
-# Export configuration
-ddev drush config:export -y
-
-# Import configuration
-ddev drush config:import -y
-
-# Update database
-ddev drush updatedb -y
-
-# Generate one-time login
-ddev drush user:login
+ddev drush cr                 # clear cache
+ddev drush config:export -y   # export config
+ddev drush config:import -y   # import config
+ddev exec phpunit -c web/core web/modules/custom/aabenforms_workflows/tests/src/Unit
 ```
 
-### Adding Modules
-```bash
-# Install via Composer
-ddev composer require drupal/<module_name>
+Workflow admin is at `/admin/config/workflow/eca`; the template wizard is at `/admin/aabenforms/workflow-templates`. See [docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md) for building flows and [docs/](docs/) for the template reference and admin guides.
 
-# Enable module
-ddev drush pm:enable <module_name>
+## Related
 
-# Export config
-ddev drush config:export -y
-```
-
-## BPMN Workflow Templates
-
-ÅbenForms ships 13 BPMN 2.0 workflow templates under
-`web/modules/custom/aabenforms_workflows/workflows/`:
-
-| Template | Use Case | Notes |
-|----------|----------|-------|
-| `building_permit` | Building permit applications | MitID, CPR lookup, audit logging |
-| `parking_permit` | Parking permit applications | MitID, payment, PDF, SMS |
-| `marriage_booking` | Marriage ceremony booking | Dual MitID, calendar, payment, reminders |
-| `address_change` | Address change notifications | DAWA, parallel system updates |
-| `company_verification` | Business registration verification | CVR + CPR cross-reference |
-| `foi_request` | Freedom of Information | 7-day deadline tracking |
-| `contact_form` | Generic citizen inquiry | Email + auto-response |
-| `citizen_service_application` | Service benefit application | MitID, CPR, caseworker review, **real Digital Post via `aabenforms_digital_post_send`** on both Approved and Rejected branches |
-| `hr_onboarding` | HR-initiated employee onboarding | Three-party cascade (HR → manager → IT) |
-| `mileage_expense` | Employee reimbursement | Manager approval, payroll forwarding |
-| `phone_declaration` | Private phone use declaration | Manager approval, archive |
-| `med_election_nomination` | MED committee election nomination | MitID, audit log (voting phase deferred) |
-| `association_booking` | Association facility booking / grant | MitID Erhverv, CVR lookup, payment |
-
-### Template Browser
-
-Browse, preview, and instantiate templates via admin UI:
-- Navigate to: **Workflow Templates** (`/admin/aabenforms/workflow-templates`)
-- Active Workflows section appears on top once you have instances
-- Click "Use This Template" to launch the 6-step wizard
-- Preview thumbnails render the BPMN diagram inline (BPMN.iO viewer)
-- Legacy import/export form: `/admin/config/workflow/aabenforms/templates`
-
-For detailed workflow development guide, see [docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md).
-
-## Documentation
-
-For detailed information, see:
-- **[docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md)** - BPMN workflow development guide
-- **[docs/TESTING_GUIDE.md](docs/TESTING_GUIDE.md)** - Testing guide
-- **Deployment**: orchestrated by
-  [contabo-infrastructure](https://github.com/madsnorgaard/contabo-infrastructure)
-  `.github/workflows/deploy.yml`. Push to `main` triggers a rebuild of the
-  Docker image on VPS2. See that repo's `docs/STATUS-REPORT.md` for the
-  current prod state.
-
-## Technology Stack
-
-| Component | Version | Purpose |
-|-----------|---------|---------|
-| Drupal Core | 11.3.2 | CMS |
-| PHP | 8.4 | Runtime |
-| MariaDB | 10.11 | Database |
-| ECA | 3.0.10 | Workflow engine |
-| BPMN.iO | 3.0.4 | Visual workflow modeller |
-| Webform | 6.3.0-beta7 | Forms |
-| Domain | 2.0.0-rc1 | Multi-tenancy |
-| Gin | 5.x | Admin theme |
-
-## Security
-
-**GDPR Compliance**: This platform handles sensitive data (CPR numbers). Always:
-1. Enable field-level encryption (`aabenforms_gdpr`)
-2. Log all CPR access (automatic via `aabenforms_cpr`)
-3. Obtain explicit consent before collection
-4. Implement data retention policies
-5. Support right to erasure
-
-## Related Projects
-
-- **Frontend**: [aabenforms-frontend](https://github.com/madsnorgaard/aabenforms-frontend) - Nuxt 3 SSR at https://aabenforms.dk
-- **Deployment orchestrator**: [contabo-infrastructure](https://github.com/madsnorgaard/contabo-infrastructure) - shared deploy workflow for this project and others on VPS2
+- Frontend: [aabenforms-frontend](https://github.com/madsnorgaard/aabenforms-frontend) (Nuxt 3)
+- Deployment: [contabo-infrastructure](https://github.com/madsnorgaard/contabo-infrastructure)
 
 ## License
 
-GPL-2.0 - See [LICENSE](LICENSE)
-
-## Contributing
-
-Issues and pull requests welcome at:
-https://github.com/madsnorgaard/aabenforms/issues
-
+GPL-2.0-or-later. See [LICENSE.txt](LICENSE.txt).

--- a/docs/PROMISES-VS-VERIFIED.md
+++ b/docs/PROMISES-VS-VERIFIED.md
@@ -6,7 +6,7 @@ Status key: **WORKS** (verified) · **PARTIAL** · **BROKEN** (verified defect) 
 
 | Claim | Status | Notes / fix |
 |---|---|---|
-| Visual workflow modeler, ready-made flows | **WORKS** | 18 ECA flows render in the React-Flow Workflow Modeler with execution replay; zero console errors. (Marketing "7"/"13 BPMN templates" count and "BPMN 2.0 designer" wording are inaccurate — it is the Modeler API / `workflow_modeler`.) |
+| Visual workflow modeler, ready-made flows | **WORKS** | 18 ECA flows render in the React-Flow Workflow Modeler with execution replay; zero console errors. (Marketing "7"/"13 BPMN templates" count and "BPMN 2.0 designer" wording are inaccurate - it is the Modeler API / `workflow_modeler`.) |
 | Parent-CPR consent gate ("only the right parent can approve", #54) | **BROKEN → fixed** | Was inert (no parent CPR collected → always `missing_expected_cpr`) and the controller failed **open**; session flag not submission-scoped. Closed in the consent-gate-hardening PR (fail-closed, real CPR fields, scoped session, submit-time re-verify). |
 | MitID authentication | **BROKEN → fixed** | `MitIdValidateAction` reported "verified" with no session ("demo mode"); the result token was never gated. Now fails **closed** by default behind `allow_mitid_demo_mode`. |
 | CPR/CVR lookup via Serviceplatformen (SF1520/SF1530) + audit "resolved against registry" | **BROKEN → fixed** | `getTokenValue()` looked up the literal `[token]` string, so the lookups never called Serviceplatformen yet logged success. Token resolution fixed; lookup steps now record `skipped`/`failed` honestly. |


### PR DESCRIPTION
The README had grown long and contradictory (POC/demo vs newer sections, 13 BPMN templates vs 18 flows, a Security section pointing at modules that do not exist, emojis, em dashes, 'powerful'). This rewrites it to ~105 lines: one status line, one honest real-vs-demo split, one module table, a plain roadmap linking the issue labels, and pointers to docs/ for the deep material. Also removes em dashes from docs/PROMISES-VS-VERIFIED.md. Restores the no-emoji/no-em-dash policy from #39.