### PR TITLE
Gate ECA flows so a failed MitID check stops the flow (#96, part of #102)

### DIFF
--- a/config/sync/eca.eca.address_change_flow.yml
+++ b/config/sync/eca.eca.address_change_flow.yml
@@ -20,11 +20,43 @@ events:
       type: 'webform_submission address_change'
     successors:
       -
-        id: cpr_lookup
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_address_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[address_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_address_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[address_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate MitID session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_address_change
+      result_token: address_mitid_valid
+      session_data_token: address_session
+    successors:
+      -
+        id: cpr_lookup
+        condition: gate_address_mitid_ok
+      -
+        id: deny_address
+        condition: gate_address_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -59,4 +91,12 @@ actions:
       body_template: '<p>Vi har registreret din adresseændring. Den nye adresse er gældende fra den angivne dato.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_address:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: address_change_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Adresseaendringen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.association_booking_flow.yml
+++ b/config/sync/eca.eca.association_booking_flow.yml
@@ -22,7 +22,25 @@ events:
       -
         id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_association_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[association_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_association_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[association_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -35,7 +53,10 @@ actions:
     successors:
       -
         id: cvr_lookup
-        condition: ''
+        condition: gate_association_mitid_ok
+      -
+        id: deny_association
+        condition: gate_association_mitid_deny
   cvr_lookup:
     label: 'CVR registry lookup'
     plugin: aabenforms_cvr_lookup
@@ -91,4 +112,12 @@ actions:
       event_type: association_booking_complete
       additional_data_token: '[webform_submission:values:association_name:raw]'
       message_template: 'Association request decisioned (stub)'
+    successors: {  }
+  deny_association:
+    label: 'Deny: MitID Erhverv not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: association_booking_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Bookingen blev ikke behandlet, fordi foreningens MitID Erhverv-identitet ikke kunne bekraeftes. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -23,11 +23,43 @@ events:
       type: 'webform_submission building_permit'
     successors:
       -
-        id: cpr_lookup
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_building_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[building_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_building_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[building_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate MitID session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_building_permit
+      result_token: building_mitid_valid
+      session_data_token: building_session
+    successors:
+      -
+        id: cpr_lookup
+        condition: gate_building_mitid_ok
+      -
+        id: deny_building
+        condition: gate_building_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -62,4 +94,12 @@ actions:
       body_template: '<p>Vi har modtaget din ansøgning om byggetilladelse. En sagsbehandler tager kontakt.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_building:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: building_permit_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Ansoegningen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.citizen_service_application_flow.yml
+++ b/config/sync/eca.eca.citizen_service_application_flow.yml
@@ -22,7 +22,25 @@ events:
       -
         id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_citizen_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[citizen_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_citizen_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[citizen_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -35,7 +53,10 @@ actions:
     successors:
       -
         id: cpr_lookup
-        condition: ''
+        condition: gate_citizen_mitid_ok
+      -
+        id: deny_citizen
+        condition: gate_citizen_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -81,4 +102,12 @@ actions:
       body_template: '<p>Der er truffet afgørelse på din ansøgning. Se bilag i Digital Post.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_citizen:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: citizen_service_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Ansoegningen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.med_election_nomination_flow.yml
+++ b/config/sync/eca.eca.med_election_nomination_flow.yml
@@ -22,7 +22,25 @@ events:
       -
         id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_nominator_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[nominator_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_nominator_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[nominator_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -35,7 +53,10 @@ actions:
     successors:
       -
         id: cpr_lookup
-        condition: ''
+        condition: gate_nominator_mitid_ok
+      -
+        id: deny_nomination
+        condition: gate_nominator_mitid_deny
   cpr_lookup:
     label: 'Resolve nominator via CPR'
     plugin: aabenforms_cpr_lookup
@@ -54,4 +75,12 @@ actions:
       event_type: med_nomination_recorded
       additional_data_token: '[webform_submission:values:nominee_name:raw]'
       message_template: 'MED election nomination recorded'
+    successors: {  }
+  deny_nomination:
+    label: 'Deny: nominator MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: med_nomination_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Indstillingen blev ikke registreret, fordi din identitet ikke kunne bekraeftes med MitID. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.parent_dual_approval_working.yml
+++ b/config/sync/eca.eca.parent_dual_approval_working.yml
@@ -25,7 +25,43 @@ events:
       -
         id: parent2_mitid
         condition: ''
-conditions: {  }
+conditions:
+  gate_parent1_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[parent1_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parent1_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[parent1_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parent2_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[parent2_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parent2_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[parent2_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   parent1_mitid:
@@ -38,7 +74,10 @@ actions:
     successors:
       -
         id: parent1_cpr
-        condition: ''
+        condition: gate_parent1_mitid_ok
+      -
+        id: deny_parent1
+        condition: gate_parent1_mitid_deny
   parent1_cpr:
     label: 'Parent 1: CPR Lookup'
     plugin: aabenforms_cpr_lookup
@@ -82,7 +121,10 @@ actions:
     successors:
       -
         id: parent2_cpr
-        condition: ''
+        condition: gate_parent2_mitid_ok
+      -
+        id: deny_parent2
+        condition: gate_parent2_mitid_deny
   parent2_cpr:
     label: 'Parent 2: CPR Lookup'
     plugin: aabenforms_cpr_lookup
@@ -123,4 +165,20 @@ actions:
       event_type: caseworker_review
       additional_data_token: 'Both parents approved'
       message_template: 'Assigned to case worker for review'
+    successors: {  }
+  deny_parent1:
+    label: 'Deny: Parent 1 MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: parent1_denied
+      step_label: 'Foraelder 1: identitet ikke bekraeftet'
+      message: 'Foraelder 1s godkendelse blev ikke registreret, fordi identiteten ikke kunne bekraeftes med MitID.'
+    successors: {  }
+  deny_parent2:
+    label: 'Deny: Parent 2 MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: parent2_denied
+      step_label: 'Foraelder 2: identitet ikke bekraeftet'
+      message: 'Foraelder 2s godkendelse blev ikke registreret, fordi identiteten ikke kunne bekraeftes med MitID.'
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/DenyAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/DenyAction.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Deny and stop the flow.
+ *
+ * A terminal node placed on the failure branch of an identity or consent
+ * gate. ECA has no flow-abort primitive, so a denied flow is modelled by
+ * routing to this action and giving it no successors: nothing downstream
+ * (CPR lookup, Digital Post, payment, approval) runs. It records a
+ * citizen-facing failed step so the synchronous response reads as failed,
+ * and writes a 'denied' audit row.
+ */
+#[Action(
+  id: 'aabenforms_workflow_deny',
+  label: new TranslatableMarkup('Deny and stop flow'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Stops the flow on a failed identity or consent gate and records a denied outcome.'),
+  version_introduced: '2.1.0',
+)]
+class DenyAction extends AabenFormsActionBase {
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'event_type' => 'workflow_denied',
+      'step_label' => 'Adgang afvist',
+      'message' => 'Sagen blev ikke behandlet, fordi identiteten ikke kunne bekraeftes.',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['event_type'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Audit event type'),
+      '#description' => $this->t('Audit log action recorded for the denial, for example citizen_service_denied.'),
+      '#default_value' => $this->configuration['event_type'],
+      '#required' => TRUE,
+    ];
+
+    $form['step_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Step label'),
+      '#description' => $this->t('Short label shown to the citizen in the execution steps.'),
+      '#default_value' => $this->configuration['step_label'],
+      '#required' => TRUE,
+    ];
+
+    $form['message'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Citizen message'),
+      '#description' => $this->t('Citizen-facing reason for the denial. Keep it free of technical detail.'),
+      '#default_value' => $this->configuration['message'],
+      '#required' => TRUE,
+      '#rows' => 2,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['event_type'] = $form_state->getValue('event_type');
+    $this->configuration['step_label'] = $form_state->getValue('step_label');
+    $this->configuration['message'] = $form_state->getValue('message');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $eventType = (string) ($this->configuration['event_type'] ?? 'workflow_denied');
+    $label = (string) ($this->configuration['step_label'] ?? 'Adgang afvist');
+    $message = (string) ($this->configuration['message'] ?? 'Sagen blev ikke behandlet.');
+
+    $this->log('Flow denied at gate: {type}', ['type' => $eventType], 'warning');
+    $this->recordStep($label, $message, 'failed');
+
+    try {
+      $this->auditLogger->log(
+        $eventType,
+        'system',
+        $message,
+        'denied',
+        ['action_id' => $this->getPluginId()]
+      );
+    }
+    catch (\Exception $e) {
+      $this->handleError($e, 'Recording denial audit entry');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/DenyActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/DenyActionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\DenyAction;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the DenyAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\DenyAction
+ * @group aabenforms_workflows
+ */
+class DenyActionTest extends UnitTestCase {
+
+  /**
+   * The DenyAction plugin.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\DenyAction
+   */
+  protected DenyAction $action;
+
+  /**
+   * Mock audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $auditLogger;
+
+  /**
+   * Mock execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $collector;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+
+    $this->auditLogger = $this->getMockBuilder(AuditLogger::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['log'])
+      ->getMock();
+    $this->collector = $this->createMock(WorkflowExecutionCollector::class);
+
+    $configuration = [
+      'event_type' => 'citizen_service_denied',
+      'step_label' => 'Identitet ikke bekraeftet',
+      'message' => 'Sagen blev ikke behandlet.',
+    ];
+
+    $this->action = new DenyAction(
+      $configuration,
+      'aabenforms_workflow_deny',
+      [],
+      $entityTypeManager,
+      $tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger
+    );
+    $this->action->setExecutionCollector($this->collector);
+
+    $reflectionClass = new \ReflectionClass($this->action);
+    $auditLoggerProperty = $reflectionClass->getProperty('auditLogger');
+    $auditLoggerProperty->setAccessible(TRUE);
+    $auditLoggerProperty->setValue($this->action, $this->auditLogger);
+  }
+
+  /**
+   * Records a failed step and writes a denied audit row.
+   *
+   * @covers ::execute
+   */
+  public function testDenyRecordsFailedStepAndDeniedAudit(): void {
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with(
+        'aabenforms_workflow_deny',
+        'Identitet ikke bekraeftet',
+        'Sagen blev ikke behandlet.',
+        'failed'
+      );
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        'citizen_service_denied',
+        'system',
+        'Sagen blev ikke behandlet.',
+        'denied',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
+   * Tests default configuration.
+   *
+   * @covers ::defaultConfiguration
+   */
+  public function testDefaultConfiguration(): void {
+    $defaults = $this->action->defaultConfiguration();
+    $this->assertArrayHasKey('event_type', $defaults);
+    $this->assertArrayHasKey('step_label', $defaults);
+    $this->assertArrayHasKey('message', $defaults);
+  }
+
+}


### PR DESCRIPTION
The keystone fix from the data-flow analysis. Flows wrote identity result tokens but no condition ever read them, so a failed or absent MitID session did not stop the flow: the CPR/CVR lookup, mock payment and Digital Post still ran, and an authenticated audit row was written.

## Approach
ECA has no flow-abort primitive (confirmed: returning early stops only the action, exceptions are caught). The only way to stop a chain is a conditional branch. Each identity step now branches on its companion status token (`<result_token>_status`, introduced in #105) via two complementary `eca_scalar` conditions, and the failure branch routes to a new terminal `aabenforms_workflow_deny` action that records a citizen-facing failed step plus a denied audit row and has no successors, so nothing downstream runs.

## A correctness finding along the way
The flows that appeared to use `eca_scalar` were themselves dead: they used `left_value`/`right_value` and `operator: '=='`, but the plugin reads `left`/`right` and equality is `operator: equal` (inequality is `negate: true`). None of the old conditions could ever be true. The new gates use the correct contract.

## Gated in this PR
- citizen_service_application, association_booking (also protects the payment step), med_election_nomination, parent_dual_approval_working
- address_change and building_permit gain the MitID step their BPMN templates already show, raising the flows to the templates (part of #102)
- New `aabenforms_workflow_deny` plugin + unit test

## Verified end to end (DDEV)
- Deny path: anonymous submit with no MitID session stops at 'Identitet ikke bekraeftet' (failed); no CPR/CVR lookup, no payment, no Digital Post, no false-success audit.
- Pass path (MitID demo on): the flow runs through CPR/CVR, audit and Digital Post.
- 164 unit tests green; phpcs clean; `config:status` clean after export.

## Deferred to #100
parent1_approval and parent2_approval need their broken update/pending trigger fixed first, and med_election_voting needs its missing ballot webform; those flows are gated there, completing #96. parent_request_form is access-denied for anonymous API submit, so parent_dual_approval_working was verified structurally (identical pattern, clean import, no ECA errors).

Stacked on #105 (which is on #104). Merge order: #104, #105, then this. Refs #96, #102.