### PR TITLE
Fix dead MED voting flow and make FOI routing real (#100)

### DIFF
--- a/config/sync/eca.eca.foi_request_flow.yml
+++ b/config/sync/eca.eca.foi_request_flow.yml
@@ -33,5 +33,19 @@ actions:
     configuration:
       event_type: foi_request_submitted
       additional_data_token: ''
-      message_template: 'FOI request received; case worker will process within 7 working days.'
+      message_template: 'FOI request received; routing to case worker.'
+    successors:
+      -
+        id: route_request
+        condition: ''
+  route_request:
+    label: 'Route FOI request to case worker'
+    plugin: aabenforms_foi_route
+    configuration:
+      caseworker_email: aktindsigt@example.dk
+      response_working_days: 7
+      requester_name_token: '[webform_submission:values:requester_name:raw]'
+      requester_email_token: '[webform_submission:values:requester_email:raw]'
+      request_text_token: '[webform_submission:values:request_text:raw]'
+      reference_token: '[webform_submission:sid]'
     successors: {  }

--- a/config/sync/eca.eca.med_election_voting_flow.yml
+++ b/config/sync/eca.eca.med_election_voting_flow.yml
@@ -31,7 +31,25 @@ events:
       -
         id: tabulate_due
         condition: ''
-conditions: {  }
+conditions:
+  gate_voter_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[voter_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_voter_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[voter_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   validate_voter_mitid:
@@ -44,7 +62,10 @@ actions:
     successors:
       -
         id: record_ballot
-        condition: ''
+        condition: gate_voter_mitid_ok
+      -
+        id: deny_ballot
+        condition: gate_voter_mitid_deny
   record_ballot:
     label: 'Record voter ballot'
     plugin: aabenforms_record_ballot
@@ -58,4 +79,12 @@ actions:
     label: 'Cron: open/close due elections'
     plugin: aabenforms_tabulate_election
     configuration: {  }
+    successors: {  }
+  deny_ballot:
+    label: 'Deny: voter MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: med_ballot_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Din stemme blev ikke registreret, fordi din identitet ikke kunne bekraeftes med MitID. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/webform.webform.med_election_ballot.yml
+++ b/config/sync/webform.webform.med_election_ballot.yml
@@ -1,0 +1,218 @@
+uuid: 7a6b8c9d-0e1f-2345-ef01-678901234599
+langcode: en
+status: open
+dependencies:
+  module:
+    - aabenforms_webform
+    - aabenforms_workflows
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: med_election_ballot
+title: 'MED Election Ballot'
+description: 'Voting form for a MED or workplace health-and-safety committee election. One ballot per eligible voter; identity is verified with MitID before the ballot is recorded.'
+categories: {  }
+elements: |
+  election_id:
+    '#type': textfield
+    '#title': 'Election ID'
+    '#required': true
+    '#description': 'Identifier of the election being voted in'
+  choice_index:
+    '#type': textfield
+    '#title': 'Candidate number'
+    '#required': true
+    '#description': 'The number of the candidate you are voting for, as shown on the ballot'
+  voter_cpr:
+    '#type': cpr_field
+    '#title': 'Your CPR number'
+    '#required': true
+    '#description': 'Used to confirm eligibility and prevent double voting. Auto-filled from MitID session in production.'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Your ballot has been recorded. Thank you for voting.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -83,6 +83,40 @@ function aabenforms_workflows_mail(string $key, array &$message, array $params):
         '@sid' => $params['submission_id'],
       ]);
       break;
+
+    case 'foi_acknowledgement':
+      $message['subject'] = t('Modtaget: din anmodning om aktindsigt (@ref)', [
+        '@ref' => $params['reference'],
+      ]);
+      $message['body'][] = t('Kaere @name,', ['@name' => $params['requester_name']]);
+      $message['body'][] = '';
+      $message['body'][] = t('Vi har modtaget din anmodning om aktindsigt. Din sag har referencenummer @ref.', [
+        '@ref' => $params['reference'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Kommunen skal efter offentlighedsloven besvare din anmodning hurtigst muligt og som udgangspunkt inden 7 arbejdsdage. Forventet svardato er @due.', [
+        '@due' => $params['due_date'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Du modtager svar pa denne e-mailadresse.');
+      break;
+
+    case 'foi_caseworker_notification':
+      $message['subject'] = t('Ny anmodning om aktindsigt (@ref)', [
+        '@ref' => $params['reference'],
+      ]);
+      $message['body'][] = t('En ny anmodning om aktindsigt er modtaget og skal behandles.');
+      $message['body'][] = '';
+      $message['body'][] = t('Reference: @ref', ['@ref' => $params['reference']]);
+      $message['body'][] = t('Frist: @due (7 arbejdsdage)', ['@due' => $params['due_date']]);
+      $message['body'][] = t('Anmoder: @name (@email)', [
+        '@name' => $params['requester_name'],
+        '@email' => $params['requester_email'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Anmodning:');
+      $message['body'][] = $params['request_text'];
+      break;
   }
 }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FoiRouteAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FoiRouteAction.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Route a freedom-of-information request.
+ *
+ * Replaces the previous log-and-forget FOI flow. It assigns a case
+ * reference, computes the statutory response due date (7 working days),
+ * emails an acknowledgement to the requester and a routing notification
+ * to the case worker inbox, and records an audit entry. This is what
+ * backs the confirmation message's promise of a response within 7
+ * working days.
+ */
+#[Action(
+  id: 'aabenforms_foi_route',
+  label: new TranslatableMarkup('Route FOI request'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Assigns a reference and due date, acknowledges the requester, and routes the FOI request to a case worker.'),
+  version_introduced: '2.1.0',
+)]
+class FoiRouteAction extends AabenFormsActionBase {
+
+  /**
+   * The mail manager.
+   *
+   * @var \Drupal\Core\Mail\MailManagerInterface
+   */
+  protected MailManagerInterface $mailManager;
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected TimeInterface $timeService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->mailManager = $container->get('plugin.manager.mail');
+    $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    $instance->timeService = $container->get('datetime.time');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'caseworker_email' => 'aktindsigt@example.dk',
+      'response_working_days' => 7,
+      'requester_name_token' => '[webform_submission:values:requester_name:raw]',
+      'requester_email_token' => '[webform_submission:values:requester_email:raw]',
+      'request_text_token' => '[webform_submission:values:request_text:raw]',
+      'reference_token' => '[webform_submission:sid]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['caseworker_email'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case worker inbox'),
+      '#description' => $this->t('Email address the FOI request is routed to.'),
+      '#default_value' => $this->configuration['caseworker_email'],
+      '#required' => TRUE,
+    ];
+    $form['response_working_days'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Response deadline (working days)'),
+      '#default_value' => $this->configuration['response_working_days'],
+      '#min' => 1,
+      '#required' => TRUE,
+    ];
+    $form['requester_name_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Requester name token'),
+      '#default_value' => $this->configuration['requester_name_token'],
+    ];
+    $form['requester_email_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Requester email token'),
+      '#default_value' => $this->configuration['requester_email_token'],
+      '#required' => TRUE,
+    ];
+    $form['request_text_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Request text token'),
+      '#default_value' => $this->configuration['request_text_token'],
+    ];
+    $form['reference_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Reference token'),
+      '#description' => $this->t('Token used to build the case reference, for example the submission id.'),
+      '#default_value' => $this->configuration['reference_token'],
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $keys = [
+      'caseworker_email',
+      'response_working_days',
+      'requester_name_token',
+      'requester_email_token',
+      'request_text_token',
+      'reference_token',
+    ];
+    foreach ($keys as $key) {
+      $this->configuration[$key] = $form_state->getValue($key);
+    }
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $requesterEmail = $this->getTokenValue((string) $this->configuration['requester_email_token'], '');
+    $requesterName = $this->getTokenValue((string) $this->configuration['requester_name_token'], '');
+    $requestText = $this->getTokenValue((string) $this->configuration['request_text_token'], '');
+    $sid = $this->getTokenValue((string) $this->configuration['reference_token'], '');
+    $reference = 'FOI-' . ($sid !== '' ? $sid : 'NEW');
+    $caseworkerEmail = (string) $this->configuration['caseworker_email'];
+    $days = (int) ($this->configuration['response_working_days'] ?? 7);
+
+    $dueTimestamp = $this->addWorkingDays($this->timeService->getRequestTime(), $days);
+    $dueDate = date('Y-m-d', $dueTimestamp);
+
+    $params = [
+      'reference' => $reference,
+      'requester_name' => $requesterName !== '' ? $requesterName : $this->t('anmoder'),
+      'requester_email' => $requesterEmail,
+      'request_text' => $requestText,
+      'due_date' => $dueDate,
+    ];
+    $langcode = LanguageInterface::LANGCODE_DEFAULT;
+
+    // Route to the case worker inbox.
+    $this->mailManager->mail('aabenforms_workflows', 'foi_caseworker_notification', $caseworkerEmail, $langcode, $params);
+    $this->recordStep('FOI routed to case worker', sprintf('Sag %s sendt til sagsbehandling. Frist: %s.', $reference, $dueDate), 'completed');
+
+    // Acknowledge the requester, if an address was given.
+    if ($requesterEmail !== '') {
+      $this->mailManager->mail('aabenforms_workflows', 'foi_acknowledgement', $requesterEmail, $langcode, $params);
+      $this->recordStep('FOI acknowledgement sent', sprintf('Kvittering sendt til anmoder med referencenummer %s.', $reference), 'completed');
+    }
+    else {
+      $this->recordStep('FOI acknowledgement skipped', 'Ingen e-mailadresse angivet til kvittering.', 'skipped');
+    }
+
+    try {
+      $this->auditLogger->log(
+        'foi_request_routed',
+        'system',
+        sprintf('FOI %s routed; due %s', $reference, $dueDate),
+        'success',
+        ['reference' => $reference, 'due_date' => $dueDate]
+      );
+    }
+    catch (\Exception $e) {
+      $this->handleError($e, 'Recording FOI routing audit entry');
+    }
+  }
+
+  /**
+   * Adds a number of working days to a timestamp, skipping weekends.
+   *
+   * @param int $timestamp
+   *   The starting Unix timestamp.
+   * @param int $days
+   *   The number of working days to add.
+   *
+   * @return int
+   *   The resulting Unix timestamp.
+   */
+  protected function addWorkingDays(int $timestamp, int $days): int {
+    $result = $timestamp;
+    $added = 0;
+    while ($added < $days) {
+      $result += 86400;
+      $dayOfWeek = (int) date('N', $result);
+      if ($dayOfWeek < 6) {
+        $added++;
+      }
+    }
+    return $result;
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/FlowWebformReferencesTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/FlowWebformReferencesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards that every ECA content-entity event references an existing webform.
+ *
+ * The MED voting flow listened on a med_election_ballot webform that did not
+ * exist, so the flow was dead. This test asserts the invariant across all
+ * exported ECA flows so a dangling reference fails CI instead of shipping.
+ *
+ * @group aabenforms_workflows
+ */
+class FlowWebformReferencesTest extends UnitTestCase {
+
+  /**
+   * Every webform_submission event type must have a matching webform config.
+   */
+  public function testEveryFlowEventReferencesAnExistingWebform(): void {
+    $syncDir = $this->locateConfigSync();
+    $this->assertNotNull($syncDir, 'Could not locate the config/sync directory.');
+
+    $missing = [];
+    foreach (glob($syncDir . '/eca.eca.*.yml') as $flowFile) {
+      $flow = Yaml::parseFile($flowFile);
+      foreach (($flow['events'] ?? []) as $event) {
+        $plugin = $event['plugin'] ?? '';
+        if (!str_starts_with($plugin, 'content_entity:')) {
+          continue;
+        }
+        $type = $event['configuration']['type'] ?? '';
+        // The type is "webform_submission <webform_id>".
+        if (!preg_match('/^webform_submission\s+([a-z0-9_]+)$/', $type, $m)) {
+          continue;
+        }
+        $webformId = $m[1];
+        if (!is_file($syncDir . '/webform.webform.' . $webformId . '.yml')) {
+          $missing[] = sprintf('%s -> webform "%s"', basename($flowFile), $webformId);
+        }
+      }
+    }
+
+    $this->assertSame([], $missing, "ECA flows reference webforms that do not exist:\n" . implode("\n", $missing));
+  }
+
+  /**
+   * Walks up from this file to find the config/sync directory.
+   *
+   * @return string|null
+   *   The absolute path to config/sync, or NULL if not found.
+   */
+  protected function locateConfigSync(): ?string {
+    $dir = __DIR__;
+    for ($i = 0; $i < 10; $i++) {
+      $candidate = $dir . '/config/sync';
+      if (is_dir($candidate)) {
+        return $candidate;
+      }
+      $parent = dirname($dir);
+      if ($parent === $dir) {
+        break;
+      }
+      $dir = $parent;
+    }
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
Two of the three dead/broken flows from the data-flow analysis, plus a guard so this class of bug fails CI.

## MED voting
The voting flow listened on a `med_election_ballot` webform that did not exist, so it never fired. This ships the ballot webform (election id, candidate number, voter CPR) and gates the flow on the voter's MitID status per #96. Verified: an anonymous ballot is denied; with a verified session the ballot recorder runs.

## FOI request
The flow logged and forgot, while the confirmation promised a response within 7 working days. It now:
- assigns a case reference (FOI-<sid>)
- computes the statutory due date (7 working days, weekends skipped)
- emails an acknowledgement to the requester and a routing notification to the case worker inbox (new `aabenforms_foi_route` action + two hook_mail templates)
- records the routing and due date in the audit log

Verified end to end on DDEV: both emails delivered to Mailpit (acknowledgement to the requester, routing to aktindsigt@), due date computed as 2026-06-16 (7 working days from Sat 6 Jun).

## CI guard
New unit test asserts every ECA `content_entity` event `type:` references an existing webform - this would have caught the missing ballot webform. 165 unit tests green; phpcs clean; config exported clean.

## Not in this PR
The third #100 item (parent1_approval / parent2_approval never fire) is left for a focused follow-up: the real per-parent approval runs through dedicated controller routes (/parent-approval/.../mitid), and the correct fix is to dispatch a one-shot custom ECA event from the approval form rather than re-trigger on every entity update. Done naively it would re-process an already-approved parent and write a denial over a prior approval. That refactor (which also completes #96 for the parent-single flows) is tracked separately.

Stacked on #106. Refs #100, #96.