### PR TITLE
Make the audit log record the real outcome, not always success (#97)

### DIFF
--- a/config/sync/eca.eca.address_change_flow.yml
+++ b/config/sync/eca.eca.address_change_flow.yml
@@ -43,6 +43,7 @@ actions:
       event_type: address_change_submitted
       additional_data_token: '[citizen_data:name]'
       message_template: 'Address change submitted; CPR resolved against registry.'
+      status_token: citizen_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.association_booking_flow.yml
+++ b/config/sync/eca.eca.association_booking_flow.yml
@@ -54,6 +54,7 @@ actions:
       event_type: association_booking_submitted
       additional_data_token: '[webform_submission:values:association_name:raw]'
       message_template: 'Association request received and CVR resolved'
+      status_token: association_data_status
     successors:
       -
         id: log_reviewer_assigned

--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -46,6 +46,7 @@ actions:
       event_type: building_permit_submitted
       additional_data_token: ''
       message_template: 'Building permit application received; CPR resolved against registry.'
+      status_token: citizen_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.citizen_service_application_flow.yml
+++ b/config/sync/eca.eca.citizen_service_application_flow.yml
@@ -54,6 +54,7 @@ actions:
       event_type: citizen_service_submitted
       additional_data_token: '[citizen_data:name]'
       message_template: 'Citizen service application received and CPR resolved'
+      status_token: citizen_data_status
     successors:
       -
         id: log_caseworker_assigned

--- a/config/sync/eca.eca.company_verification_flow.yml
+++ b/config/sync/eca.eca.company_verification_flow.yml
@@ -46,6 +46,7 @@ actions:
       event_type: company_verification_submitted
       additional_data_token: ''
       message_template: 'Company verification request received; CVR resolved.'
+      status_token: company_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.marriage_booking_flow.yml
+++ b/config/sync/eca.eca.marriage_booking_flow.yml
@@ -57,6 +57,7 @@ actions:
       event_type: marriage_booking_submitted
       additional_data_token: ''
       message_template: 'Marriage booking received; both partners CPR-verified.'
+      status_token: partner2_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.parent1_approval_flow.yml
+++ b/config/sync/eca.eca.parent1_approval_flow.yml
@@ -75,6 +75,7 @@ actions:
       event_type: parent1_approval
       additional_data_token: '[parent1_data:name]'
       message_template: 'Parent 1 authenticated and approved'
+      status_token: parent1_mitid_valid_status
     successors:
       -
         id: mark_parent1_complete

--- a/config/sync/eca.eca.parent2_approval_flow.yml
+++ b/config/sync/eca.eca.parent2_approval_flow.yml
@@ -75,6 +75,7 @@ actions:
       event_type: parent2_approval
       additional_data_token: '[parent2_data:name]'
       message_template: 'Parent 2 authenticated and approved'
+      status_token: parent2_mitid_valid_status
     successors:
       -
         id: mark_parent2_complete

--- a/config/sync/eca.eca.parent_dual_approval_working.yml
+++ b/config/sync/eca.eca.parent_dual_approval_working.yml
@@ -57,6 +57,7 @@ actions:
       event_type: parent1_approval
       additional_data_token: '[parent1_data:name]'
       message_template: 'Parent 1 authenticated'
+      status_token: parent1_mitid_valid_status
     successors:
       -
         id: mark_parent1_complete
@@ -100,6 +101,7 @@ actions:
       event_type: parent2_approval
       additional_data_token: '[parent2_data:name]'
       message_template: 'Parent 2 authenticated'
+      status_token: parent2_mitid_valid_status
     successors:
       -
         id: mark_parent2_complete

--- a/config/sync/eca.eca.parking_permit_flow.yml
+++ b/config/sync/eca.eca.parking_permit_flow.yml
@@ -46,6 +46,7 @@ actions:
       event_type: parking_permit_submitted
       additional_data_token: ''
       message_template: 'Parking permit application received; CPR resolved.'
+      status_token: citizen_data_status
     successors:
       -
         id: send_confirmation

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
@@ -48,6 +48,8 @@ class AuditLogAction extends AabenFormsActionBase {
       'cpr_token' => 'cpr',
       'message_template' => 'Workflow action executed',
       'additional_data_token' => '',
+      'status' => 'success',
+      'status_token' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -93,6 +95,26 @@ class AuditLogAction extends AabenFormsActionBase {
       '#default_value' => $this->configuration['additional_data_token'],
     ];
 
+    $form['status_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Status token'),
+      '#description' => $this->t('Optional token whose value determines the logged status. A prior step result such as <code>citizen_data_status</code> or <code>citizen_mitid_valid_status</code>. Values like found/verified/match/completed map to success; denied maps to denied; anything else (not_found, failed, error) maps to failure. Leave empty to use the fixed status below.'),
+      '#default_value' => $this->configuration['status_token'],
+    ];
+
+    $form['status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Status'),
+      '#description' => $this->t('Status to log when no status token is configured.'),
+      '#options' => [
+        'success' => $this->t('Success'),
+        'failure' => $this->t('Failure'),
+        'denied' => $this->t('Denied'),
+        'skipped' => $this->t('Skipped'),
+      ],
+      '#default_value' => $this->configuration['status'],
+    ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -104,6 +126,8 @@ class AuditLogAction extends AabenFormsActionBase {
     $this->configuration['cpr_token'] = $form_state->getValue('cpr_token');
     $this->configuration['message_template'] = $form_state->getValue('message_template');
     $this->configuration['additional_data_token'] = $form_state->getValue('additional_data_token');
+    $this->configuration['status_token'] = $form_state->getValue('status_token');
+    $this->configuration['status'] = $form_state->getValue('status');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -141,13 +165,17 @@ class AuditLogAction extends AabenFormsActionBase {
         }
       }
 
+      // Derive the status from the real outcome of a prior step rather than
+      // always recording success. This is what keeps the audit trail honest.
+      $status = $this->resolveStatus();
+
       // Create audit log entry.
       if ($cpr && $eventType === 'cpr_access') {
         $this->auditLogger->log(
           'cpr_access',
           $cpr,
           'workflow_action',
-          'success',
+          $status,
           array_merge(['message' => $message], $additionalData)
         );
       }
@@ -156,13 +184,14 @@ class AuditLogAction extends AabenFormsActionBase {
           $eventType,
           $cpr ?? 'system',
           $message,
-          'success',
+          $status,
           array_merge(['action_id' => $this->getPluginId()], $additionalData)
         );
       }
 
-      $this->log('Audit log entry created: {type}', [
+      $this->log('Audit log entry created: {type} ({status})', [
         'type' => $eventType,
+        'status' => $status,
       ]);
       $this->recordStep('GDPR Audit Trail', 'Audit log entry created for regulatory compliance');
 
@@ -170,6 +199,53 @@ class AuditLogAction extends AabenFormsActionBase {
     catch (\Exception $e) {
       $this->handleError($e, 'Creating audit log entry');
     }
+  }
+
+  /**
+   * Resolves the status to log.
+   *
+   * When a status token is configured, the real outcome of the prior step is
+   * read and normalised; otherwise the configured fixed status is used. This
+   * stops the audit log from recording success for a step that failed or was
+   * never verified.
+   *
+   * @return string
+   *   One of 'success', 'failure', 'denied' or 'skipped'.
+   */
+  protected function resolveStatus(): string {
+    $statusToken = (string) ($this->configuration['status_token'] ?? '');
+    if ($statusToken !== '') {
+      $raw = $this->getTokenValue($statusToken, '');
+      if ($raw !== '') {
+        return $this->normalizeStatus($raw);
+      }
+    }
+    $fixed = (string) ($this->configuration['status'] ?? 'success');
+    return $fixed !== '' ? $this->normalizeStatus($fixed) : 'success';
+  }
+
+  /**
+   * Maps a raw status marker to the audit-log vocabulary.
+   *
+   * @param string $raw
+   *   The raw status from a result token or config (for example 'found',
+   *   'verified', 'match', 'not_found', 'failed', 'denied').
+   *
+   * @return string
+   *   One of 'success', 'failure', 'denied' or 'skipped'.
+   */
+  protected function normalizeStatus(string $raw): string {
+    $value = strtolower(trim($raw));
+    if (in_array($value, ['success', 'completed', 'found', 'verified', 'match', 'true', '1', 'ok'], TRUE)) {
+      return 'success';
+    }
+    if ($value === 'denied') {
+      return 'denied';
+    }
+    if ($value === 'skipped') {
+      return 'skipped';
+    }
+    return 'failure';
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
@@ -126,6 +126,7 @@ class CprLookupAction extends AabenFormsActionBase {
     if (empty($cpr)) {
       $this->log('CPR lookup skipped: no CPR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('skipped');
       $this->recordStep('CPR Registry Lookup', 'Skipped - no CPR available to look up', 'skipped');
       return;
     }
@@ -140,6 +141,7 @@ class CprLookupAction extends AabenFormsActionBase {
         'demo' => TRUE,
       ];
       $this->setTokenValue($this->configuration['result_token'], $demoPerson);
+      $this->setResultStatus('found');
       $this->log('CPR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
       $this->recordStep('CPR Registry Lookup', 'Demo: CPR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
       return;
@@ -168,6 +170,7 @@ class CprLookupAction extends AabenFormsActionBase {
           'cpr' => substr($cpr, 0, 6) . 'XXXX',
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
+        $this->setResultStatus('not_found');
         $this->recordStep('CPR Registry Lookup', 'No person found in the national CPR registry (SF1520)', 'failed');
         return;
       }
@@ -177,6 +180,7 @@ class CprLookupAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], $personData);
+      $this->setResultStatus('found');
       $this->recordStep('CPR Registry Lookup', 'Personal data retrieved from the national CPR registry (SF1520)');
 
     }
@@ -185,7 +189,26 @@ class CprLookupAction extends AabenFormsActionBase {
       // cURL/SSL/Serviceplatformen error to the citizen.
       $this->log('CPR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('error');
       $this->recordStep('CPR Registry Lookup', 'CPR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
+    }
+  }
+
+  /**
+   * Writes an explicit scalar status companion token for downstream gating.
+   *
+   * The result_token holds the person array (or NULL); ECA conditions and the
+   * audit action read this `<result_token>_status` scalar (`found`,
+   * `not_found`, `skipped` or `error`) because comparing an array or NULL
+   * token is unreliable.
+   *
+   * @param string $status
+   *   One of 'found', 'not_found', 'skipped' or 'error'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
@@ -126,6 +126,7 @@ class CvrLookupAction extends AabenFormsActionBase {
     if (empty($cvr)) {
       $this->log('CVR lookup skipped: no CVR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('skipped');
       $this->recordStep('CVR Registry Lookup', 'Skipped - no CVR available to look up', 'skipped');
       return;
     }
@@ -140,6 +141,7 @@ class CvrLookupAction extends AabenFormsActionBase {
         'demo' => TRUE,
       ];
       $this->setTokenValue($this->configuration['result_token'], $demoCompany);
+      $this->setResultStatus('found');
       $this->log('CVR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
       $this->recordStep('CVR Registry Lookup', 'Demo: CVR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
       return;
@@ -170,6 +172,7 @@ class CvrLookupAction extends AabenFormsActionBase {
           'cvr' => $cvr,
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
+        $this->setResultStatus('not_found');
         $this->recordStep('CVR Registry Lookup', 'No company found in the central business registry (SF1530)', 'failed');
         return;
       }
@@ -179,6 +182,7 @@ class CvrLookupAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], $companyData);
+      $this->setResultStatus('found');
       $this->recordStep('CVR Registry Lookup', 'Company data retrieved from the central business registry (SF1530)');
 
     }
@@ -187,7 +191,26 @@ class CvrLookupAction extends AabenFormsActionBase {
       // cURL/SSL/Serviceplatformen error to the citizen.
       $this->log('CVR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('error');
       $this->recordStep('CVR Registry Lookup', 'CVR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
+    }
+  }
+
+  /**
+   * Writes an explicit scalar status companion token for downstream gating.
+   *
+   * The result_token holds the company array (or NULL); ECA conditions and the
+   * audit action read this `<result_token>_status` scalar (`found`,
+   * `not_found`, `skipped` or `error`) because comparing an array or NULL
+   * token is unreliable.
+   *
+   * @param string $status
+   *   One of 'found', 'not_found', 'skipped' or 'error'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -68,12 +68,32 @@ class MitIdValidateAction extends AabenFormsActionBase {
     if ($this->demoModeAllowed()) {
       $this->log('MitID validation: ' . $context . ' - demo mode (allow_mitid_demo_mode on)', [], 'info');
       $this->setTokenValue($this->configuration['result_token'], TRUE);
+      $this->setResultStatus('verified');
       $this->recordStep('MitID Identity Validation', 'Demo mode: identity was NOT verified (no MitID session)', 'completed');
       return;
     }
     $this->log('MitID validation failed: ' . $context . ' (demo mode off)', [], 'warning');
     $this->setTokenValue($this->configuration['result_token'], FALSE);
+    $this->setResultStatus('failed');
     $this->recordStep('MitID Identity Validation', 'No valid MitID session - identity could not be verified', 'failed');
+  }
+
+  /**
+   * Writes an explicit scalar status companion token for downstream gating.
+   *
+   * The boolean result_token is kept for backward compatibility, but ECA
+   * conditions and the audit action read this `<result_token>_status` scalar
+   * (`verified` or `failed`) because comparing a rendered boolean token is
+   * unreliable.
+   *
+   * @param string $status
+   *   Either 'verified' or 'failed'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
+    }
   }
 
   /**
@@ -155,6 +175,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
           'workflow_id' => $workflowId,
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], FALSE);
+        $this->setResultStatus('failed');
         $this->recordStep('MitID Identity Validation', 'Session expired - re-authentication required', 'failed');
         return;
       }
@@ -165,6 +186,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], TRUE);
+      $this->setResultStatus('verified');
       $this->setTokenValue($this->configuration['session_data_token'], $sessionData);
       $this->recordStep('MitID Identity Validation', 'Citizen identity verified via NemID/MitID national eID');
 
@@ -172,6 +194,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
     catch (\Exception $e) {
       $this->handleError($e, 'MitID Identity Validation');
       $this->setTokenValue($this->configuration['result_token'], FALSE);
+      $this->setResultStatus('failed');
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -338,6 +338,94 @@ class AuditLogActionTest extends UnitTestCase {
   }
 
   /**
+   * A status token resolving to a failed outcome is logged as failure.
+   *
+   * @covers ::execute
+   * @covers ::resolveStatus
+   * @covers ::normalizeStatus
+   */
+  public function testStatusTokenReflectsFailure(): void {
+    // A prior CPR lookup that found nothing.
+    $this->tokenStorage['citizen_data_status'] = 'not_found';
+
+    $reflectionClass = new \ReflectionClass($this->action);
+    $configProperty = $reflectionClass->getProperty('configuration');
+    $configProperty->setAccessible(TRUE);
+    $config = $configProperty->getValue($this->action);
+    $config['status_token'] = 'citizen_data_status';
+    $configProperty->setValue($this->action, $config);
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        'failure',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
+   * A status token resolving to a verified outcome is logged as success.
+   *
+   * @covers ::execute
+   * @covers ::resolveStatus
+   * @covers ::normalizeStatus
+   */
+  public function testStatusTokenReflectsSuccess(): void {
+    $this->tokenStorage['citizen_mitid_valid_status'] = 'verified';
+
+    $reflectionClass = new \ReflectionClass($this->action);
+    $configProperty = $reflectionClass->getProperty('configuration');
+    $configProperty->setAccessible(TRUE);
+    $config = $configProperty->getValue($this->action);
+    $config['status_token'] = 'citizen_mitid_valid_status';
+    $configProperty->setValue($this->action, $config);
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        'success',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
+   * The fixed status is used (and normalised) when no status token is set.
+   *
+   * @covers ::execute
+   * @covers ::resolveStatus
+   */
+  public function testFixedStatusUsedWhenNoToken(): void {
+    $reflectionClass = new \ReflectionClass($this->action);
+    $configProperty = $reflectionClass->getProperty('configuration');
+    $configProperty->setAccessible(TRUE);
+    $config = $configProperty->getValue($this->action);
+    $config['status'] = 'denied';
+    $configProperty->setValue($this->action, $config);
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        'denied',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
    * Tests default configuration.
    *
    * @covers ::defaultConfiguration
@@ -356,6 +444,12 @@ class AuditLogActionTest extends UnitTestCase {
 
     $this->assertArrayHasKey('additional_data_token', $defaults);
     $this->assertEquals('', $defaults['additional_data_token']);
+
+    $this->assertArrayHasKey('status', $defaults);
+    $this->assertEquals('success', $defaults['status']);
+
+    $this->assertArrayHasKey('status_token', $defaults);
+    $this->assertEquals('', $defaults['status_token']);
   }
 
 }


### PR DESCRIPTION
AuditLogAction wrote status 'success' as a literal regardless of the preceding step, so the GDPR audit trail asserted things that did not happen: CPR resolved on a skipped lookup, parents authenticated on an unverified MitID session.

Changes:
- AuditLogAction gains an optional `status_token` plus a fixed `status` fallback. The status is derived from a prior step result via a normaliser: found/verified/match/completed -> success; denied -> denied; skipped -> skipped; not_found/failed/error -> failure. Default with no token stays 'success'.
- MitIdValidateAction, CprLookupAction and CvrLookupAction now emit a deterministic companion scalar token `<result_token>_status` ('verified'/'failed', 'found'/'not_found'/'skipped'/'error'). The boolean/array result tokens are unchanged; the scalar exists because comparing a rendered boolean or an array token is unreliable. These same tokens are what the #96 gateways will read.
- The claim audit nodes across the citizen, building/parking permit, marriage, parent (single and dual) and association/company flows now pass the matching status token.

Verified end to end: an anonymous citizen_service submission with no MitID session now logs the application-received row as 'skipped' (the CPR lookup was skipped) where it previously logged 'success'. 36 unit tests green; config imports clean.

Stacked on #104 (shares the CvrLookupAction file). Review/merge #104 first. From the data-flow analysis (docs/DATA-FLOW.md). Closes #97.