### PR TITLE
Make the demo honest: no raw cURL error, labelled demo CPR/Digital Post

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 **ÅbenForms** is a headless workflow automation platform for Danish municipalities, built on:
-- **Backend**: Drupal 11.3.2 (this repository)
+- **Backend**: Drupal 11.3.10 (this repository)
 - **Frontend**: Nuxt 3 (separate repository)
 - **Deployment**: contabo-infrastructure orchestration (separate repository, deploys to VPS2)
 
@@ -16,17 +16,17 @@ This backend provides:
 - Modular SF1601 Digital Post (`aabenforms_digital_post` + ECA bridge submodule, plug-and-play on bare Drupal 11)
 - Shared admin design tokens via `aabenforms_core/admin` library (CSS custom properties)
 
-## Active workstream (Apr 2026)
+## Active workstream
 
-Modular Digital Post + NemLogin rewrite. Approved plan: `/home/mno/.claude/plans/zesty-wobbling-kahn.md`. Goal: each Danish-gov integration installs cleanly on any modern Drupal 11 with at most one mainstream contrib (`drupal:key`) - no OS2/Bellcom dependency maze.
+Modular Digital Post + NemLogin rewrite. Goal: each Danish-government integration installs cleanly on any modern Drupal 11 with at most one mainstream contrib (`drupal:key`), with no dependency on proprietary alternative stacks.
 
-- **Session 1 SHIPPED**: `aabenforms_digital_post` core (DTOs, sender service, fake_db / wiremock transports, Drush, settings form, log table). Live on prod in `fake_db` mode.
-- **Session 2A SHIPPED**: `aabenforms_digital_post_eca` submodule (plugin id `aabenforms_digital_post_send`). `citizen_service_application.bpmn` Approved + Rejected branches both wired; verified end-to-end on prod.
-- **Session 2B PENDING**: real MeMo XML + SF1601 SOAP via `itk-dev/serviceplatformen`; `live_test` against Serviceplatformen exttest endpoint.
-- **Session 2C PENDING**: `aabenforms_nemlogin` OIDC core + Keycloak preset + shim `aabenforms_mitid` over it.
-- **Session 3 PENDING**: webform / beskedfordeler / os2web_key bridges, advanced queue, examples, remove `aabenforms_mitid`, bare-D11 GitHub Actions verification.
+- **Session 1 (shipped)**: `aabenforms_digital_post` core (DTOs, sender service, fake_db / wiremock transports, Drush, settings form, log table). Runs on the demo in `fake_db` mode. No live MeMo/SOAP and no idempotency yet.
+- **Session 2A (shipped)**: `aabenforms_digital_post_eca` submodule (plugin id `aabenforms_digital_post_send`). `citizen_service_application.bpmn` Approved + Rejected branches both wired.
+- **Session 2B (planned, issue #77)**: real MeMo XML + SF1601 SOAP via `itk-dev/serviceplatformen`; `live_test` against Serviceplatformen exttest endpoint.
+- **Session 2C (planned, issue #79)**: `aabenforms_nemlogin` OIDC core + Keycloak preset + shim `aabenforms_mitid` over it. These modules do not exist yet.
+- **Session 3 (planned)**: webform / beskedfordeler (#78) / key bridges, advanced queue, examples, remove `aabenforms_mitid`, bare-D11 GitHub Actions verification.
 
-Recent platform-wide fixes (Apr 25, 2026):
+Recent platform-wide fixes:
 - `aabenforms_log` shim replaces removed upstream `eca_base_log`/`eca_base_mail`. `aabenforms_workflows_update_11001` migrates saved configs.
 - `hook_storage_transform_import` in `aabenforms_workflows.module` preserves wizard-created configs across `drush cim` (without it, every deploy nuked admin-created workflows).
 - Wizard step indicator modernized (numbered circles + track line) using `--af-*` tokens from `aabenforms_core/admin`.
@@ -37,9 +37,9 @@ Recent platform-wide fixes (Apr 25, 2026):
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| Drupal Core | 11.3.2 | CMS foundation |
+| Drupal Core | 11.3.10 | CMS foundation |
 | PHP | 8.4 | Runtime |
-| MariaDB | 10.11 | Database (consistent local→production) |
+| MariaDB | (DDEV default) | Database (consistent local to production) |
 | DDEV | Latest | Local development |
 | Composer | 2.x | Dependency management |
 | Drush | 13.7 | CLI tool |
@@ -102,139 +102,116 @@ ddev composer update drupal/core --with-dependencies
 
 ### Custom Modules (Package: ÅbenForms)
 
+These are the modules that actually exist today under `web/modules/custom/`:
+
 ```
 web/modules/custom/
-├── aabenforms_core/              # Foundation (CRITICAL - Phase 1)
+├── aabenforms_core/              # Foundation: shared services, Serviceplatformen
+│   │                            #   client, field-level CPR encryption (AES-256),
+│   │                            #   GDPR audit logging, admin design tokens
 │   ├── aabenforms_core.info.yml
 │   ├── aabenforms_core.module
 │   └── src/
-│       └── Services/             # Shared services, utilities
 │
-├── aabenforms_tenant/            # Multi-tenancy (Optional - Phase 1)
+├── aabenforms_tenant/            # Multi-tenancy (depends on: domain)
 │   ├── aabenforms_tenant.info.yml
-│   ├── aabenforms_tenant.module
 │   └── src/
-│       ├── Entity/TenantConfig.php
-│       └── Services/TenantDetector.php
 │
-├── aabenforms_workflows/         # ECA integration (CRITICAL - Phase 1)
+├── aabenforms_workflows/         # ECA integration + Workflow Modeler editor
+│   │                            #   13 workflow templates (.bpmn source files),
+│   │                            #   21 ECA action plugins (incl. CPR/CVR lookup)
 │   ├── aabenforms_workflows.info.yml
 │   ├── aabenforms_workflows.module
-│   └── config/install/           # Pre-built workflow templates
+│   └── workflows/                # .bpmn template source files
 │
-├── aabenforms_gdpr/              # Security & GDPR (HIGH - Phase 2)
-│   └── [Field encryption, audit logs, retention policies]
+├── aabenforms_webform/           # Custom webform elements with server-side
+│   └──                          #   validation: CPR (modulus-11), CVR, DAWA address
 │
-├── aabenforms_mitid/             # MitID authentication (HIGH - Phase 2)
-│   └── [OIDC integration for citizen/business login]
+├── aabenforms_mitid/             # MitID OIDC sign-in (against a Keycloak mock IdP)
+│   └──                          #   Fails closed by default; demo mode gated by
+│                                #   allow_mitid_demo_mode
 │
-├── aabenforms_cpr/               # SF1520 CPR lookup (HIGH - Phase 3)
-│   └── [Serviceplatformen person data]
-│
-├── aabenforms_cvr/               # SF1530 CVR lookup (HIGH - Phase 3)
-│   └── [Serviceplatformen company data]
-│
-├── aabenforms_dawa/              # Address autocomplete (MEDIUM - Phase 3)
-│   └── [Danish address validation]
-│
-├── aabenforms_digital_post/      # SF1601 Digital Post (HIGH - Phase 3)
-│   └── [Official notifications]
-│
-├── aabenforms_sbsys/             # SBSYS integration (MEDIUM - Phase 4)
-│   └── [Case management]
-│
-└── aabenforms_get_organized/     # GetOrganized ESDH (MEDIUM - Phase 4)
-    └── [Document archiving]
+└── aabenforms_digital_post/      # SF1601 Digital Post core (DTOs, sender service)
+    └── modules/
+        ├── aabenforms_digital_post_eca/            # ECA bridge submodule
+        └── aabenforms_digital_post_session_inbox/  # Session inbox submodule
 ```
 
-### Module Dependencies
+Planned, not yet implemented (do not assume these exist): `aabenforms_nemlogin`
+(+ `_keycloak`), `aabenforms_digital_post_webform`, `aabenforms_digital_post_beskedfordeler`,
+`aabenforms_digital_post_os2web_key`, `aabenforms_cpr`, `aabenforms_cvr`, `aabenforms_dawa`,
+`aabenforms_gdpr`, `aabenforms_sbsys`, `aabenforms_get_organized`. See the GitHub issue
+backlog (#72-#92) for status.
+
+Notes on the "standalone module" framing:
+- CPR (SF1520) and CVR (SF1530) lookup are ECA action plugins inside `aabenforms_workflows`
+  plus a Serviceplatformen client in `aabenforms_core` - not standalone modules.
+- DAWA address autocomplete is a webform element in `aabenforms_webform` - not a module.
+- Field-level CPR encryption and GDPR audit logging are built into `aabenforms_core`. There
+  is no retention / right-to-erasure subsystem yet (planned, issue #91).
+
+### Module Dependencies (existing modules)
 
 ```
-aabenforms_core (no dependencies)
-  ↓
-  ├─→ aabenforms_tenant (depends on: domain module)
-  ├─→ aabenforms_workflows (depends on: eca, webform)
-  ├─→ aabenforms_gdpr (depends on: encrypt, key, real_aes)
-  ├─→ aabenforms_mitid (depends on: openid_connect, aabenforms_gdpr)
-  ├─→ aabenforms_cpr (depends on: aabenforms_gdpr)
-  ├─→ aabenforms_cvr (depends on: aabenforms_core)
-  ├─→ aabenforms_dawa (depends on: aabenforms_core)
-  ├─→ aabenforms_digital_post (depends on: aabenforms_gdpr)
-  ├─→ aabenforms_sbsys (depends on: aabenforms_workflows)
-  └─→ aabenforms_get_organized (depends on: aabenforms_workflows)
+aabenforms_core (no aabenforms dependencies)
+  ├─→ aabenforms_tenant (depends on: domain)
+  ├─→ aabenforms_workflows (depends on: eca, webform; eca 3.1 also needs modeler_api)
+  ├─→ aabenforms_webform (depends on: webform, aabenforms_core)
+  ├─→ aabenforms_mitid (depends on: openid_connect, aabenforms_core)
+  └─→ aabenforms_digital_post (depends on: key, aabenforms_core)
+        ├─→ aabenforms_digital_post_eca (depends on: eca)
+        └─→ aabenforms_digital_post_session_inbox
 ```
-
-**Key Principle**: All Danish integration modules are STANDALONE - enable only what you need.
 
 ## Contrib Modules
 
 | Module | Version | Purpose |
 |--------|---------|---------|
 | **Workflow Engine** | | |
-| eca | 2.1.18 | Event-Condition-Action engine (replaces Maestro) |
-| webform | 6.3.0-beta7 | Dynamic form builder |
+| eca | 3.1.1 | Event-Condition-Action engine (depends on modeler_api) |
+| modeler | 1.0.3 | Workflow Modeler editor (adopted editor for all flows) |
+| bpmn_io | 3.0.5 | Present, but the Workflow Modeler is the adopted editor |
+| webform | 6.3.0-beta8 | Dynamic form builder |
 | **Multi-Tenancy** | | |
-| domain | 2.0.0-rc1 | URL-based tenant routing |
-| domain_access | 2.0.0-rc1 | Per-tenant content isolation |
-| **Security & GDPR** | | |
-| encrypt | 3.2.0 | Field-level encryption |
+| domain | 2.0.1 | URL-based tenant routing |
+| domain_access | 2.0.1 | Per-tenant content isolation |
+| **Security** | | |
 | key | 1.22.0 | Key management |
-| real_aes | 2.6.0 | AES encryption provider |
 | **API** | | |
 | jsonapi | Core | JSON:API implementation |
 | jsonapi_extras | 3.28.0 | JSON:API enhancements |
 | **Authentication** | | |
-| openid_connect | 3.0.0-alpha6 | OpenID Connect (for MitID) |
-| externalauth | 2.0.8 | External authentication framework |
+| openid_connect | 3.x | OpenID Connect (for MitID) |
+| externalauth | 2.x | External authentication framework |
 | **Admin** | | |
-| gin | 3.0.0 | Modern admin theme |
-| gin_toolbar | 1.0.0 | Enhanced toolbar |
+| gin | 5.0.12 | Admin theme |
+| gin_toolbar | 2.x | Toolbar |
 
-## Danish Government Integrations Roadmap
+## Danish Government Integrations
 
-### Phase 2: Authentication & Security (Weeks 5-8)
-- **aabenforms_mitid**: MitID OIDC integration
-  - Personal login (MitID Privat)
-  - Business login (MitID Erhverv)
-  - NSIS compliance
-- **aabenforms_gdpr**: GDPR compliance
-  - CPR field encryption (AES-256)
-  - Access audit logging
-  - Data retention policies
-  - Right to erasure workflows
+### Today (real, against test/mock endpoints)
+- **aabenforms_mitid**: MitID OIDC sign-in against a Keycloak mock IdP. No live registration;
+  fails closed by default, demo mode behind `allow_mitid_demo_mode`.
+- **CPR (SF1520) / CVR (SF1530) lookup**: action plugins in `aabenforms_workflows` plus a
+  Serviceplatformen client in `aabenforms_core`. Run against test/WireMock; live access needs
+  client certificates (planned, issue #76).
+- **DAWA / CPR / CVR webform elements**: custom elements in `aabenforms_webform` with
+  server-side validation (CPR modulus-11, CVR, DAWA).
+- **Field-level CPR encryption + audit logging**: built into `aabenforms_core`.
+- **aabenforms_digital_post** (SF1601): runs in `fake_db` / `wiremock` test modes. No live
+  MeMo/SOAP and no idempotency yet (planned, issues #73, #77).
 
-### Phase 3: Serviceplatformen (Weeks 9-12)
-All integrations via **Serviceplatformen SF15** (KOMBIT's API gateway):
+### Planned (not yet implemented - see GitHub backlog #72-#92)
+- Live Serviceplatformen certs + enrollment for SF1520/SF1530 (#76)
+- Real SF1601 MeMo builder + SOAP transport (#77)
+- Beskedfordeler SF1461/SF1462 delivery receipts (#78)
+- MitID / NemLog-in token validation + production registration (#79)
+- DAWA + Datafordeler (BBR/Matriklen) server-side validation (#80)
+- Case-handoff / ESDH adapters and SF1470 journaling (#84-#86)
+- GDPR retention + right-to-erasure subsystem (#91)
 
-- **aabenforms_cpr** (SF1520): CPR lookup
-  - Person master data
-  - Address history
-  - Family relations
-
-- **aabenforms_cvr** (SF1530): CVR lookup
-  - Company data
-  - P-numbers (production units)
-  - Industry classifications
-
-- **aabenforms_dawa**: DAWA autocomplete
-  - Address validation
-  - Geolocation
-  - Direct integration (no auth required)
-
-- **aabenforms_digital_post** (SF1601): Digital Post
-  - Secure notifications
-  - Fallback to physical mail
-  - Delivery receipts
-
-### Phase 4: Case Management (Weeks 13-16)
-- **aabenforms_sbsys**: SBSYS integration
-  - Case creation
-  - Document archiving
-  - Status synchronization
-
-- **aabenforms_get_organized**: GetOrganized ESDH
-  - Document filing
-  - Metadata management
+Payment, SMS, GIS/zoning, payroll and calendar/booking actions are currently demo mocks, not
+production integrations (#81-#83).
 
 ## Development Workflow
 
@@ -288,7 +265,12 @@ ddev drush domain:create odense.aabenforms.ddev.site "Odense Kommune"
 # 127.0.0.1 odense.aabenforms.ddev.site
 ```
 
-## BPMN Workflow Development
+## Workflow Development
+
+The visual editor is the **Workflow Modeler** provided by `drupal/modeler` (React Flow /
+Modeler API, modeler_id `workflow_modeler`). It is the adopted editor for all flows. `bpmn_io`
+is installed but is not the editor used for the flows. Workflow templates are stored as `.bpmn`
+source files (BPMN is the on-disk template format, not the editor).
 
 ### BpmnTemplateManager Service
 
@@ -321,7 +303,9 @@ file_put_contents('/tmp/workflow.bpmn', $exported);
 
 ### Creating Custom BPMN Templates
 
-BPMN templates are stored in `web/modules/custom/aabenforms_workflows/templates/bpmn/`:
+There are 13 ready-made workflow templates (BPMN source files) stored in
+`web/modules/custom/aabenforms_workflows/workflows/`, and 18 ECA flows deployed under
+`config/sync/eca.eca.*`. A template file looks like this:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -364,7 +348,8 @@ BPMN templates are stored in `web/modules/custom/aabenforms_workflows/templates/
 
 ### ECA Action Plugins
 
-ÅbenForms provides 4 custom ECA action plugins for Danish workflows:
+ÅbenForms provides 21 custom ECA action plugins (non-test) in `aabenforms_workflows` for Danish
+workflows. A few representative examples:
 
 #### 1. MitID Validation (`aabenforms_mitid_validate`)
 ```php
@@ -449,10 +434,10 @@ To export:
  **CRITICAL**: CPR numbers (Danish social security numbers) are **sensitive personal data** under GDPR Article 9.
 
 **Requirements**:
-1. **Field-level encryption** via `aabenforms_gdpr` module
+1. **Field-level encryption** built into `aabenforms_core`
 2. **Access logging** - all CPR lookups must be audited
 3. **Data minimization** - only request CPR when absolutely necessary
-4. **Retention policies** - auto-delete after legal retention period
+4. **Retention policies** - planned, not yet implemented (issue #91)
 5. **Consent management** - explicit user consent required
 
 ### Encryption Setup
@@ -465,7 +450,7 @@ ddev drush config:set encrypt.profile.cpr_encryption encryption_key aes
 ```
 
 ### Audit Logging
-All CPR lookups via `aabenforms_cpr` are automatically logged:
+All CPR lookups via the CPR lookup action plugin are automatically logged:
 - User ID
 - Timestamp
 - CPR queried
@@ -503,8 +488,8 @@ web_environment:
 
 ## Database
 
-**Type**: MariaDB 10.11
-**Why**: Consistent across all environments (local DDEV → Platform.sh production)
+**Type**: MariaDB (DDEV default)
+**Why**: Consistent across local and production environments
 
 ```bash
 # Connect to database
@@ -532,9 +517,9 @@ ddev drush config:get system.performance
 ```
 
 ### Production Recommendations
-- Enable Redis (Platform.sh service)
+- Enable Redis or Memcached
 - Enable Drupal performance caching
-- Use Varnish (Platform.sh CDN)
+- Put a reverse-proxy cache or CDN in front
 - Lazy-load Webform fields
 - Index frequently queried fields
 
@@ -691,10 +676,10 @@ ddev exec phpunit --filter=SendSmsActionTest
 
 **Creating New BPMN Templates**:
 
-1. **Use BPMN Modeler**:
+1. **Use the Workflow Modeler** (drupal/modeler, modeler_id `workflow_modeler`):
    ```
-   Navigate to: /admin/config/workflow/eca/modeler
-   Create new model or import BPMN 2.0 XML
+   Navigate to: /admin/config/workflow/eca
+   Create a new model with the Workflow Modeler, or import a .bpmn template file
    ```
 
 2. **Template Structure**:
@@ -959,4 +944,4 @@ ddev drush watchdog:show --format=json > workflow_logs.json
 
 ## License
 
-GPL-2.0 - See LICENSE file
+GPL-2.0-or-later - See LICENSE file

--- a/docs/CI_CD_STRATEGY.md
+++ b/docs/CI_CD_STRATEGY.md
@@ -13,7 +13,7 @@
 ├─────────────────────────────────────────────────────────────┤
 │                                                              │
 │  Local Dev          CI/CD              Staging     Production│
-│  (DDEV)         (GitHub Actions)      (Platform)  (Platform) │
+│  (DDEV)         (GitHub Actions)      (Docker)    (VPS2)     │
 │     │                  │                  │            │      │
 │     ▼                  ▼                  ▼            ▼      │
 │  Mock Services    Mock Services      Mock Services  Real     │
@@ -512,7 +512,7 @@ jobs:
 
 ---
 
-## 3. Staging Environment (Platform.sh / Docker)
+## 3. Staging Environment (Docker)
 
 ### Docker Compose for Staging
 
@@ -585,11 +585,8 @@ volumes:
 
 **Deploy to Staging**:
 ```bash
-# On staging server
+# On the staging host
 docker compose -f docker-compose.staging.yml up -d
-
-# Or use Platform.sh
-platform push
 ```
 
 ---
@@ -712,10 +709,8 @@ strategy:
 
 | Metric | With Mocks | Without Mocks |
 |--------|-----------|---------------|
-| **Setup Time** | 30 seconds | N/A (impossible) |
-| **Test Speed** | 5 minutes | N/A |
+| **Setup Time** | Seconds | N/A (impossible) |
 | **Credentials Needed** | None | Required |
-| **Cost** | $0 | DKK 200,000+ |
 | **Offline Development** | Yes | No |
 
 ---
@@ -798,9 +793,16 @@ SLACK_WEBHOOK            # Notifications
 
 ### Continuous Deployment (CD)
 
+Production runs on VPS2 (the contabo-infrastructure host) as a Docker image.
+Deployment is not driven by a Platform.sh action; instead a push to `main`
+fires a `repository_dispatch` event that the `contabo-infrastructure`
+`deploy.yml` workflow picks up on the self-hosted runner. That workflow
+rebuilds the backend Docker image on VPS2 and runs `drush updatedb` and
+`drush cim` against the live container.
+
 ```yaml
-# .github/workflows/deploy.yml
-name: Deploy to Production
+# .github/workflows/deploy.yml (project repo)
+name: Trigger production deploy
 
 on:
   push:
@@ -808,34 +810,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Deploy to Platform.sh
+  dispatch:
+    name: Notify contabo-infrastructure
     runs-on: ubuntu-latest
     needs: [ci-summary]  # Only deploy if CI passes
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Deploy to Platform.sh
-        uses: platformsh/deploy-action@v1
-        with:
-          project-id: ${{ secrets.PLATFORMSH_PROJECT_ID }}
-          cli-token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-
-      - name: Run database updates
+      - name: Fire repository_dispatch
         run: |
-          platform ssh "cd /app/backend && vendor/bin/drush updatedb -y"
-          platform ssh "cd /app/backend && vendor/bin/drush cr"
+          gh api repos/madsnorgaard/contabo-infrastructure/dispatches \
+            -f event_type=deploy-aabenforms \
+            -F client_payload[sha]=${{ github.sha }}
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+```
 
-      - name: Notify on success
-        uses: slackapi/slack-github-action@v1
-        with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          payload: |
-            {
-              "text": "Deployed to production: ${{ github.sha }}"
-            }
+On VPS2 the `contabo-infrastructure` deploy job rebuilds the image and applies
+config:
+
+```bash
+docker compose -f ~/docker/aabenforms/docker-compose.yml up -d --build
+docker compose exec -T backend drush updatedb -y
+docker compose exec -T backend drush cim -y
 ```
 
 ---
@@ -903,9 +899,6 @@ jobs:
 **Docker Compose**:
 - https://docs.docker.com/compose/
 
-**Platform.sh**:
-- https://docs.platform.sh/
-
 **Testing Tools**:
 - PHPUnit: https://phpunit.de/
 - Playwright: https://playwright.dev/
@@ -919,26 +912,23 @@ jobs:
 
 1. **Mock services everywhere** (local, CI, staging)
 2. **No credentials needed** for development
-3. **Fast CI/CD** (15 minutes total)
-4. **Cost-effective** ($0 for CI minutes)
-5. **Production-ready** (switch to real services in prod)
+3. **Fast CI/CD**
+4. **Environment-switched services** (mocks in local/CI/staging; real Danish
+   government endpoints are wired only in production, and most of those
+   integrations are still test/mock-backed - see `docs/PROMISES-VS-VERIFIED.md`)
 
 ### Key Benefits
 
-- **99% faster** than waiting for credentials
-- **DKK 200,000+ saved** per project
-- **Deterministic tests** (same data every time)
-- **Secure** (no production credentials in CI)
--  **Scalable** (parallel jobs, caching)
+- No waiting for real-service credentials to run the suite
+- Deterministic tests (same data every time)
+- Secure (no production credentials in CI)
+- Scalable (parallel jobs, caching)
 
 ---
 
-**Status**: **READY TO IMPLEMENT**
-
-**Next Command**: Create `.github/workflows/ci.yml` and push to test!
+**Status**: Implemented. CI runs on every push and pull request.
 
 ---
 
-**Created By**: Claude Sonnet 4.5 + Mads Nørgaard
 **Date**: 2026-01-25
 **Version**: 1.0.0

--- a/docs/CI_WITH_MOCK_SERVICES.md
+++ b/docs/CI_WITH_MOCK_SERVICES.md
@@ -1,17 +1,25 @@
 # CI/CD with Danish Government Mock Services
 
-**Status**: **COMPLETE** - Mock services integrated into GitHub Actions CI
-**Date**: 2026-01-25
+**Status**: Working - mock services integrated into GitHub Actions CI
+
+This is a pre-pilot POC. The same mock services described here run locally in DDEV
+and in CI; none of them talk to live Danish government endpoints.
 
 ---
 
 ## What We Built
 
-Your GitHub Actions CI pipeline now runs with the **same Danish government mock services** that you use locally in DDEV:
+The GitHub Actions CI pipeline runs with the same Danish government mock services
+used locally in DDEV:
 
-1. **Keycloak** (MitID Mock) - 10 realistic Danish test users
-2. **WireMock** (Serviceplatformen Mock) - SF1520 CPR lookup stubs
-3. **Realistic test data** - Valid CPR numbers, Danish names, Copenhagen addresses
+1. Keycloak (MitID mock) - 10 Danish test users in the `danish-gov-test` realm
+2. WireMock (Serviceplatformen mock) - SF1520 CPR lookup stubs
+3. Test data - valid CPR numbers, Danish names, Copenhagen addresses
+
+MitID is a Keycloak mock realm only (no live MitID registration). CPR (SF1520) and
+CVR (SF1530) lookups run against WireMock; live use would require client
+certificates. Digital Post (SF1601) is exercised in test/mock modes only - there is
+no live MeMo/SOAP path yet.
 
 ---
 
@@ -45,9 +53,9 @@ Your GitHub Actions CI pipeline now runs with the **same Danish government mock 
                        ┌──────────────────────┐
                        │ CI Summary           │
                        │                      │
-                       │ Tests passed      │
-                       │ 70% coverage      │
-                       │ 🇩🇰 10 test users    │
+                       │ Tests result         │
+                       │ Coverage report      │
+                       │ 10 test users        │
                        └──────────────────────┘
 ```
 
@@ -81,10 +89,10 @@ The CI pipeline automatically:
 - No external API dependencies
 - **100% offline capable**
 
-### 4. Fast & Free
+### 4. Fast and free
 
-- **Pipeline duration**: ~5-8 minutes
-- **Cost**: $0 (GitHub free tier)
+- **Pipeline duration**: a few minutes
+- **Cost**: GitHub free tier
 - **Parallel jobs**: Composer validation + PHPUnit tests
 - **Caching**: Composer dependencies cached
 
@@ -179,7 +187,7 @@ class MitIdAuthenticationTest extends KernelTestBase {
 ```php
 <?php
 
-namespace Drupal\Tests\aabenforms_cpr\Kernel;
+namespace Drupal\Tests\aabenforms_workflows\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use GuzzleHttp\Client;
@@ -187,12 +195,16 @@ use GuzzleHttp\Client;
 /**
  * Tests SF1520 CPR lookup with mock Serviceplatformen.
  *
- * @group aabenforms_cpr
+ * CPR (SF1520) and CVR (SF1530) lookups are action plugins in
+ * aabenforms_workflows backed by the Serviceplatformen client in
+ * aabenforms_core. They are not standalone modules.
+ *
+ * @group aabenforms_workflows
  * @group integration
  */
 class CprLookupTest extends KernelTestBase {
 
-  protected static $modules = ['aabenforms_core', 'aabenforms_cpr'];
+  protected static $modules = ['aabenforms_core', 'aabenforms_workflows'];
 
   public function testMockCprLookup() {
     $serviceplatformenUrl = getenv('SERVICEPLATFORMEN_URL');
@@ -290,7 +302,7 @@ Navigate to: `https://github.com/madsnorgaard/aabenforms/actions`
 You'll see:
 - All jobs (Composer validation, PHPUnit tests)
 - Code coverage percentage
-- 🇩🇰 Mock service information
+- Mock service information
 -  Duration (~5-8 minutes)
 
 ### 3. Coverage Report Artifact
@@ -343,13 +355,11 @@ ddev test
 
 ## Benefits Summary
 
-| Metric | Before Mock Services | With Mock Services | Improvement |
-|--------|---------------------|-------------------|-------------|
-| **Setup Time** | 4-8 weeks (credentials) | 5 minutes | **99% faster** |
-| **CI Duration** | 15-20 min (external APIs) | 5-8 min | **60% faster** |
-| **CI Cost** | $50-100/month (paid tier) | $0 | **100% saved** |
-| **Test Reliability** | 70% (flaky APIs) | 99% (deterministic) | **41% more stable** |
-| **Offline Development** | No | Yes | **Developer happiness** |
+Running against mock services instead of live Danish government endpoints means:
+
+- No service agreements or production credentials needed to develop or run CI
+- No external network dependency, so CI is deterministic and can run offline
+- Faster, more reliable CI runs (no flaky third-party APIs)
 
 ---
 
@@ -357,11 +367,11 @@ ddev test
 
 ### 1. Write More Integration Tests
 
-Focus on modules that will integrate with Danish services:
-- `aabenforms_mitid`: Authentication flows
-- `aabenforms_cpr`: CPR data validation
-- `aabenforms_cvr`: Company lookup (add SF1530 stubs)
-- `aabenforms_digital_post`: Notification delivery (add SF1601 stubs)
+Focus on the areas that integrate with Danish services:
+- `aabenforms_mitid`: authentication flows (Keycloak mock)
+- `aabenforms_workflows`: CPR (SF1520) and CVR (SF1530) lookup action plugins
+- `aabenforms_core`: Serviceplatformen client
+- `aabenforms_digital_post`: Digital Post (SF1601) delivery in fake_db / wiremock modes
 
 ### 2. Add More WireMock Stubs
 
@@ -450,43 +460,27 @@ Configure GitHub to require CI passing before merge:
 
 ---
 
-## Success Metrics
+## Coverage Targets
 
-### Coverage Goals
-- **aabenforms_core**: 70%+ (foundation services)
-- **aabenforms_mitid**: 80%+ (authentication critical)
-- **aabenforms_cpr**: 80%+ (personal data handling)
-- **aabenforms_workflows**: 60%+ (ECA integration)
-
-### CI Performance Goals
-- **Duration**: < 10 minutes
-- **Reliability**: > 95% pass rate
-- **Cost**: $0 (free tier)
+Targets to aim for as tests are added:
+- **aabenforms_core**: foundation services and Serviceplatformen client
+- **aabenforms_mitid**: authentication (security critical)
+- **aabenforms_workflows**: ECA actions including CPR/CVR lookup
+- **aabenforms_digital_post**: SF1601 in test/mock modes
 
 ---
 
-## Community Value
+## Reusing the Mock Stack
 
-This CI setup can be shared with:
-- **OS2 community**: Other municipalities building on Drupal
-- **Danish government projects**: Reusable mock services
-- **Open-source projects**: Standards-based testing approach
-
-Consider extracting `.ddev/mocks/` to separate repository:
-```
-github.com/os2community/danish-gov-mock-services
-```
-
-Benefits:
-- Reusable across projects
-- Docker Hub images
-- Community contributions (more test users, more stubs)
-- Presentation at OS2 Day
+The `.ddev/mocks/` setup (Keycloak realm + WireMock mappings) is self-contained and
+could be extracted into a separate repository for reuse across other Drupal projects
+or open-source efforts. It is standards-based (OIDC, SOAP) so it is not tied to this
+project.
 
 ---
 
-**Status**: **COMPLETE** - CI with mock services is ready
+**Status**: Working - CI runs against mock services.
 
-**Next Action**: Write your first integration test and watch it run with Danish test data!
+**Next Action**: Write an integration test and run it with the Danish test data.
 
-**Questions?** See `docs/DDEV_MOCK_SERVICES_GUIDE.md` for detailed setup guide.
+**Questions?** See `docs/DDEV_MOCK_SERVICES_GUIDE.md` for the setup guide.

--- a/docs/MOCK_SERVICES_QUICK_REFERENCE.md
+++ b/docs/MOCK_SERVICES_QUICK_REFERENCE.md
@@ -1,6 +1,8 @@
 # ÅbenForms Mock Services - Quick Reference Card
 
-**Print this page and keep it handy while developing!** 
+Quick reference for the local DDEV mock services. MitID is a Keycloak mock realm,
+Serviceplatformen (CPR/CVR) is a WireMock mock, and DAWA is mocked via Prism. None
+of these talk to live Danish government endpoints.
 
 ---
 
@@ -26,7 +28,7 @@ ddev mocks-logs         # View logs
 
 ---
 
-##  Test Users (Password: test1234)
+## Test Users (Password: test1234)
 
 | Username | Name | CPR | Type |
 |----------|------|-----|------|
@@ -52,7 +54,7 @@ ddev mocks-logs         # View logs
 
 ---
 
-##  Quick Tests
+## Quick Tests
 
 ### Test MitID Login
 ```bash
@@ -80,7 +82,7 @@ curl http://localhost:8080/realms/danish-gov-test/.well-known/openid-configurati
 
 ---
 
-##  Drupal Configuration Snippet
+## Drupal Configuration Snippet
 
 **File**: `web/sites/default/settings.local.php`
 
@@ -91,17 +93,18 @@ $config['aabenforms_mitid.settings']['oidc']['client_id'] = 'aabenforms-backend'
 $config['aabenforms_mitid.settings']['oidc']['client_secret'] = 'aabenforms-backend-secret-change-in-production';
 $config['aabenforms_mitid.settings']['mock_mode'] = TRUE;
 
-// Serviceplatformen Mock
+// Serviceplatformen Mock (CPR SF1520 / CVR SF1530 via WireMock)
 $config['aabenforms_core.settings']['serviceplatformen']['endpoint'] = 'http://localhost:8081';
 $config['aabenforms_core.settings']['serviceplatformen']['mock_mode'] = TRUE;
 
-// DAWA Mock
-$config['aabenforms_dawa.settings']['api_url'] = 'http://localhost:8082';
+// DAWA Mock (Prism). DAWA address lookup is a webform element in
+// aabenforms_webform, not a standalone module.
+$config['aabenforms_webform.settings']['dawa']['api_url'] = 'http://localhost:8082';
 ```
 
 ---
 
-##  Nuxt 3 Configuration Snippet
+## Nuxt 3 Configuration Snippet
 
 **File**: `nuxt.config.ts`
 
@@ -127,7 +130,7 @@ export default defineNuxtConfig({
 
 ---
 
-##  Troubleshooting
+## Troubleshooting
 
 ### Keycloak Not Starting?
 ```bash
@@ -158,7 +161,7 @@ ddev mocks-logs wiremock                     # Check logs
 
 ---
 
-##  OIDC Endpoints (MitID Mock)
+## OIDC Endpoints (MitID Mock)
 
 ```
 Discovery:      http://localhost:8080/realms/danish-gov-test/.well-known/openid-configuration
@@ -171,7 +174,7 @@ Logout:         http://localhost:8080/realms/danish-gov-test/protocol/openid-con
 
 ---
 
-##  Serviceplatformen Endpoints
+## Serviceplatformen Endpoints
 
 ```
 SF1520 (CPR):         POST http://localhost:8081/sf1520
@@ -181,7 +184,7 @@ SF1601 (Digital Post): POST http://localhost:8081/sf1601
 
 ---
 
-##  DAWA API Endpoints
+## DAWA API Endpoints
 
 ```
 Autocomplete:  GET http://localhost:8082/adresser/autocomplete?q={query}
@@ -244,7 +247,7 @@ ddev drush sql:query "SELECT * FROM aabenforms_audit_log ORDER BY timestamp DESC
 
 ---
 
-##  Full Documentation
+## Full Documentation
 
 - **Comprehensive Guide**: `docs/DDEV_MOCK_SERVICES_GUIDE.md`
 - **International Standards**: `docs/INTERNATIONAL_STANDARDS_AND_TOOLS.md`
@@ -252,7 +255,7 @@ ddev drush sql:query "SELECT * FROM aabenforms_audit_log ORDER BY timestamp DESC
 
 ---
 
-## 🆘 Need Help?
+## Need Help?
 
 1. Check logs: `ddev mocks-logs [service]`
 2. Verify status: `ddev mocks-status`
@@ -262,6 +265,4 @@ ddev drush sql:query "SELECT * FROM aabenforms_audit_log ORDER BY timestamp DESC
 
 ---
 
-**Happy Coding!** 🇩🇰
-
-**Version**: 1.0.0 | **Last Updated**: 2026-01-25
+Drupal 11.3.10 / PHP 8.4 / ECA 3.1.1. Pre-pilot POC.

--- a/docs/MOCK_SERVICES_STATUS.md
+++ b/docs/MOCK_SERVICES_STATUS.md
@@ -59,9 +59,9 @@ curl http://localhost:8080/realms/danish-gov-test/.well-known/openid-configurati
 - **SF1520** (CPR Lookup) - Freja Nielsen (CPR: 0101904521)
 
 **Missing Stubs** (TODO):
-- ⏳ SF1520 for remaining 9 test users
-- ⏳ SF1530 (CVR Lookup)
-- ⏳ SF1601 (Digital Post)
+- SF1520 for remaining 9 test users
+- SF1530 (CVR Lookup)
+- SF1601 (Digital Post)
 
 **Verification**:
 ```bash

--- a/docs/MUNICIPAL_SALES_GUIDE.md
+++ b/docs/MUNICIPAL_SALES_GUIDE.md
@@ -4,47 +4,51 @@
 **Version**: 1.0
 **Date**: February 2026
 **Target Audience**: Municipal decision-makers, IT managers, digital transformation leaders
+**Status**: Pre-pilot POC. Live demo at https://aabenforms.dk (frontend) and https://api.aabenforms.dk (backend). MitID via Keycloak mock; Serviceplatformen and Digital Post via test/mock endpoints. No production municipality deployments yet.
 
 ---
 
 ## Executive Summary
 
-ÅbenForms is an open-source digital workflow automation platform purpose-built for Danish municipalities. It enables citizen-facing services through visual workflow design, seamless integration with Danish government systems, and full GDPR compliance - all at zero licensing cost.
+ÅbenForms is an open-source digital workflow automation platform aimed at Danish municipalities. It enables citizen-facing services through visual workflow design, integration with Danish government systems, and GDPR-minded data handling - with no licence fees. It is currently a pre-pilot POC: the workflow engine, MitID sign-in, and CPR/CVR lookups run against test/mock endpoints, and several integration actions (payment, SMS, GIS, payroll, calendar) are demo mocks today.
 
 **Key Value Proposition**:
-- 100% open-source: No licensing fees (vs. 75,000 DKK/year for XFlow)
-- Visual workflow builder: No-code/low-code workflow creation
-- Danish-first: Built-in integrations with MitID, CPR, CVR, DAWA, Digital Post
-- GDPR-compliant: Encrypted data handling, audit trails, retention policies
-- Fast deployment: Pre-built templates for common municipal services
-- Modern architecture: API-first, headless, cloud-native
+- Open source: no per-form or per-integration licence fees, unlike proprietary alternatives
+- Visual workflow builder: the Workflow Modeler editor, no-code/low-code workflow creation
+- Danish-first: integrations with MitID, CPR, CVR, DAWA, Digital Post (against test/mock endpoints today)
+- GDPR-minded: field-level CPR encryption (AES-256) and audit logging built in
+- Ready-made templates for common municipal services
+- Modern architecture: API-first, headless, JSON:API, no vendor lock-in
 
 ---
 
 ## Platform Benefits
 
-### 1. Cost Savings
+### 1. Cost Model
 
-**Total Cost Comparison (3-year)**:
+Proprietary self-service workflow platforms typically charge annual licence fees, often with
+additional per-integration and per-form fees. ÅbenForms is open source and carries no licence
+fees. Your costs are limited to hosting and whatever implementation or support you choose to
+buy or do in-house.
 
-| Cost Category | XFlow | ÅbenForms | Savings |
-|---------------|-------|-----------|---------|
-| Licensing (Year 1) | 75,000 DKK | 0 DKK | 75,000 DKK |
-| Licensing (Year 2) | 75,000 DKK | 0 DKK | 75,000 DKK |
-| Licensing (Year 3) | 75,000 DKK | 0 DKK | 75,000 DKK |
-| Implementation | 150,000 DKK | 50,000 DKK | 100,000 DKK |
-| Training | 50,000 DKK | 20,000 DKK | 30,000 DKK |
-| Annual Support | 25,000 DKK | 15,000 DKK | 10,000 DKK |
-| **3-Year Total** | **500,000 DKK** | **95,000 DKK** | **405,000 DKK** |
+**Where proprietary alternatives cost money** (generalised):
+- Annual platform licence
+- Per-integration module fees (MitID, CPR/CVR, Digital Post, etc.)
+- Per-form or per-transaction fees in some models
 
-**ROI**: 81% cost reduction over 3 years
+**Where ÅbenForms costs money**:
+- Hosting
+- Optional implementation and support (in-house or bought)
+
+There are no fabricated savings figures here; do your own comparison against your current
+vendor's actual quote.
 
 ### 2. Rapid Deployment
 
-- Pre-built templates for 8+ common municipal workflows
-- Visual drag-and-drop workflow designer (BPMN 2.0 standard)
+- 13 ready-made workflow templates (BPMN source files) for common municipal workflows
+- Visual workflow editing via the Workflow Modeler
 - No custom development required for standard use cases
-- Average implementation time: 2-4 weeks per workflow
+- 18 ECA flows deployed in the current configuration
 
 ### 3. Danish Government Integration
 
@@ -70,27 +74,36 @@ Built-in connectors for essential Danish services:
 - GetOrganized ESDH integration
 - Document archiving with metadata
 
-### 4. GDPR Compliance
+### 4. GDPR-Minded Data Handling
 
-- Field-level AES-256 encryption for sensitive data
-- Comprehensive audit logging
-- Automated data retention policies
-- Right to erasure workflows
+Built in today:
+- Field-level AES-256 encryption for CPR numbers
+- Audit logging
+- Role-based access control
+
+Planned (not yet shipped):
+- Automated data retention and right-to-erasure subsystem (issue #91)
 - Consent management
-- Access control with role-based permissions
+
+Engage your Data Protection Officer for a full compliance assessment before any pilot.
 
 ### 5. Modern Architecture
 
-- Headless CMS (Drupal 11) backend
-- Modern Vue.js/Nuxt 3 frontend
+- Headless CMS (Drupal 11, core 11.3.10, PHP 8.4) backend
+- Vue.js/Nuxt 3 frontend
 - RESTful JSON:API
-- Cloud-native deployment (Platform.sh)
-- Multi-tenancy support (shared instance for multiple municipalities)
+- Self-hostable; no vendor lock-in
+- Multi-tenancy support via the domain module
 - Mobile-responsive design
 
 ---
 
 ## Flagship Workflows
+
+Note on integration status: in the current POC, MitID sign-in, CPR/CVR lookup, DAWA validation,
+and audit logging are real (against test/mock endpoints). Payment, SMS, GIS, and calendar/booking
+steps are demo mocks today. The "annual impact" estimates below are illustrative planning figures,
+not measured results from any deployment - there are no production deployments yet.
 
 ### Workflow 1: Parking Permit Application
 
@@ -125,10 +138,10 @@ Built-in connectors for essential Danish services:
 **Setup Time**: 1 week
 **Technical Complexity**: Low
 
-**Annual Impact (Medium Municipality)**:
+**Illustrative Annual Impact (Medium Municipality, planning estimate only - not measured)**:
 - Applications processed: ~2,000
-- Time saved: 6,000 hours (3 hours/application eliminated)
-- Cost savings: ~900,000 DKK (staff time + postage)
+- Potential time saved if manual processing is fully automated
+- Actual savings depend on the municipality's current process and volumes
 
 ---
 
@@ -155,8 +168,8 @@ Built-in connectors for essential Danish services:
 **Business Value**:
 - Eliminates phone/email booking coordination
 - Dual authentication ensures identity verification
-- Automated reminders reduce no-shows by 40%
-- Real-time calendar synchronization
+- Automated reminders to reduce no-shows
+- Calendar synchronization (calendar action is a demo mock today)
 - Digital certificate delivery
 - Complete audit trail for legal compliance
 
@@ -173,11 +186,10 @@ Built-in connectors for essential Danish services:
 **Setup Time**: 2 weeks
 **Technical Complexity**: Medium
 
-**Annual Impact (Medium Municipality)**:
+**Illustrative Annual Impact (Medium Municipality, planning estimate only - not measured)**:
 - Ceremonies booked: ~300
-- Time saved: 1,200 hours (4 hours/booking eliminated)
-- No-show reduction: 40% (120 ceremonies)
-- Cost savings: ~200,000 DKK
+- Potential reduction in phone/email coordination time and no-shows
+- Actual results depend on the municipality's current process
 
 ---
 
@@ -223,44 +235,37 @@ Built-in connectors for essential Danish services:
 **Setup Time**: 3 weeks
 **Technical Complexity**: High
 
-**Annual Impact (Medium Municipality)**:
+**Illustrative Annual Impact (Medium Municipality, planning estimate only - not measured)**:
 - Applications processed: ~800
-- Time saved: 2,400 hours (3 hours/application eliminated)
-- Paper/postage savings: ~50,000 DKK
-- Faster processing: Average 15 days (vs. 30 days)
-- Cost savings: ~450,000 DKK
+- Potential reduction in caseworker time and paper/postage
+- Potential faster processing through automated pre-checks
+- Actual results depend on the municipality's current process
 
 ---
 
-## ROI Calculations
+## ROI - How to Build Your Own Estimate
 
-### Scenario: Medium Municipality (50,000 residents)
+There are no measured ROI figures to quote: ÅbenForms has no production deployments yet. Rather
+than present fabricated numbers, build an estimate from your own data.
 
-**Annual Workflow Volume**:
-- Parking permits: 2,000 applications
-- Marriage bookings: 300 ceremonies
-- Building permits: 800 applications
-- Other services: 1,500 transactions
+### Inputs to gather
 
-**Total Annual Savings**:
+- Annual volume per workflow (parking permits, marriage bookings, building permits, etc.)
+- Current staff time per application and your loaded hourly staff cost
+- Current paper/postage and reconciliation costs
+- Your current vendor's actual licence and per-integration quote (for the comparison)
 
-| Category | Amount (DKK) |
-|----------|--------------|
-| Staff time savings | 1,400,000 |
-| Paper/postage elimination | 80,000 |
-| Payment reconciliation | 120,000 |
-| No-show reduction | 40,000 |
-| IT licensing fees | 75,000 |
-| **Total Annual Savings** | **1,715,000 DKK** |
+### Method
 
-**Implementation Investment**:
-- Initial setup: 50,000 DKK (3 workflows)
-- Training: 20,000 DKK
-- Annual support: 15,000 DKK
+1. Estimate staff time potentially saved per workflow once routine steps are automated.
+2. Multiply by volume and hourly cost for a conservative staff-time figure.
+3. Add paper/postage and reconciliation savings where applicable.
+4. Subtract your ÅbenForms costs: hosting plus any implementation/support you buy or staff
+   in-house. Remember there are no licence fees.
+5. Compare against the avoided proprietary licence and per-integration fees from your vendor quote.
 
-**Year 1 ROI**: (1,715,000 - 85,000) / 85,000 = 1,918% ROI
-
-**Payback Period**: Less than 3 weeks
+Use conservative assumptions. The honest message is "no licence fees, open source, no lock-in,
+modern JSON:API" - not a fabricated payback period.
 
 ---
 
@@ -352,7 +357,7 @@ Built-in connectors for essential Danish services:
 
 ### Open Source Licensing
 
-ÅbenForms is released under GPL-2.0 license:
+ÅbenForms is released under the GPL-2.0-or-later license:
 - **Zero licensing fees** forever
 - **No per-user costs**
 - **No per-transaction costs**
@@ -371,8 +376,8 @@ Built-in connectors for essential Danish services:
 
 **Professional Package** (350,000 DKK one-time):
 - Everything in Starter Package
-- 8 workflows (all templates)
-- SBSYS/ESDH integration
+- Additional workflows from the template library
+- SBSYS/ESDH integration (planned modules)
 - Custom workflow development (up to 2 workflows)
 - Visual identity customization
 - 5 days on-site training
@@ -419,60 +424,12 @@ Built-in connectors for essential Danish services:
 
 ---
 
-## Municipal Success Stories
+## Deployment Status
 
-### Scenario 1: Aarhus Kommune (350,000 residents)
-
-**Challenge**: Processing 15,000 parking permit applications annually with 4 FTE staff, causing 2-week delays.
-
-**Solution**: Deployed ÅbenForms parking permit workflow with MitID, DAWA, and Nets Easy integration.
-
-**Results** (Year 1):
-- Processing time: 2 weeks → instant
-- Staff redeployed: 3 FTE to higher-value work
-- Citizen satisfaction: 67% → 94%
-- Cost savings: 1,200,000 DKK
-- Paper eliminated: 15,000 permits
-- ROI: 2,400%
-
-**Quote**: "ÅbenForms transformed our parking permit service from a bureaucratic bottleneck to a 24/7 digital experience. Citizens love the instant service, and our staff can focus on exceptions rather than routine processing." - IT Director, Aarhus Kommune
-
----
-
-### Scenario 2: Odense Kommune (205,000 residents)
-
-**Challenge**: Marriage ceremony bookings required phone calls, email exchanges, and manual calendar management, consuming 600 staff hours annually.
-
-**Solution**: Implemented ÅbenForms marriage booking workflow with dual MitID authentication, calendar integration, and automated reminders.
-
-**Results** (Year 1):
-- Booking time: 45 minutes → 10 minutes
-- No-shows reduced: 15% → 6% (40% reduction)
-- Staff hours saved: 480 hours
-- Couple satisfaction: 78% → 96%
-- Cost savings: 180,000 DKK
-- ROI: 900%
-
-**Quote**: "The dual MitID authentication ensures we have verified identities before the ceremony, eliminating last-minute issues. Automated reminders reduced no-shows dramatically." - Citizen Services Manager, Odense Kommune
-
----
-
-### Scenario 3: Randers Kommune (98,000 residents)
-
-**Challenge**: Building permit applications required physical submissions, causing postal delays and incomplete applications.
-
-**Solution**: Deployed ÅbenForms building permit workflow with document upload, caseworker portal, and SBSYS integration.
-
-**Results** (Year 1):
-- Processing time: 30 days → 18 days (40% faster)
-- Incomplete submissions: 35% → 12% (66% reduction)
-- Staff time per application: 4 hours → 2.5 hours
-- Annual hours saved: 1,200 hours
-- Citizen satisfaction: 62% → 87%
-- Cost savings: 420,000 DKK
-- ROI: 1,680%
-
-**Quote**: "Automated document validation catches missing items before caseworker review, dramatically reducing back-and-forth with applicants. SBSYS integration eliminated duplicate data entry." - Planning Director, Randers Kommune
+ÅbenForms is a pre-pilot POC. There are no production municipality deployments and therefore
+no customer references, satisfaction figures, or measured ROI to cite. Any "before/after"
+numbers you may see elsewhere are illustrative planning estimates, not results from a real
+municipality. We can run a live demo against test/mock endpoints and discuss a pilot.
 
 ---
 
@@ -493,12 +450,12 @@ Built-in connectors for essential Danish services:
 - Load balancer for high availability
 
 **Database**:
-- MariaDB 10.11+ or MySQL 8.0+
-- PostgreSQL 14+ (alternative)
+- MariaDB or MySQL 8.0+
+- PostgreSQL (alternative)
 
 **Web Server**:
 - Apache 2.4+ or Nginx 1.20+
-- PHP 8.3+
+- PHP 8.4
 - SSL/TLS certificate (required)
 
 ### Hosting Options
@@ -508,12 +465,10 @@ Built-in connectors for essential Danish services:
 - Full data control
 - Requires IT staff for maintenance
 
-**Cloud Hosting** (Recommended):
-- Platform.sh, AWS, Azure, Google Cloud
-- Automatic scaling
+**Cloud Hosting**:
+- Any standard LAMP/cloud provider (AWS, Azure, Google Cloud, EU regions)
 - Managed backups
-- 99.9% SLA
-- GDPR-compliant EU regions
+- GDPR-appropriate EU regions
 
 **Managed Service**:
 - Fully managed by ÅbenForms team
@@ -634,19 +589,18 @@ Built-in connectors for essential Danish services:
 
 ### GDPR Compliance
 
-**Data Protection**:
+**Data Protection** (built in today):
 - Field-level AES-256 encryption for CPR numbers
-- Pseudonymization for analytics
-- Automated data retention policies (7-year default for municipal records)
-- Right to erasure workflows
+- Audit logging
 - Data minimization (only collect necessary data)
 
+**Planned (not yet shipped)**:
+- Automated data retention policies and right-to-erasure subsystem (issue #91)
+- Pseudonymization for analytics
+
 **Audit & Accountability**:
-- Comprehensive audit logging (who, what, when, why)
-- Tamper-proof logs
-- Regular audit reports
-- Data processing agreements
-- Privacy impact assessments
+- Audit logging (who, what, when, why)
+- Supports data processing agreements and privacy impact assessments as part of a pilot
 
 **Consent Management**:
 - Explicit consent collection

--- a/docs/QUICKSTART_DEMO.md
+++ b/docs/QUICKSTART_DEMO.md
@@ -1,10 +1,34 @@
 # ÅbenForms Quick Start Demo Guide
 
-**Goal**: Demonstrate ÅbenForms can replace XFlow in 15 minutes.
+**Goal**: Demonstrate ÅbenForms as a no-licence-fee, open-source alternative to proprietary municipal workflow platforms in 15 minutes.
+
+**Status**: Pre-pilot POC. Live demo at https://aabenforms.dk (frontend) and https://api.aabenforms.dk (backend). MitID via Keycloak mock; Serviceplatformen and Digital Post via test/mock endpoints. There are no production municipality deployments.
 
 ---
 
-##  Quick Demo (15 minutes)
+## Important: what is real vs what is a demo mock
+
+Before running this demo, be honest with yourself and the audience about which parts are
+real and which are illustrative mocks.
+
+**Real today** (works, though against test/mock endpoints):
+- ECA workflow engine, the Workflow Modeler editor, and execution replay
+- MitID OIDC sign-in against a Keycloak mock IdP (fails closed by default; demo mode is opt-in)
+- CPR (SF1520) and CVR (SF1530) lookup clients (against test/WireMock; need client certs for live)
+- Custom webform elements with server-side validation: CPR (modulus-11), CVR, DAWA
+- Field-level CPR encryption (AES-256) plus audit logging
+- Digital Post (SF1601) in fake_db / wiremock test modes (no live MeMo/SOAP or idempotency yet)
+
+**Demo mocks** (NOT production - do not claim these "work in production"):
+- Payment, SMS, GIS/zoning, payroll, and calendar/booking actions are demo mocks that return
+  canned success responses. They demonstrate the workflow shape, not a live integration.
+
+When you show the demos below, say plainly: "This is a demo mock that returns a simulated
+response so we can see the workflow end to end. A live integration is a pilot deliverable."
+
+---
+
+## Quick Demo (15 minutes)
 
 ### Prerequisites
 ```bash
@@ -13,20 +37,22 @@ ddev start
 ddev drush cr
 ```
 
-### Demo 1: Payment Processing (3 minutes)
+### Demo 1: Payment Processing - demo mock (3 minutes)
 
-**Show XFlow Alternative**:
+**Demonstrate the payment step in a workflow**. The payment service is a demo mock that
+returns a simulated success response; it does not contact a live payment provider.
+
 ```bash
-echo "=== Testing Payment Service (Nets Easy Mock) ==="
+echo "=== Testing Payment Service (demo mock) ==="
 ddev drush php:eval '
 $payment = \Drupal::service("aabenforms_workflows.payment_service");
 
-// Process parking permit payment
+// Process parking permit payment (mock)
 $result = $payment->processPayment([
   "amount" => 30000, // 300 DKK
   "currency" => "DKK",
   "order_id" => "DEMO-PARKING-001",
-  "payment_method" => "nets_easy",
+  "payment_method" => "card",
   "description" => "Parking permit - 6 months",
 ]);
 
@@ -45,14 +71,16 @@ Transaction ID: TXN-ABCDEF123456
 Amount: 300 DKK
 ```
 
- **XFlow Feature Parity**: Payment processing works!
+Note: simulated response from the demo mock. A live payment integration is a pilot deliverable.
 
 ---
 
-### Demo 2: SMS Notifications (2 minutes)
+### Demo 2: SMS Notifications - demo mock (2 minutes)
+
+The SMS service is a demo mock that returns a simulated send result.
 
 ```bash
-echo "=== Testing SMS Service (Danish SMS Gateway Mock) ==="
+echo "=== Testing SMS Service (demo mock) ==="
 ddev drush php:eval '
 $sms = \Drupal::service("aabenforms_workflows.sms_service");
 
@@ -74,7 +102,7 @@ Message ID: SMS-xxx-1234567890
 Segments: 1
 ```
 
- **XFlow Feature Parity**: SMS notifications work!
+Note: simulated response from the demo mock.
 
 ---
 
@@ -98,18 +126,18 @@ echo "File URL: " . $result["file_url"] . "\n";
 '
 ```
 
- **XFlow Feature Parity**: PDF generation works!
-
 ---
 
-### Demo 4: Calendar Booking (3 minutes)
+### Demo 4: Calendar Booking - demo mock (3 minutes)
+
+The calendar/booking service is a demo mock returning simulated slots and bookings.
 
 ```bash
-echo "=== Testing Calendar Service (Marriage Booking) ==="
+echo "=== Testing Calendar Service (demo mock - Marriage Booking) ==="
 ddev drush php:eval '
 $calendar = \Drupal::service("aabenforms_workflows.calendar_service");
 
-// Fetch available ceremony slots
+// Fetch available ceremony slots (mock)
 $slots = $calendar->getAvailableSlots("2026-03-01", "2026-03-15", 60);
 
 echo "Available Slots: " . $slots["total_slots"] . "\n";
@@ -118,7 +146,7 @@ foreach (array_slice($slots["slots"], 0, 5) as $slot) {
   echo "  - " . $slot["date"] . " " . $slot["start_time"] . "-" . $slot["end_time"] . " at " . $slot["location"] . "\n";
 }
 
-// Book a slot
+// Book a slot (mock)
 $booking = $calendar->bookSlot($slots["slots"][0]["slot_id"], [
   ["name" => "Partner 1", "email" => "p1@test.dk"],
   ["name" => "Partner 2", "email" => "p2@test.dk"],
@@ -129,20 +157,21 @@ echo "Booking ID: " . $booking["booking_id"] . "\n";
 '
 ```
 
- **XFlow Feature Parity**: Calendar/booking works!
+Note: simulated response from the demo mock.
 
 ---
 
-### Demo 5: GIS Zoning Validation (3 minutes)
+### Demo 5: GIS Zoning Validation - demo mock (3 minutes)
 
-** This feature EXCEEDS XFlow capabilities!**
+The GIS/zoning service is a demo mock. It returns illustrative zoning and neighbour data; it
+does not query a live GIS system.
 
 ```bash
-echo "=== Testing GIS Service (Zoning Validation) ==="
+echo "=== Testing GIS Service (demo mock - Zoning Validation) ==="
 ddev drush php:eval '
 $gis = \Drupal::service("aabenforms_workflows.gis_service");
 
-// Check if extension is allowed
+// Check if extension is allowed (mock)
 $validation = $gis->validateConstructionType(
   "Vestergade 10, 8000 Aarhus C",
   "tilbygning"
@@ -154,7 +183,7 @@ echo "Construction Type: " . $validation["construction_type"] . "\n";
 echo "Allowed: " . ($validation["allowed"] ? "YES" : "NO") . "\n";
 echo "Reason: " . $validation["reason"] . "\n";
 
-// Find neighbors to notify
+// Find neighbors to notify (mock)
 $neighbors = $gis->findNeighborsInRadius(
   "Vestergade 10, 8000 Aarhus C",
   50
@@ -167,28 +196,31 @@ foreach ($neighbors["neighbors"] as $neighbor) {
 '
 ```
 
- **EXCEEDS XFlow**: Automatic GIS validation and neighbor discovery!
+Note: simulated response from the demo mock. GIS integration is a pilot deliverable, not a
+shipped feature.
 
 ---
 
 ### Demo 6: Complete Workflow Test (2 minutes)
 
+This stitches together the payment, PDF, and SMS steps. Payment and SMS are demo mocks.
+
 ```bash
 echo "=== Testing Complete Parking Permit Workflow ==="
 ddev drush php:eval '
-// Simulate complete workflow execution
+// Simulate complete workflow execution (payment + SMS are demo mocks)
 $services = [
   "payment" => \Drupal::service("aabenforms_workflows.payment_service"),
   "sms" => \Drupal::service("aabenforms_workflows.sms_service"),
   "pdf" => \Drupal::service("aabenforms_workflows.pdf_service"),
 ];
 
-echo "Step 1: Process payment...\n";
+echo "Step 1: Process payment (mock)...\n";
 $payment_result = $services["payment"]->processPayment([
   "amount" => 30000,
   "currency" => "DKK",
   "order_id" => "WORKFLOW-DEMO-001",
-  "payment_method" => "nets_easy",
+  "payment_method" => "card",
 ]);
 echo "   Payment " . $payment_result["status"] . "\n";
 
@@ -199,76 +231,85 @@ $pdf_result = $services["pdf"]->generatePdf("parking_permit", [
 ]);
 echo "   PDF generated: " . $pdf_result["filename"] . "\n";
 
-echo "\nStep 3: Send SMS confirmation...\n";
+echo "\nStep 3: Send SMS confirmation (mock)...\n";
 $sms_result = $services["sms"]->sendSms(
   "+4512345678",
   "Din parkeringslicens er godkendt! Se vedhæftet PDF."
 );
 echo "   SMS " . $sms_result["status"] . "\n";
 
-echo "\n Complete workflow executed successfully!\n";
-echo "This is what XFlow does - but we did it with open source!\n";
+echo "\nWorkflow executed (payment and SMS via demo mocks).\n";
+echo "Open source, no per-form or per-integration licence fees.\n";
 '
 ```
 
 ---
 
-##  Summary: ÅbenForms vs XFlow
+## Summary: ÅbenForms vs proprietary alternatives
 
-| Feature | XFlow | ÅbenForms | Status |
-|---------|-------|-----------|--------|
-| Payment Processing |  |  Demonstrated | **PARITY** |
-| SMS Notifications |  |  Demonstrated | **PARITY** |
-| PDF Generation |  |  Demonstrated | **PARITY** |
-| Calendar Booking |  |  Demonstrated | **PARITY** |
-| GIS Validation |  Limited |  Full GIS + neighbors | **EXCEEDS** |
-| Cost | €75K/5yr | €0 software license | **59% SAVINGS** |
+| Area | Proprietary alternatives | ÅbenForms |
+|------|--------------------------|-----------|
+| Payment step | Production integration | Demo mock today; live integration is a pilot deliverable |
+| SMS step | Production integration | Demo mock today |
+| PDF generation | Yes | Working |
+| Calendar booking | Production integration | Demo mock today |
+| GIS validation | Varies by vendor | Demo mock today |
+| Licensing | Annual licence fees, often per-integration and per-form | Open source, no licence fees |
+| API | Often older SOAP APIs | Modern JSON:API |
+| Data control / lock-in | Vendor-controlled | Self-hosted, full source access, no lock-in |
 
----
-
-##  Key Talking Points for Demo
-
-1. **"This is what XFlow does for €75,000 over 5 years..."**
-   - Show payment processing
-   - Show SMS sending
-   - Show PDF generation
-
-2. **"...but ÅbenForms does it for FREE with open source"**
-   - Zero licensing costs
-   - Same functionality
-   - Better in some areas (GIS)
-
-3. **"Plus we added features XFlow doesn't have"**
-   - Automatic neighbor discovery
-   - GIS zoning validation
-   - Open API (JSON:API standard)
-
-4. **"And it's all built on proven technology"**
-   - Drupal 11 (1M+ developers)
-   - BPMN 2.0 (industry standard)
-   - Modern PHP 8.4
+The honest pitch: ÅbenForms already runs real ECA workflows, MitID sign-in, CPR/CVR lookups, and
+field-level encryption against test endpoints. The payment, SMS, GIS, payroll, and calendar
+actions are demo mocks that show the workflow shape; making them live is pilot work.
 
 ---
 
-##  Next Steps
+## Key Talking Points for Demo
 
-1.  **Core functionality works** (as demonstrated)
-2.  **Complete UI** (frontend components)
-3.  **Add tests** (quality assurance)
-4.  **Write docs** (user guides)
-5.  **Record videos** (training materials)
+1. **No per-form or per-integration licence fees**
+   - Proprietary self-service platforms typically charge annual licence fees plus
+     per-integration fees. ÅbenForms is open source with no licence fees.
 
-**Status**: **Ready for pilot deployment in forward-thinking municipality!**
+2. **Open source, no vendor lock-in**
+   - Full source access, self-hostable, your data stays under your control.
+
+3. **Workflows are real, several integrations are still mocks**
+   - The ECA engine, Workflow Modeler, MitID sign-in, CPR/CVR lookup, and encryption are real.
+   - Payment, SMS, GIS, payroll, and calendar actions are demo mocks today.
+
+4. **Built on proven technology**
+   - Drupal 11 (core 11.3.10), PHP 8.4
+   - ECA 3.1.1 workflow engine with the Workflow Modeler editor
+   - Modern JSON:API
 
 ---
 
-##  Contact
+## Workflow Library
 
-- **Email**: aabenforms@example.dk
-- **Demo Site**: https://demo.aabenforms.dk (coming soon)
+- 13 ready-made workflow templates (BPMN source files) under
+  `web/modules/custom/aabenforms_workflows/workflows/`.
+- 18 ECA flows deployed (config/sync/eca.eca.*).
+
+---
+
+## Status and Next Steps
+
+This is a pre-pilot POC. Outstanding work before a pilot:
+
+1. Replace demo mocks (payment, SMS, GIS, payroll, calendar) with live integrations.
+2. Live Serviceplatformen and Digital Post endpoints (client certs, MeMo/SOAP, idempotency).
+3. Data retention / right-to-erasure subsystem (planned, issue #91).
+4. Frontend components and end-to-end tests.
+5. User guides and training materials.
+
+---
+
+## Contact
+
+- **Demo Site (frontend)**: https://aabenforms.dk
+- **Demo Site (backend API)**: https://api.aabenforms.dk
 - **GitHub**: https://github.com/madsnorgaard/aabenforms
-- **Docs**: https://docs.aabenforms.dk
 
 ---
 
-*"Open source. Zero vendor lock-in. Danish municipal workflows. That's ÅbenForms."*
+*Open source. No vendor lock-in. Danish municipal workflows. That's ÅbenForms.*

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -2,12 +2,9 @@
 
 ## Overview
 
-ÅbenForms backend includes comprehensive automated testing across unit, kernel, and integration test levels. This guide covers running tests, writing new tests, and understanding the testing infrastructure.
+ÅbenForms backend includes automated testing across unit, kernel, and integration test levels. This guide covers running tests, writing new tests, and understanding the testing infrastructure.
 
-**Current Test Metrics** (Phase 3):
-- **Total Tests**: 156 tests
-- **Coverage**: 45%
-- **Test Types**: Unit (68), Kernel (52), Integration (36)
+Test counts and coverage figures are not hardcoded here because they drift. CI measures both on every run and publishes them as live README badges (see `docs/TESTING.md` for the coverage gate). To see the current numbers locally, run the suite with `--coverage-text`. CI scopes the gating run to the `unit` and `kernel` suites.
 
 ---
 
@@ -24,7 +21,7 @@ ddev start
 ### Run All Tests
 
 ```bash
-# Run full test suite (156 tests)
+# Run full test suite
 ddev exec phpunit --configuration phpunit.xml
 
 # Run with coverage report (HTML format)
@@ -36,19 +33,19 @@ ddev launch coverage/index.html
 
 ### Run Specific Test Types
 
-#### Unit Tests (68 tests)
+#### Unit Tests
 Tests individual classes in isolation with mocked dependencies:
 ```bash
 ddev exec phpunit --configuration phpunit.xml --testsuite unit
 ```
 
-#### Kernel Tests (52 tests)
+#### Kernel Tests
 Tests with Drupal services available but no database:
 ```bash
 ddev exec phpunit --configuration phpunit.xml --testsuite kernel
 ```
 
-#### Integration Tests (36 tests)
+#### Integration Tests
 Tests with full Drupal installation and WireMock for external services:
 ```bash
 ddev exec phpunit --configuration phpunit.xml --testsuite integration
@@ -180,7 +177,9 @@ class BpmnTemplateManagerTest extends UnitTestCase {
     $this->assertIsArray($templates);
     $this->assertContains('building_permit', $templates);
     $this->assertContains('contact_form', $templates);
-    $this->assertCount(5, $templates);
+    // 13 workflow templates ship under
+    // web/modules/custom/aabenforms_workflows/workflows/.
+    $this->assertCount(13, $templates);
   }
 
   /**
@@ -255,6 +254,9 @@ class MitIdValidateActionTest extends KernelTestBase {
     'aabenforms_core',
     'aabenforms_workflows',
     'eca',
+    // ECA 3.1.x hard-depends on modeler_api; kernel tests that enable 'eca'
+    // must enable it too or the container will fail to build.
+    'modeler_api',
   ];
 
   /**
@@ -358,10 +360,10 @@ class WorkflowExecutionTest extends BrowserTestBase {
     'user',
     'webform',
     'eca',
+    'modeler_api',
     'aabenforms_core',
     'aabenforms_workflows',
     'aabenforms_mitid',
-    'aabenforms_cpr',
   ];
 
   /**
@@ -554,7 +556,7 @@ ddev launch coverage/index.html
 
 ### Coverage Thresholds
 
-PHPUnit is configured with minimum coverage thresholds in `phpunit.xml`:
+PHPUnit is configured to emit a coverage report in `phpunit.xml`:
 
 ```xml
 <coverage processUncoveredFiles="true">
@@ -564,15 +566,11 @@ PHPUnit is configured with minimum coverage thresholds in `phpunit.xml`:
 </coverage>
 ```
 
-**Current Coverage** (Phase 3):
-- **Overall**: 45%
-- **aabenforms_workflows**: 52%
-- **aabenforms_core**: 41%
-- **aabenforms_tenant**: 38%
-
-**Target Coverage** (Phase 4):
-- **Overall**: 60%
-- **Critical modules**: 70%+
+CI parses `coverage/cobertura.xml` and fails the job if line coverage drops
+below the minimum floor enforced in `.github/workflows/ci.yml` (see
+`docs/TESTING.md`). Do not record a fixed percentage here; read the live
+coverage badge in the README or run `--coverage-text` locally for the current
+number.
 
 ---
 
@@ -613,8 +611,9 @@ jobs:
 ### Viewing CI Results
 
 - **GitHub Actions**: https://github.com/madsnorgaard/aabenforms/actions
-- **Coverage Badge**: ![Coverage](https://img.shields.io/badge/coverage-45%25-yellow)
-- **Test Badge**: ![Tests](https://img.shields.io/badge/tests-156%20passing-brightgreen)
+- **Coverage and test-count badges**: rendered live from the JSON the CI run
+  writes (`.github/badges/coverage.json`, `.github/badges/tests.json`) via
+  `img.shields.io/endpoint`; there are no hardcoded numbers.
 
 ---
 
@@ -786,4 +785,4 @@ ddev exec phpunit --coverage-html coverage/
 
 ---
 
-**Last Updated**: 2026-02-01 (Phase 3 completion - 156 tests, 45% coverage)
+**Last Updated**: 2026-06

--- a/docs/WORKFLOW_TEMPLATES.md
+++ b/docs/WORKFLOW_TEMPLATES.md
@@ -1,10 +1,18 @@
 # Workflow Template Reference
 
-**Last Updated**: 2026-02-02
+**Last Updated**: 2026-06-06
+
+## Status
+
+Pre-pilot POC. There are no real municipality deployments. Live demo at https://aabenforms.dk (frontend) and https://api.aabenforms.dk (backend). MitID runs against a Keycloak mock IdP; Serviceplatformen (CPR/CVR) and Digital Post run against test/mock endpoints.
 
 ## Overview
 
-ÅbenForms provides 5 pre-built BPMN workflow templates for common Danish municipal use cases. This document describes each template in detail, including when to use it, required fields, and configuration options.
+ÅbenForms ships 13 ready-made workflow templates (BPMN source files under `web/modules/custom/aabenforms_workflows/workflows/`) for common Danish municipal use cases, plus a set of supporting flows; in total 18 ECA flows are deployed. The visual editor is the Workflow Modeler (the `drupal/modeler` React Flow editor, modeler id `workflow_modeler`), not a BPMN designer. This document describes the most commonly used templates in detail, including when to use each one, required fields, and configuration options.
+
+The full template set is: address_change, association_booking, building_permit, citizen_service_application, company_verification, contact_form, foi_request, hr_onboarding, marriage_booking, med_election_nomination, mileage_expense, parking_permit, phone_declaration.
+
+Several action plugins referenced below are demo mocks, not production integrations. Payment, SMS, GIS/zoning, payroll and calendar/booking actions return simulated results and must not be treated as working production features. Real (against test or mock endpoints) actions are: the ECA workflow engine and Workflow Modeler, MitID OIDC sign-in (Keycloak mock), CPR (SF1520) and CVR (SF1530) lookup clients, the custom CPR/CVR/DAWA webform elements with server-side validation, field-level CPR encryption with audit logging, and Digital Post (SF1601) in its `fake_db`/`wiremock` test modes.
 
 ---
 
@@ -29,13 +37,13 @@
 
 ### Description
 
-Complex building permit workflow demonstrating full Danish municipal workflow pattern with:
+Complex building permit workflow demonstrating a full Danish municipal workflow pattern with:
 - MitID authentication
 - Document validation
 - Multi-step approvals
 - Case worker review
-- SBSYS integration
-- GDPR compliance with full audit logging
+- Case-system handoff (planned ESDH/case-management integration, not yet implemented)
+- GDPR compliance with field-level CPR encryption and audit logging
 
 ### Use Cases
 
@@ -101,7 +109,7 @@ expected_completion_date: Date (required)
 7. USER TASK: Case Worker Review
    ↓
 8. GATEWAY: Decision
-   ├─ APPROVE → Create SBSYS Case → Send Approval
+   ├─ APPROVE → Create Case (planned case-system handoff) → Send Approval
    ├─ REJECT → Send Rejection Notice
    └─ REQUEST INFO → Wait for Response (30 days timeout)
        ├─ Info Received → Back to Case Worker Review
@@ -120,29 +128,29 @@ expected_completion_date: Date (required)
 | `document_validation` | Strict | Strict, Lenient, None | Document format checking |
 | `review_timeout` | 30 days | 7-90 days | Time for case worker review |
 | `info_request_timeout` | 30 days | 7-60 days | Time for applicant to provide info |
-| `sbsys_case_type` | Building Permit | Configurable | SBSYS case classification |
+| `case_type` | Building Permit | Configurable | Case classification (used by planned case-system handoff) |
 | `notification_method` | Digital Post | Email, Digital Post, Both | Notification channel |
 
 ### Integration Points
 
 **Danish Services**:
-- **MitID**: Citizen authentication (OIDC)
-- **SF1520**: CPR person lookup (Serviceplatformen)
-- **DAWA**: Address validation (open API)
-- **SF1601**: Digital Post notifications (Serviceplatformen)
+- **MitID**: Citizen authentication (OIDC, against a Keycloak mock IdP today)
+- **SF1520**: CPR person lookup (Serviceplatformen, test/mock endpoint)
+- **DAWA**: Address validation (open API; implemented as a webform element)
+- **SF1601**: Digital Post notifications (Serviceplatformen; test/mock modes only today)
 
-**Municipal Systems**:
-- **SBSYS**: Case creation and management
-- **GetOrganized**: Document archiving (ESDH)
+**Case / ESDH systems** (planned, not yet implemented):
+- Case creation and management handoff
+- Document archiving (ESDH)
 
-### Example: Aarhus Kommune Building Permit
+### Example: Building Permit (illustrative scenario)
 
-**Scenario**: Citizen applies for renovation permit for residential property.
+**Scenario**: A citizen applies for a renovation permit for a residential property. This is a hypothetical demo scenario, not a real deployment.
 
 ```yaml
 # Configuration
-Workflow ID: building_permit_aarhus_residential
-Label: Boligrenoveringspermit - Aarhus Kommune
+Workflow ID: building_permit_residential
+Label: Boligrenoveringstilladelse
 Authentication: MitID High
 Review SLA: 21 working days
 Auto-assign: Building Department
@@ -151,22 +159,20 @@ Auto-assign: Building Department
 **Process**:
 1. Citizen submits application online
 2. MitID authentication (High)
-3. CPR verification against national registry
+3. CPR verification (SF1520 test endpoint)
 4. DAWA validates property address exists
 5. System checks uploaded documents (PDF format, max 20MB)
 6. Case assigned to building inspector
-7. Inspector reviews within 21 days
-8. If approved: SBSYS case created, Digital Post sent
-9. If more info needed: 14-day deadline for response
+7. Inspector reviews within the configured SLA
+8. If approved: case-system handoff (planned) runs, Digital Post sent
+9. If more info needed: deadline timer for applicant response
 10. All actions logged for GDPR compliance
-
-**Timeline**: Average 25 days from submission to decision.
 
 ### Limitations
 
 - Requires MitID integration (not suitable for anonymous submissions)
 - Document validation basic (format/size only, not content)
-- SBSYS integration required for case creation
+- Case-system handoff is planned, not yet implemented
 - Maximum 90-day timeout (configure shorter if needed)
 
 ### When to Use vs. Other Templates
@@ -288,14 +294,14 @@ priority: Radios (admin only, optional)
 - Ticket system integration (Zendesk, Freshdesk)
 - CRM integration (for tracking inquiries)
 
-### Example: Odense Kommune Contact Form
+### Example: Contact Form (illustrative scenario)
 
-**Scenario**: Citizen asks question about waste collection schedule.
+**Scenario**: A citizen asks a question about the waste collection schedule. Hypothetical demo scenario, not a real deployment.
 
 ```yaml
 # Configuration
-Workflow ID: contact_form_odense
-Label: Kontaktformular - Odense Kommune
+Workflow ID: contact_form
+Label: Kontaktformular
 Spam Protection: Honeypot
 Auto-Response: Enabled
 ```
@@ -303,12 +309,10 @@ Auto-Response: Enabled
 **Process**:
 1. Citizen fills out form (no login needed)
 2. System validates email format
-3. Inquiry type "Environment" → routes to environment@odense.dk
-4. Confirmation email sent to citizen (within 1 minute)
+3. Inquiry type "Environment" routes to the environment department
+4. Confirmation email sent to citizen
 5. Submission logged
-6. Department responds within 3 days via email
-
-**Timeline**: Instant submission confirmation, response within SLA.
+6. Department responds within its SLA via email
 
 ### Limitations
 
@@ -444,22 +448,22 @@ From SF1520 (Serviceplatformen):
 ### Integration Points
 
 **Required**:
-- **SF1530**: CVR company lookup (Serviceplatformen)
-- **SF1520**: CPR person lookup (Serviceplatformen)
-- **MitID**: Authentication
+- **SF1530**: CVR company lookup (Serviceplatformen, test/mock endpoint)
+- **SF1520**: CPR person lookup (Serviceplatformen, test/mock endpoint)
+- **MitID**: Authentication (Keycloak mock IdP today)
 
 **Optional**:
-- Certificate storage (ESDH/GetOrganized)
+- Certificate storage (planned ESDH integration)
 - Email notifications
 
-### Example: Aarhus Kommune Contractor Verification
+### Example: Contractor Verification (illustrative scenario)
 
-**Scenario**: Municipality verifies contractor is authorized to sign contract.
+**Scenario**: A municipality verifies that a contractor is authorized to sign a contract. Hypothetical demo scenario, not a real deployment.
 
 ```yaml
 # Configuration
-Workflow ID: contractor_verification_aarhus
-Label: Leverandørverifikation - Aarhus Kommune
+Workflow ID: contractor_verification
+Label: Leverandørverifikation
 Certificate Validity: 180 days
 ```
 
@@ -474,8 +478,6 @@ Certificate Validity: 180 days
 8. If NO: Send rejection notice
 9. All lookups logged (who, when, why)
 
-**Timeline**: 30 seconds to 2 minutes (real-time verification).
-
 ### Certificate Contents
 
 ```
@@ -483,9 +485,9 @@ Certificate Validity: 180 days
    VIRKSOMHEDSVERIFIKATION
 ═══════════════════════════════════════
 
-Udstedt af: Aarhus Kommune
-Dato: 2026-02-02 14:35:00
-Gyldighed: 2026-08-01
+Udstedt af: [Kommune]
+Dato: 2026-06-06 14:35:00
+Gyldighed: 2026-12-03
 
 VIRKSOMHED:
   Navn: Eksempel A/S
@@ -498,7 +500,7 @@ PERSON:
 
 BEKRÆFTELSE:
    Anders Andersen er registreret som
-    direktør for Eksempel A/S per 2026-02-02.
+    direktør for Eksempel A/S per 2026-06-06.
 
    Data verificeret via:
     - CVR-registret (SF1530)
@@ -616,6 +618,8 @@ forward_mail: Checkbox (optional)
 
 ### System Integrations
 
+Note: the municipal-system update steps below are illustrative. In the current POC they run as demo mock actions and do not call live municipal REST APIs.
+
 **Municipal Systems Updated** (parallel):
 
 1. **Citizen Portal**
@@ -652,14 +656,14 @@ forward_mail: Checkbox (optional)
 - Property Tax System API
 - Waste Management System API
 
-### Example: Copenhagen Municipality Address Update
+### Example: Address Update (illustrative scenario)
 
-**Scenario**: Citizen moves within Copenhagen, needs all systems updated.
+**Scenario**: A citizen moves within the same municipality and needs all systems updated. Hypothetical demo scenario, not a real deployment.
 
 ```yaml
 # Configuration
-Workflow ID: address_change_copenhagen
-Label: Adresseændring - Københavns Kommune
+Workflow ID: address_change
+Label: Adresseændring
 Update Systems:
   - Citizen Portal
   - Property Tax
@@ -887,17 +891,17 @@ Day 8+: Escalated to legal team, requester notified of delay
 
 **Optional**:
 - **MitID**: If requiring authentication
-- **SF1601**: Digital Post for official notice
-- **ESDH**: GetOrganized for document management
+- **SF1601**: Digital Post for official notice (test/mock modes today)
+- **ESDH**: Document management (planned integration)
 
-### Example: Aarhus Kommune FOI Request
+### Example: FOI Request (illustrative scenario)
 
-**Scenario**: Journalist requests meeting minutes from municipal board.
+**Scenario**: A journalist requests meeting minutes from a municipal board. Hypothetical demo scenario, not a real deployment.
 
 ```yaml
 # Configuration
-Workflow ID: foi_request_aarhus
-Label: Aktindsigt - Aarhus Kommune
+Workflow ID: foi_request
+Label: Aktindsigt
 Deadline: 7 days (legal requirement)
 Authentication: Optional
 Auto-Redact CPR: Yes
@@ -969,7 +973,7 @@ If denying access, must provide legal basis:
 | **Approvals** | Multi-step | None | Automatic | Automatic | Case-by-case |
 | **Documents** | Yes (upload) | No | No | No | Yes (release) |
 | **Deadline** | 30-90 days | None (SLA) | Real-time | Immediate | 7 days (legal) |
-| **Integrations** | SBSYS, ESDH | Email | CVR, CPR | Multiple systems | Email, ESDH |
+| **Integrations** | Case system (planned), ESDH (planned) | Email | CVR, CPR | Multiple systems (mock) | Email, ESDH (planned) |
 | **Use Frequency** | Occasional | Frequent | Occasional | Occasional | Rare |
 
 ### Complexity Scale
@@ -1080,19 +1084,15 @@ Need to route inquiries?
 
 To create a completely new template:
 
-1. **Use BPMN editor**: `/admin/config/workflow/eca/modeler`
-2. **Follow BPMN 2.0 standard**
-3. **Include required elements**:
+1. **Open the Workflow Modeler**: edit a flow at `/admin/config/workflow/eca`; the adopted editor is the Workflow Modeler (`drupal/modeler`, modeler id `workflow_modeler`)
+2. **Include required elements**:
    - Start event
    - End event
    - At least one task
    - Process documentation
-4. **Test with BpmnTemplateManager**:
-   ```php
-   $manager->validateTemplate('my_template');
-   ```
-5. **Add to workflows directory**
-6. **Document in this file**
+3. **Add the BPMN source file** to `web/modules/custom/aabenforms_workflows/workflows/`
+4. **Browse ready-made templates** at `/admin/aabenforms/workflow-templates`
+5. **Document in this file**
 
 ---
 

--- a/docs/video-scripts/01-PLATFORM_OVERVIEW.md
+++ b/docs/video-scripts/01-PLATFORM_OVERVIEW.md
@@ -61,66 +61,64 @@
 ### [0:15-0:45] The Problem Statement (30 seconds)
 
 #### NARRATION (Danish)
-"I dag betaler danske kommuner millioner af kroner årligt for digitale selvbetjeningsløsninger som KMD XFlow. Men hvad nu hvis der fandtes en moderne, open source alternative - uden vendor lock-in, uden skjulte omkostninger, og med fuld kontrol over jeres data?"
+"I dag betaler danske kommuner for digitale selvbetjeningsløsninger fra proprietære alternativer - typisk med årlige licensafgifter og gebyrer pr. formular eller integration. Men hvad nu hvis der fandtes et moderne, open source-alternativ - uden vendor lock-in, uden licensafgifter pr. formular, og med fuld kontrol over jeres data?"
 
 #### NARRATION (English)
-"Today, Danish municipalities pay millions of kroner annually for digital self-service solutions like KMD XFlow. But what if there was a modern, open-source alternative - without vendor lock-in, without hidden costs, and with full control over your data?"
+"Today, Danish municipalities pay proprietary alternatives for digital self-service solutions - typically with annual licence fees and per-form or per-integration charges. But what if there was a modern, open-source alternative - without vendor lock-in, without per-form licence fees, and with full control over your data?"
 
 #### SCREEN ACTIONS
-1. Show cost comparison slide:
-   - XFlow: 500,000 kr/year (typical municipality)
-   - ÅbenForms: Self-hosted (free) or 50,000 kr/year (managed)
-2. Highlight savings: **90% cost reduction**
+1. Show cost comparison slide (framing only, no fabricated figures):
+   - Proprietary alternatives: annual licence fees plus per-integration fees
+   - ÅbenForms: self-hosted (no licence fee) or a managed-hosting option
+2. Highlight: no per-form licence fees
 
 #### VISUAL CALLOUTS
-- Animated bar chart showing cost comparison
-- Highlight "90% savings" in bold
-- Show checkmarks for benefits:
-  -  No vendor lock-in
-  -  Full data sovereignty
-  -  Community-driven development
+- Comparison slide framing proprietary licence + per-integration fees vs open source
+- Show benefits as plain text:
+  - No vendor lock-in
+  - Full data control
+  - Community-driven development
 
 #### RECORDING TIPS
-- Pause for 2 seconds on cost comparison chart
-- Use arrow annotations to highlight key numbers
-- Emphasize "millions of kroner" with slight vocal stress
+- Pause for 2 seconds on cost comparison slide
+- Keep the comparison generic - do not cite specific vendor prices
+- Emphasize "no per-form licence fees"
 
 ---
 
 ### [0:45-1:30] Key Features Overview (45 seconds)
 
 #### NARRATION (Danish)
-"ÅbenForms giver jer alle de funktioner I kender fra XFlow - og meget mere. MitID-integration, betalingshåndtering via Nets, PDF-generering, SMS-beskeder, og kompleks workflow-orkestrering. Men vi går længere: GIS-integration til byggesager, GDPR-compliance by design, og en visuel workflow-builder der gør det let at oprette nye selvbetjeningsløsninger uden at skrive kode."
+"ÅbenForms har MitID-login og en ECA-workflow-motor med en visuel editor, Workflow Modeler, der gør det let at oprette godkendelsesflows uden at skrive kode. Custom webform-elementer validerer CPR, CVR og adresser serverside, og CPR-felter krypteres på feltniveau med audit-logning. I demoen vises betaling, SMS, GIS og kalender som mocks - de illustrerer den tiltænkte funktionalitet, men er ikke live produktionsintegrationer endnu."
 
 #### NARRATION (English)
-"ÅbenForms provides all the features you know from XFlow - and more. MitID integration, payment processing via Nets, PDF generation, SMS notifications, and complex workflow orchestration. But we go further: GIS integration for building permits, GDPR compliance by design, and a visual workflow builder that makes it easy to create new self-service solutions without writing code."
+"ÅbenForms has MitID sign-in and an ECA workflow engine with a visual editor, the Workflow Modeler, that makes it easy to create approval flows without writing code. Custom webform elements validate CPR, CVR and addresses server-side, and CPR fields are encrypted at field level with audit logging. In the demo, payment, SMS, GIS and calendar appear as mocks - they illustrate the intended functionality but are not live production integrations yet."
 
 #### SCREEN ACTIONS
 1. Navigate to Features page
 2. Scroll through feature list slowly
-3. Show feature comparison table:
+3. Show feature overview table (status, not vendor comparison):
 
-| Feature | XFlow | ÅbenForms |
-|---------|-------|-----------|
-| MitID Integration |  |  |
-| Payment Processing |  |  |
-| PDF Generation |  |  |
-| SMS Notifications |  |  |
-| GIS Zoning Validation |  |  |
-| Visual Workflow Builder | Limited |  |
-| Open Source |  |  |
-| Self-Hosting |  |  |
+| Feature | Status |
+|---------|--------|
+| MitID sign-in (Keycloak mock IdP) | Working |
+| CPR / CVR / DAWA webform validation | Working |
+| Field-level CPR encryption + audit log | Working |
+| ECA workflow engine + Workflow Modeler | Working |
+| Payment processing | Demo mock |
+| SMS notifications | Demo mock |
+| GIS zoning validation | Demo mock |
+| Open source / self-hosting | Yes |
 
 #### VISUAL CALLOUTS
-- Highlight each feature with animated checkmark
-- Circle "GIS Integration" as unique feature
-- Box "Visual Workflow Builder" section
-- Use green highlights for ÅbenForms advantages
+- Mark each row with its status (Working / Demo mock)
+- Box the "Workflow Modeler" row
+- Be clear which items are demo mocks
 
 #### RECORDING TIPS
 - Slow down when listing technical features
 - Use cursor to point to each feature as you mention it
-- Pause briefly between feature categories
+- Do not present demo mocks as live production features
 
 ---
 
@@ -145,7 +143,7 @@
 
 #### VISUAL CALLOUTS
 - Label each workflow card with category
-- Show "15 ready-to-use workflows" counter
+- Show "13 ready-to-use workflow templates" counter
 - Highlight "Community Templates" section
 - Show workflow complexity indicator (Simple/Medium/Complex)
 

--- a/docs/video-scripts/INDEX.md
+++ b/docs/video-scripts/INDEX.md
@@ -20,11 +20,11 @@ Complete video script package for producing professional demo videos.
 ### 1. Platform Overview (3 minutes)
 **File**: [01-PLATFORM_OVERVIEW.md](01-PLATFORM_OVERVIEW.md)
 
-**Purpose**: Introduction to ÅbenForms, value proposition, cost comparison
+**Purpose**: Introduction to ÅbenForms, value proposition
 **Audience**: Municipal decision-makers, IT managers
 **Key Messages**:
-- Open source alternative to XFlow
-- 90% cost savings
+- Open source alternative to proprietary alternatives
+- No per-form licence fees
 - No vendor lock-in
 - Community-driven
 
@@ -32,12 +32,12 @@ Complete video script package for producing professional demo videos.
 - Exact narration (Danish + English)
 - Screen actions with timestamps
 - Visual callouts and graphics
-- Cost comparison chart
-- Feature comparison table
+- Cost comparison framing (no fabricated figures)
+- Feature overview
 - GitHub repository showcase
 - Call to action
 
-**Complexity**: ⭐ Simple (mostly slides and homepage)
+**Complexity**: Simple (mostly slides and homepage)
 **Recording Time**: ~1 hour
 **Editing Time**: ~4 hours
 
@@ -49,29 +49,27 @@ Complete video script package for producing professional demo videos.
 **Purpose**: End-to-end workflow demonstration (simple example)
 **Audience**: Municipal staff, citizens, general public
 **Key Messages**:
-- 5 minutes from start to approved permit
-- MitID authentication
-- Payment processing
-- Automatic PDF generation
-- SMS confirmation
-- 75% time savings vs manual process
+- A short, guided application flow
+- MitID authentication (against a Keycloak mock IdP)
+- Payment step (demo mock - not a live payment gateway)
+- PDF generation
+- SMS confirmation (demo mock)
 
 **Script Includes**:
 - Complete workflow walkthrough
-- MitID login sequence
+- MitID login sequence (mock IdP)
 - Form completion (vehicle info, address)
-- Payment processing (Nets)
+- Payment step (demo mock)
 - PDF license generation
-- SMS notification
-- Time comparison graphic
+- SMS notification (demo mock)
 
 **Test Data Required**:
-- Citizen: Jens Jensen (CPR: 0101701234)
-- Vehicle: AB12345 (VW Golf)
+- Citizen: Jens Jensen (fictional, CPR: 0101701234)
+- Vehicle: AB12345 (VW Golf, fictional)
 - Payment: Test card 4111 1111 1111 1111
-- Zone: Zone 2 - Nørregade området
+- Zone: Zone 2 - Nørregade området (fictional scenario)
 
-**Complexity**: ⭐⭐ Medium (live demo with integrations)
+**Complexity**: Medium (demo flow with mocked integrations)
 **Recording Time**: ~2 hours
 **Editing Time**: ~5 hours
 
@@ -83,29 +81,28 @@ Complete video script package for producing professional demo videos.
 **Purpose**: Complex dual-authentication workflow
 **Audience**: Municipal registry office, engaged couples
 **Key Messages**:
-- Dual MitID authentication (both partners)
-- Calendar integration
-- Real-time availability
-- Automated reminders (email + SMS)
-- Complex workflow orchestration
+- Dual MitID authentication (both partners, against the mock IdP)
+- Calendar/booking step (demo mock)
+- Reminders (email + SMS, demo mocks)
+- Multi-party workflow orchestration
 - Celebratory, warm tone
 
 **Script Includes**:
 - Dual partner authentication flow
-- Calendar and venue selection
+- Calendar and venue selection (demo mock)
 - Witness information
-- Payment and confirmation
-- Automated reminder system
+- Payment and confirmation (payment is a demo mock)
+- Reminder system (demo mock)
 - Calendar invitation (.ics) download
 
 **Test Data Required**:
-- Partner A: Anna Andersen (CPR: 0101851234)
-- Partner B: Bo Bertelsen (CPR: 0202881234)
-- Witnesses: Carla Christensen, David Davidsen
-- Venue: Rådhuset, Gammel Festsal
+- Partner A: Anna Andersen (fictional, CPR: 0101851234)
+- Partner B: Bo Bertelsen (fictional, CPR: 0202881234)
+- Witnesses: Carla Christensen, David Davidsen (fictional)
+- Venue: Rådhuset, Gammel Festsal (fictional scenario)
 - Date: 3 weeks from recording date
 
-**Complexity**: ⭐⭐⭐ Complex (dual auth, calendar, multiple integrations)
+**Complexity**: Complex (dual auth, calendar/payroll/calendar steps are demo mocks)
 **Recording Time**: ~2.5 hours
 **Editing Time**: ~6 hours
 
@@ -117,37 +114,37 @@ Complete video script package for producing professional demo videos.
 **Purpose**: Advanced features showcase (GIS, SBSYS, GDPR)
 **Audience**: Municipal planners, building inspectors, architects
 **Key Messages**:
-- **GIS zoning validation** (XFlow doesn't have this!)
-- Automatic neighbor notification
-- Multi-stage approval workflow
-- SBSYS integration
-- GDPR compliance by design
-- 75% faster than manual process
+- GIS zoning validation (demo mock)
+- Automatic neighbor notification (demo mock)
+- Multi-stage approval workflow (ECA flows)
+- SBSYS integration (planned, shown as demo mock)
+- Field-level CPR encryption and audit logging (real, built into aabenforms_core)
+- Faster than a manual paper process
 
 **Script Includes**:
 - Project type selection
-- MitID + property identification
-- **GIS map visualization** (KEY FEATURE)
-- **Automatic zoning validation** (KEY FEATURE)
+- MitID + property identification (mock IdP)
+- GIS map visualization (demo mock)
+- Automatic zoning validation (demo mock)
 - Document upload with validation
-- **Automatic neighbor notification** (KEY FEATURE)
-- BPMN workflow stages
-- SBSYS integration
-- GDPR compliance dashboard
+- Automatic neighbor notification (demo mock)
+- Workflow stages (ECA flows)
+- SBSYS integration (planned, shown as demo mock)
+- GDPR / audit-log view
 - Building permit issuance
 
 **Test Data Required**:
-- Applicant: Mette Mortensen (CPR: 0101701234)
-- Property: Skovvej 15 (ID: 751-12345)
-- GIS data: Zone Residential, 3 neighbors identified
+- Applicant: Mette Mortensen (fictional, CPR: 0101701234)
+- Property: Skovvej 15 (fictional, ID: 751-12345)
+- GIS data: Zone Residential, 3 neighbors (mock scenario)
 - Documents: 6 PDFs (plans, drawings, calculations)
-- Contractor: Byg & Anlæg ApS (CVR: 98765432)
+- Contractor: Byg & Anlæg ApS (fictional, CVR: 98765432)
 
-**Complexity**: ⭐⭐⭐⭐ Very Complex (GIS maps, multi-stage workflow, many integrations)
+**Complexity**: Very Complex (GIS/SBSYS shown as demo mocks, multi-stage ECA workflow)
 **Recording Time**: ~3 hours
 **Editing Time**: ~8 hours
 
-**NOTE**: This is the **most important video** - it showcases features XFlow doesn't have!
+**NOTE**: Several features in this video (GIS, neighbor notification, SBSYS) are demo mocks, not live production integrations. Narrate them as illustrative.
 
 ---
 
@@ -158,31 +155,31 @@ Complete video script package for producing professional demo videos.
 **Audience**: Municipal IT staff, workflow designers, administrators
 **Key Messages**:
 - No coding required
-- BPMN.io industry standard
-- 16 Danish municipal task types
+- Workflow Modeler (visual workflow editor)
+- 13 ready-made workflow templates / 18 ECA flows deployed
 - Drag-and-drop interface
 - Validation and testing
 - Template gallery
 - Community sharing
 
 **Script Includes**:
-- BPMN.io editor overview (3 panels)
-- Building simple workflow from scratch (dog registration)
-- Adding conditional logic (gateways)
-- Danish municipal task palette (16 types)
-- **GIS Validation task** (unique feature)
-- **Neighbor Notification task** (unique feature)
+- Workflow Modeler editor overview
+- Building a simple workflow from scratch (dog registration)
+- Adding conditional logic
+- Danish municipal task palette
+- GIS Validation task (demo mock)
+- Neighbor Notification task (demo mock)
 - Validation and simulation
 - Template gallery browsing
-- Export/import workflows (BPMN XML)
-- Advanced features (subprocess, timers, parallel gateways)
+- Export/import workflows
+- Advanced features (subprocess, timers, parallel branches)
 
 **Test Data Required**:
 - Admin account: admin@demo.aabenforms.dk / demo123
-- Workflow templates: 16+ in gallery
-- BPMN.io editor configured with Danish palette
+- 13 ready-made workflow templates in gallery
+- Workflow Modeler configured with Danish palette
 
-**Complexity**: ⭐⭐⭐ Complex (technical tutorial, requires clear instruction)
+**Complexity**: Complex (technical tutorial, requires clear instruction)
 **Recording Time**: ~4 hours
 **Editing Time**: ~8 hours
 
@@ -206,38 +203,35 @@ Complete video script package for producing professional demo videos.
 
 ---
 
-## Key Differentiators to Emphasize
+## Key Points to Emphasize
 
-These features make ÅbenForms superior to XFlow:
+These points differentiate ÅbenForms from proprietary alternatives:
 
 ### 1. GIS Zoning Validation (Video 04)
 - **What**: Automatic property identification and zoning validation
-- **Why**: XFlow requires manual checking; we automate it
-- **Impact**: Saves 2 hours per building permit application
+- **Status**: Demo mock - illustrates the intended capability, not a live integration
 - **Screen Time**: 90 seconds in Video 04 (1:45-3:00)
 
 ### 2. Automatic Neighbor Notification (Video 04)
-- **What**: GIS-based neighbor identification and automated letters
-- **Why**: XFlow requires manual neighbor lookup and letter writing
-- **Impact**: Saves 1 hour per application, reduces errors
+- **What**: GIS-based neighbor identification and generated letters
+- **Status**: Demo mock - illustrates the intended capability
 - **Screen Time**: 45 seconds in Video 04 (4:00-4:45)
 
-### 3. Visual Workflow Builder (Video 05)
-- **What**: Drag-and-drop BPMN workflow creation without coding
-- **Why**: XFlow has limited workflow customization
+### 3. Visual Workflow Editor (Video 05)
+- **What**: Drag-and-drop workflow creation without coding via the Workflow Modeler
+- **Why**: Proprietary alternatives typically have limited workflow customization
 - **Impact**: Non-technical staff can create new services
 - **Screen Time**: Entire 10-minute video
 
 ### 4. Open Source & No Vendor Lock-in (Video 01)
-- **What**: AGPL-3.0 licensed, self-hostable, community-driven
-- **Why**: XFlow is proprietary, expensive, vendor lock-in
-- **Impact**: 90% cost savings, full data sovereignty
+- **What**: GPL-2.0-or-later licensed, self-hostable, community-driven
+- **Why**: Proprietary alternatives carry licence and per-integration fees and vendor lock-in
+- **Impact**: No per-form licence fees, full data control
 - **Screen Time**: 45 seconds in Video 01 (2:15-2:45)
 
 ### 5. Danish Municipal Task Palette (Video 05)
-- **What**: 16 pre-configured task types for Danish workflows
+- **What**: Pre-configured task types for Danish workflows
 - **Why**: Generic BPM tools require extensive configuration
-- **Impact**: 10x faster workflow creation
 - **Screen Time**: 90 seconds in Video 05 (5:00-6:30)
 
 ---
@@ -279,7 +273,7 @@ These features make ÅbenForms superior to XFlow:
 - Documentation: https://docs.aabenforms.dk
 - Community: https://community.aabenforms.dk
 
-### Test Accounts
+### Test Accounts (all fictional)
 - **Citizen**: 0101701234 (Jens Jensen)
 - **Partner A**: 0101851234 (Anna Andersen)
 - **Partner B**: 0202881234 (Bo Bertelsen)
@@ -313,13 +307,13 @@ Examples:
 
 | Video | Script | Recording | Editing | QA | Published |
 |-------|--------|-----------|---------|-----|-----------|
-| 01 - Platform Overview |  | ⬜ | ⬜ | ⬜ | ⬜ |
-| 02 - Parking Permit |  | ⬜ | ⬜ | ⬜ | ⬜ |
-| 03 - Marriage Booking |  | ⬜ | ⬜ | ⬜ | ⬜ |
-| 04 - Building Permit |  | ⬜ | ⬜ | ⬜ | ⬜ |
-| 05 - Visual Builder |  | ⬜ | ⬜ | ⬜ | ⬜ |
+| 01 - Platform Overview | Done | Not started | Not started | Not started | Not started |
+| 02 - Parking Permit | Done | Not started | Not started | Not started | Not started |
+| 03 - Marriage Booking | Done | Not started | Not started | Not started | Not started |
+| 04 - Building Permit | Done | Not started | Not started | Not started | Not started |
+| 05 - Visual Builder | Done | Not started | Not started | Not started | Not started |
 
-**Legend**:  Complete |  In Progress | ⬜ Not Started
+**Legend**: Done | In Progress | Not Started
 
 ---
 
@@ -352,24 +346,8 @@ Examples:
 
 ## Success Metrics
 
-### YouTube Performance Targets (First Month)
-- **Platform Overview**: 1,000+ views, 65%+ retention
-- **Parking Permit**: 500+ views, 55%+ retention
-- **Marriage Booking**: 400+ views, 55%+ retention
-- **Building Permit**: 600+ views, 60%+ retention (key video)
-- **Visual Builder**: 800+ views, 50%+ retention
-
-### Engagement Targets
-- Click-through rate: 4-10% (thumbnail quality)
-- Like ratio: 95%+ (high quality indicator)
-- Comments: 5-10 per video (engagement)
-- Subscribers gained: 50-100 from series
-
-### Business Impact Targets
-- Demo requests: 10-20 from municipalities
-- GitHub stars: +200 (from 1,247 to 1,450+)
-- Downloads: 50-100 (self-hosted installations)
-- Community members: +50 (forum, Discord)
+Set concrete view/retention/engagement targets once the channel has a baseline.
+Avoid publishing fabricated benchmark figures before any video exists.
 
 ---
 
@@ -397,7 +375,5 @@ All video scripts and production materials:
 
 ---
 
-**Last Updated**: 2024-02-02
-**Version**: 1.0.0
-**Status**: Ready for Production 
+**Status**: Pre-pilot POC. Scripts ready for review.
 **Maintained by**: ÅbenForms Core Team

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -216,9 +216,14 @@ class SendDigitalPostAction extends AabenFormsActionBase {
 
       $result = $this->sender->send($post);
 
+      $mode = $this->sender->testMode();
+      $demo = in_array($mode, ['fake_db', 'wiremock'], TRUE);
+      $description = $demo
+        ? sprintf('Demo: Digital Post simuleret (%s).', $mode)
+        : ($result->message ?: 'Digital Post afsendt.');
       $this->recordStep(
         label: $result->isSuccess() ? 'Digital Post sent' : 'Digital Post failed',
-        description: sprintf('%s: %s', $this->sender->testMode(), $result->message),
+        description: $description,
         status: $result->isSuccess() ? 'completed' : 'failed',
       );
       $this->setResultToken(

--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -118,3 +118,6 @@ aabenforms_workflows.settings:
     allow_mitid_demo_mode:
       type: boolean
       label: 'Allow MitID validation to pass without a real session (demo only; default off)'
+    allow_cpr_demo_mode:
+      type: boolean
+      label: 'Force CPR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
@@ -4,6 +4,7 @@ namespace Drupal\aabenforms_workflows\Plugin\Action;
 
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\eca\Attribute\EcaAction;
@@ -31,12 +32,35 @@ class CprLookupAction extends AabenFormsActionBase {
   protected ServiceplatformenClient $serviceplatformenClient;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->serviceplatformenClient = $container->get('aabenforms_core.serviceplatformen_client');
+    $instance->configFactory = $container->get('config.factory');
     return $instance;
+  }
+
+  /**
+   * Whether to run CPR lookup in demo mode (no real Serviceplatformen call).
+   *
+   * True when the demo flag is set, or - the common case for a POC - when no
+   * Serviceplatformen client certificate is provisioned. Once a certificate is
+   * configured, real SF1520 lookups resume automatically.
+   */
+  protected function demoModeAllowed(): bool {
+    if ($this->configFactory->get('aabenforms_workflows.settings')->get('allow_cpr_demo_mode')) {
+      return TRUE;
+    }
+    $certs = $this->configFactory->get('aabenforms_core.settings')->get('serviceplatformen.certificates') ?? [];
+    return empty($certs['cert_path']) && empty($certs['key_path']);
   }
 
   /**
@@ -106,6 +130,21 @@ class CprLookupAction extends AabenFormsActionBase {
       return;
     }
 
+    if ($this->demoModeAllowed()) {
+      // No Serviceplatformen certificate is provisioned (the POC case). Do not
+      // call SF1520; record an honest, clearly-labelled demo step with test
+      // data so the flow continues without surfacing a connection error.
+      $demoPerson = [
+        'cpr' => substr($cpr, 0, 6) . 'XXXX',
+        'full_name' => 'Demoborger (testdata)',
+        'demo' => TRUE,
+      ];
+      $this->setTokenValue($this->configuration['result_token'], $demoPerson);
+      $this->log('CPR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
+      $this->recordStep('CPR Registry Lookup', 'Demo: CPR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
+      return;
+    }
+
     try {
       $this->log('Performing CPR lookup via SF1520 for: {cpr}', [
         'cpr' => substr($cpr, 0, 6) . 'XXXX',
@@ -142,8 +181,11 @@ class CprLookupAction extends AabenFormsActionBase {
 
     }
     catch (\Exception $e) {
-      $this->handleError($e, 'CPR Registry Lookup');
+      // Keep the technical detail in the server log, but never surface a raw
+      // cURL/SSL/Serviceplatformen error to the citizen.
+      $this->log('CPR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->recordStep('CPR Registry Lookup', 'CPR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -6,6 +6,8 @@ use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\CprLookupAction;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -55,6 +57,13 @@ class CprLookupActionTest extends UnitTestCase {
    * @var array
    */
   protected array $tokenStorage = [];
+
+  /**
+   * Whether CPR demo mode is forced on for the current test.
+   *
+   * @var bool
+   */
+  protected bool $cprDemoMode = FALSE;
 
   /**
    * {@inheritdoc}
@@ -113,6 +122,45 @@ class CprLookupActionTest extends UnitTestCase {
     $clientProperty = $reflectionClass->getProperty('serviceplatformenClient');
     $clientProperty->setAccessible(TRUE);
     $clientProperty->setValue($this->action, $this->serviceplatformenClient);
+
+    // Config factory: demo flag reads $this->cprDemoMode; certs are present by
+    // default so the existing tests exercise the real SF1520 path. A test sets
+    // $this->cprDemoMode = TRUE to exercise the demo branch.
+    $wfSettings = $this->createMock(ImmutableConfig::class);
+    $wfSettings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'allow_cpr_demo_mode' ? $this->cprDemoMode : NULL
+    );
+    $coreSettings = $this->createMock(ImmutableConfig::class);
+    $coreSettings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'serviceplatformen.certificates' ? ['cert_path' => '/cert.pem', 'key_path' => '/key.pem'] : NULL
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturnCallback(
+      fn ($name) => $name === 'aabenforms_core.settings' ? $coreSettings : $wfSettings
+    );
+    $configFactoryProperty = $reflectionClass->getProperty('configFactory');
+    $configFactoryProperty->setAccessible(TRUE);
+    $configFactoryProperty->setValue($this->action, $configFactory);
+  }
+
+  /**
+   * Demo mode records a labelled simulated step and never calls SF1520.
+   *
+   * @covers ::execute
+   */
+  public function testDemoModeSimulatesWithoutCallingServiceplatformen(): void {
+    $this->cprDemoMode = TRUE;
+    $this->tokenStorage['cpr'] = '0101104321';
+
+    // Serviceplatformen must not be called in demo mode.
+    $this->serviceplatformenClient->expects($this->never())->method('request');
+
+    $this->action->execute();
+
+    $person = $this->tokenStorage['person_data'];
+    $this->assertIsArray($person);
+    $this->assertTrue($person['demo']);
+    $this->assertSame('Demoborger (testdata)', $person['full_name']);
   }
 
   /**


### PR DESCRIPTION
The live Byggetilladelse demo called SF1520 with no Serviceplatformen certificate and showed the citizen the raw cURL/SSL error, while the copy claimed all steps ran on real integrations.

- CprLookupAction runs in demo mode when no Serviceplatformen certificate is configured (auto-detected, or forced via allow_cpr_demo_mode). It records an honest 'Demo: CPR-opslag simuleret med testdata' step instead of calling SF1520; real lookups resume automatically once a certificate is provisioned (#76).
- A genuine lookup error logs the technical detail server-side and records a friendly 'CPR-opslaget er midlertidigt utilgaengeligt' step - no raw cURL/SSL string reaches the citizen.
- Digital Post step reads 'Demo: Digital Post simuleret (fake_db)' rather than the doubled technical line.

Frontend copy (the 'real integrations' overclaim) is fixed in a paired aabenforms-frontend PR. 15 unit tests pass incl. a demo-mode test; phpcs clean.