### PR TITLE
Add demo guard and error sanitisation to CvrLookupAction (#99)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -121,3 +121,6 @@ aabenforms_workflows.settings:
     allow_cpr_demo_mode:
       type: boolean
       label: 'Force CPR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'
+    allow_cvr_demo_mode:
+      type: boolean
+      label: 'Force CVR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
@@ -4,6 +4,7 @@ namespace Drupal\aabenforms_workflows\Plugin\Action;
 
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\eca\Attribute\EcaAction;
@@ -31,12 +32,35 @@ class CvrLookupAction extends AabenFormsActionBase {
   protected ServiceplatformenClient $serviceplatformenClient;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->serviceplatformenClient = $container->get('aabenforms_core.serviceplatformen_client');
+    $instance->configFactory = $container->get('config.factory');
     return $instance;
+  }
+
+  /**
+   * Whether to run CVR lookup in demo mode (no real Serviceplatformen call).
+   *
+   * True when the demo flag is set, or - the common case for a POC - when no
+   * Serviceplatformen client certificate is provisioned. Once a certificate is
+   * configured, real SF1530 lookups resume automatically.
+   */
+  protected function demoModeAllowed(): bool {
+    if ($this->configFactory->get('aabenforms_workflows.settings')->get('allow_cvr_demo_mode')) {
+      return TRUE;
+    }
+    $certs = $this->configFactory->get('aabenforms_core.settings')->get('serviceplatformen.certificates') ?? [];
+    return empty($certs['cert_path']) && empty($certs['key_path']);
   }
 
   /**
@@ -96,14 +120,30 @@ class CvrLookupAction extends AabenFormsActionBase {
   public function execute(): void {
     $cvr = $this->getTokenValue($this->configuration['cvr_token'], '');
 
+    // Clean CVR (remove spaces/hyphens).
+    $cvr = $cvr ? preg_replace('/[^0-9]/', '', $cvr) : '';
+
     if (empty($cvr)) {
-      $this->log('CVR lookup failed: No CVR number provided', [], 'warning');
+      $this->log('CVR lookup skipped: no CVR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->recordStep('CVR Registry Lookup', 'Skipped - no CVR available to look up', 'skipped');
       return;
     }
 
-    // Clean CVR (remove spaces/hyphens).
-    $cvr = preg_replace('/[^0-9]/', '', $cvr);
+    if ($this->demoModeAllowed()) {
+      // No Serviceplatformen certificate is provisioned (the POC case). Do not
+      // call SF1530; record an honest, clearly-labelled demo step with test
+      // data so the flow continues without surfacing a connection error.
+      $demoCompany = [
+        'cvr' => $cvr,
+        'name' => 'Demovirksomhed ApS (testdata)',
+        'demo' => TRUE,
+      ];
+      $this->setTokenValue($this->configuration['result_token'], $demoCompany);
+      $this->log('CVR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
+      $this->recordStep('CVR Registry Lookup', 'Demo: CVR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
+      return;
+    }
 
     try {
       $this->log('Performing CVR lookup via SF1530 for: {cvr}', [
@@ -130,6 +170,7 @@ class CvrLookupAction extends AabenFormsActionBase {
           'cvr' => $cvr,
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
+        $this->recordStep('CVR Registry Lookup', 'No company found in the central business registry (SF1530)', 'failed');
         return;
       }
 
@@ -138,11 +179,15 @@ class CvrLookupAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], $companyData);
+      $this->recordStep('CVR Registry Lookup', 'Company data retrieved from the central business registry (SF1530)');
 
     }
     catch (\Exception $e) {
-      $this->handleError($e, 'CVR lookup via SF1530');
+      // Keep the technical detail in the server log, but never surface a raw
+      // cURL/SSL/Serviceplatformen error to the citizen.
+      $this->log('CVR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->recordStep('CVR Registry Lookup', 'CVR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CvrLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CvrLookupActionTest.php
@@ -6,6 +6,8 @@ use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\CvrLookupAction;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -55,6 +57,13 @@ class CvrLookupActionTest extends UnitTestCase {
    * @var array
    */
   protected array $tokenStorage = [];
+
+  /**
+   * Whether CVR demo mode is forced on for the current test.
+   *
+   * @var bool
+   */
+  protected bool $cvrDemoMode = FALSE;
 
   /**
    * {@inheritdoc}
@@ -113,6 +122,45 @@ class CvrLookupActionTest extends UnitTestCase {
     $clientProperty = $reflectionClass->getProperty('serviceplatformenClient');
     $clientProperty->setAccessible(TRUE);
     $clientProperty->setValue($this->action, $this->serviceplatformenClient);
+
+    // Config factory: demo flag reads $this->cvrDemoMode; certs are present by
+    // default so the existing tests exercise the real SF1530 path. A test sets
+    // $this->cvrDemoMode = TRUE to exercise the demo branch.
+    $wfSettings = $this->createMock(ImmutableConfig::class);
+    $wfSettings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'allow_cvr_demo_mode' ? $this->cvrDemoMode : NULL
+    );
+    $coreSettings = $this->createMock(ImmutableConfig::class);
+    $coreSettings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'serviceplatformen.certificates' ? ['cert_path' => '/cert.pem', 'key_path' => '/key.pem'] : NULL
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturnCallback(
+      fn ($name) => $name === 'aabenforms_core.settings' ? $coreSettings : $wfSettings
+    );
+    $configFactoryProperty = $reflectionClass->getProperty('configFactory');
+    $configFactoryProperty->setAccessible(TRUE);
+    $configFactoryProperty->setValue($this->action, $configFactory);
+  }
+
+  /**
+   * Demo mode records a labelled simulated step and never calls SF1530.
+   *
+   * @covers ::execute
+   */
+  public function testDemoModeSimulatesWithoutCallingServiceplatformen(): void {
+    $this->cvrDemoMode = TRUE;
+    $this->tokenStorage['cvr'] = '12345678';
+
+    // Serviceplatformen must not be called in demo mode.
+    $this->serviceplatformenClient->expects($this->never())->method('request');
+
+    $this->action->execute();
+
+    $company = $this->tokenStorage['company_data'];
+    $this->assertIsArray($company);
+    $this->assertTrue($company['demo']);
+    $this->assertSame('Demovirksomhed ApS (testdata)', $company['name']);
   }
 
   /**


### PR DESCRIPTION
Ports the #95 CPR pattern to the CVR path. Before this, with no Serviceplatformen certificate provisioned, an anonymous company_verification or association_booking submission made the server attempt an outbound SF1530 SOAP POST with empty WS-Security credentials; the call failed and the raw cURL error was returned to the caller in workflow.steps.

Changes:
- CvrLookupAction injects ConfigFactoryInterface and gains demoModeAllowed() (allow_cvr_demo_mode flag, or auto-detected when no cert/key is configured). In demo mode it records a labelled simulated step with test company data and never calls SF1530.
- Sanitised catch: the raw exception is logged server-side; the citizen sees a Danish 'midlertidigt utilgaengeligt' message instead of a cURL/SSL string. Replaces the raw handleError() call.
- Adds recordStep() calls for the skipped, not-found, success and failure paths (previously absent).
- New allow_cvr_demo_mode schema key.
- CvrLookupActionTest wires a config-factory mock (certs present by default so existing tests keep the real SF1530 path) and adds a demo-mode test. 9 tests green.

From the data-flow analysis (docs/DATA-FLOW.md). Closes #99.