### PR TITLE
Bind internal and HR flows to the authenticated employee (#101)

### DIFF
--- a/config/sync/aabenforms_workflows.org_chart.yml
+++ b/config/sync/aabenforms_workflows.org_chart.yml
@@ -1,0 +1,12 @@
+default_tier_limit_cents: 200000
+employees:
+  E1001:
+    name: Administrator
+    account_name: admin
+    manager_email: leder@example.dk
+    tier_limit_cents: 500000
+  E1002:
+    name: 'Medarbejder Demo'
+    account_name: medarbejder
+    manager_email: leder@example.dk
+    tier_limit_cents: 300000

--- a/config/sync/eca.eca.hr_onboarding_flow.yml
+++ b/config/sync/eca.eca.hr_onboarding_flow.yml
@@ -20,11 +20,42 @@ events:
       type: 'webform_submission hr_onboarding'
     successors:
       -
-        id: log_received
+        id: resolve_employee
         condition: ''
-conditions: {  }
+conditions:
+  gate_hr_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[hr_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_hr_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[hr_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  resolve_employee:
+    label: 'Bind HR submitter identity from login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[webform_submission:values:hr_submitter_email:raw]'
+      result_token: hr_employee_id
+    successors:
+      -
+        id: log_received
+        condition: gate_hr_employee_ok
+      -
+        id: deny_internal
+        condition: gate_hr_employee_deny
   log_received:
     label: 'Log: HR onboarding request received'
     plugin: aabenforms_audit_log
@@ -40,8 +71,8 @@ actions:
     label: 'Resolve manager email from org-chart'
     plugin: aabenforms_manager_lookup
     configuration:
-      employee_id_token: '[webform_submission:values:hr_submitter_email:raw]'
-      fallback_email_token: '[webform_submission:values:manager_email:raw]'
+      employee_id_token: '[hr_employee_id]'
+      fallback_email_token: ''
       result_token: hr_onboarding_manager_email
     successors:
       -
@@ -65,4 +96,12 @@ actions:
       event_type: hr_onboarding_it_notified
       additional_data_token: '[webform_submission:values:it_distribution_email:raw]'
       message_template: 'Stub. Production would email IT distribution on manager approval.'
+    successors: {  }
+  deny_internal:
+    label: 'Deny: HR submitter identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: hr_onboarding_denied
+      step_label: 'Adgang afvist'
+      message: 'Anmodningen blev ikke behandlet, fordi det ikke kunne bekraeftes, at du er logget ind som medarbejder.'
     successors: {  }

--- a/config/sync/eca.eca.mileage_expense_flow.yml
+++ b/config/sync/eca.eca.mileage_expense_flow.yml
@@ -20,11 +20,42 @@ events:
       type: 'webform_submission mileage_expense'
     successors:
       -
-        id: log_received
+        id: resolve_employee
         condition: ''
-conditions: {  }
+conditions:
+  gate_mileage_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[mileage_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mileage_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[mileage_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  resolve_employee:
+    label: 'Bind employee identity from login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[webform_submission:values:employee_id:raw]'
+      result_token: mileage_employee_id
+    successors:
+      -
+        id: log_received
+        condition: gate_mileage_employee_ok
+      -
+        id: deny_internal
+        condition: gate_mileage_employee_deny
   log_received:
     label: 'Log: expense claim received'
     plugin: aabenforms_audit_log
@@ -40,8 +71,8 @@ actions:
     label: 'Resolve manager email from org-chart'
     plugin: aabenforms_manager_lookup
     configuration:
-      employee_id_token: '[webform_submission:values:employee_id:raw]'
-      fallback_email_token: '[webform_submission:values:manager_email:raw]'
+      employee_id_token: '[mileage_employee_id]'
+      fallback_email_token: ''
       result_token: mileage_expense_manager_email
     successors:
       -
@@ -62,8 +93,16 @@ actions:
     label: 'Forward expense claim to payroll'
     plugin: aabenforms_payroll_post
     configuration:
-      employee_id_token: '[webform_submission:values:employee_id:raw]'
+      employee_id_token: '[mileage_employee_id]'
       amount_token: '[webform_submission:values:amount:raw]'
       claim_type: mileage_expense
       result_token: mileage_expense_payroll_result
+    successors: {  }
+  deny_internal:
+    label: 'Deny: employee identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: mileage_expense_denied
+      step_label: 'Adgang afvist'
+      message: 'Udlaegget blev ikke behandlet, fordi det ikke kunne bekraeftes, at du er logget ind som medarbejder.'
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -65,11 +65,13 @@ services:
     arguments:
       - '@logger.factory'
 
-  # Stub default for the org-chart lookup. A real LDAP/AD/HR-system
+  # Directory-backed org-chart lookup, sourced from the
+  # aabenforms_workflows.org_chart config. A real LDAP/AD/HR-system
   # integration replaces this via service decoration without touching
   # the action plugin.
   aabenforms_workflows.org_chart:
-    class: Drupal\aabenforms_workflows\Service\StubOrgChartService
+    class: Drupal\aabenforms_workflows\Service\ConfigOrgChartService
+    arguments: ['@config.factory']
 
   # MED voting service: window open/close, ballot recording (with
   # CPR-hash uniqueness), tabulation. Used by the cron-driven ECA flow

--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -124,3 +124,32 @@ aabenforms_workflows.settings:
     allow_cvr_demo_mode:
       type: boolean
       label: 'Force CVR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'
+
+# Directory used to resolve managers, policy limits, and the account-to-
+# employee binding for internal and HR flows.
+aabenforms_workflows.org_chart:
+  type: config_object
+  label: 'Org chart directory'
+  mapping:
+    default_tier_limit_cents:
+      type: integer
+      label: 'Default per-claim limit in cents'
+    employees:
+      type: sequence
+      label: 'Employees keyed by employee id'
+      sequence:
+        type: mapping
+        label: 'Employee'
+        mapping:
+          name:
+            type: label
+            label: 'Name'
+          account_name:
+            type: string
+            label: 'Drupal account name bound to this employee'
+          manager_email:
+            type: email
+            label: 'Manager email'
+          tier_limit_cents:
+            type: integer
+            label: 'Per-claim limit in cents'

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/PayrollPostAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/PayrollPostAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\aabenforms_workflows\Plugin\Action;
 
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
 use Drupal\aabenforms_workflows\Service\PayrollService;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Form\FormStateInterface;
@@ -39,11 +40,19 @@ class PayrollPostAction extends AabenFormsActionBase {
   protected PayrollService $payroll;
 
   /**
+   * The org-chart directory, used for the per-employee policy limit.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface
+   */
+  protected OrgChartServiceInterface $orgChart;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->payroll = $container->get('aabenforms_workflows.payroll');
+    $instance->orgChart = $container->get('aabenforms_workflows.org_chart');
     return $instance;
   }
 
@@ -111,6 +120,26 @@ class PayrollPostAction extends AabenFormsActionBase {
       $amount_raw = $this->getTokenValue((string) $this->configuration['amount_token'], '0');
       $amount_cents = (int) round(((float) str_replace(',', '.', $amount_raw)) * 100);
       $claim_type = (string) ($this->configuration['claim_type'] ?? 'unspecified');
+
+      // Enforce the per-employee policy limit before forwarding money.
+      $limit_cents = $this->orgChart->tierLimitCents($employee_id);
+      if ($limit_cents > 0 && $amount_cents > $limit_cents) {
+        $name = (string) $this->configuration['result_token'];
+        if ($name !== '') {
+          $this->setTokenValue($name, [
+            'status' => PayrollService::STATUS_FAILURE,
+            'transaction_id' => '',
+            'reason_code' => 'AMOUNT_EXCEEDS_POLICY',
+            'message' => 'Beloeb overstiger den tilladte graense for medarbejderen.',
+          ]);
+        }
+        $this->recordStep(
+          label: 'Payroll forwarding blocked',
+          description: sprintf('%s: beloebet (%.2f kr.) overstiger graensen (%.2f kr.) og blev ikke sendt til loen.', $claim_type, $amount_cents / 100, $limit_cents / 100),
+          status: 'failed',
+        );
+        return;
+      }
 
       $result = $this->payroll->forward($employee_id, $claim_type, $amount_cents, [
         'submission_id' => $this->getSubmission($entity)?->id(),

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ResolveEmployeeAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ResolveEmployeeAction.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Resolve and bind the employee identity.
+ *
+ * Internal and HR flows previously routed money and tasks on a
+ * self-asserted employee_id form field. This action derives the employee
+ * identifier from the authenticated account via the org-chart directory
+ * and writes it to a result token, plus a companion status token
+ * (verified | failed) so the flow can gate on it. Anonymous submissions,
+ * or accounts that map to no employee, resolve to failed.
+ */
+#[Action(
+  id: 'aabenforms_resolve_employee',
+  label: new TranslatableMarkup('Resolve employee identity'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Binds the submission to the authenticated employee via the org-chart directory.'),
+  version_introduced: '2.1.0',
+)]
+class ResolveEmployeeAction extends AabenFormsActionBase {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected AccountProxyInterface $account;
+
+  /**
+   * The org-chart directory.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface
+   */
+  protected OrgChartServiceInterface $orgChart;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->account = $container->get('current_user');
+    $instance->orgChart = $container->get('aabenforms_workflows.org_chart');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'submitted_employee_id_token' => '[webform_submission:values:employee_id:raw]',
+      'result_token' => 'employee_id',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['submitted_employee_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Submitted employee id token'),
+      '#description' => $this->t('Self-asserted employee id from the form. Used only to detect a mismatch; the authenticated identity is authoritative.'),
+      '#default_value' => $this->configuration['submitted_employee_id_token'],
+    ];
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Receives the resolved employee id. A companion <token>_status (verified/failed) is also set.'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['submitted_employee_id_token'] = $form_state->getValue('submitted_employee_id_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    if ($this->account->isAnonymous()) {
+      $this->setResult('', 'failed');
+      $this->recordStep('Employee identity', 'Afvist: interne anmodninger kraever, at medarbejderen er logget ind.', 'failed');
+      return;
+    }
+
+    $resolvedId = $this->orgChart->employeeIdForAccountName($this->account->getAccountName());
+    if ($resolvedId === '') {
+      $this->setResult('', 'failed');
+      $this->recordStep('Employee identity', 'Afvist: den loggede bruger er ikke knyttet til en medarbejder i organisationen.', 'failed');
+      return;
+    }
+
+    $submitted = $this->getTokenValue((string) $this->configuration['submitted_employee_id_token'], '');
+    $mismatch = $submitted !== '' && $submitted !== $resolvedId;
+
+    $this->setResult($resolvedId, 'verified');
+    $this->recordStep(
+      'Employee identity',
+      $mismatch
+        ? 'Medarbejderidentitet bekraeftet fra login. Det indtastede medarbejdernummer blev ignoreret, da det ikke matchede.'
+        : 'Medarbejderidentitet bekraeftet fra login.',
+      'completed'
+    );
+  }
+
+  /**
+   * Writes the resolved employee id and its companion status token.
+   *
+   * @param string $employeeId
+   *   The resolved employee identifier (may be empty on failure).
+   * @param string $status
+   *   Either 'verified' or 'failed'.
+   */
+  protected function setResult(string $employeeId, string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken, $employeeId);
+      $this->setTokenValue($resultToken . '_status', $status);
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/ConfigOrgChartService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ConfigOrgChartService.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Directory-backed org-chart, sourced from aabenforms_workflows.org_chart.
+ *
+ * Resolves the manager email, the per-claim policy limit, and the
+ * account-to-employee binding from config. Unlike the previous stub, it
+ * never echoes a self-asserted fallback: an unknown employee resolves to
+ * an empty manager email so a submitted "manager_email" field cannot route
+ * an approval.
+ */
+final class ConfigOrgChartService implements OrgChartServiceInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * Constructs a ConfigOrgChartService.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Returns the employee directory keyed by employee id.
+   *
+   * @return array<string, array<string, mixed>>
+   *   The employees map from config.
+   */
+  protected function employees(): array {
+    $employees = $this->configFactory->get('aabenforms_workflows.org_chart')->get('employees');
+    return is_array($employees) ? $employees : [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function findManagerEmail(string $employee_id, string $fallback = ''): string {
+    $employee = $this->employees()[$employee_id] ?? NULL;
+    if (is_array($employee) && !empty($employee['manager_email'])) {
+      return (string) $employee['manager_email'];
+    }
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tierLimitCents(string $employee_id): int {
+    $employee = $this->employees()[$employee_id] ?? NULL;
+    if (is_array($employee) && isset($employee['tier_limit_cents'])) {
+      return (int) $employee['tier_limit_cents'];
+    }
+    $default = $this->configFactory->get('aabenforms_workflows.org_chart')->get('default_tier_limit_cents');
+    return $default !== NULL ? (int) $default : 0;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function employeeIdForAccountName(string $account_name): string {
+    if ($account_name === '') {
+      return '';
+    }
+    foreach ($this->employees() as $employee_id => $employee) {
+      if (is_array($employee) && ($employee['account_name'] ?? '') === $account_name) {
+        return (string) $employee_id;
+      }
+    }
+    return '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/OrgChartServiceInterface.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/OrgChartServiceInterface.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Drupal\aabenforms_workflows\Service;
 
 /**
- * Resolves an employee's manager from their employee identifier.
+ * Resolves an employee's manager and policy data from their identifier.
  *
- * Two implementations ship: StubOrgChartService (default) returns the
- * fallback email it's given so existing webform-driven approval flows
- * keep working. A site that wires LDAP / Active Directory / a real HR
- * system can decorate aabenforms_workflows.org_chart and replace
- * findManagerEmail() with a real lookup.
+ * The default implementation is ConfigOrgChartService, a directory backed
+ * by aabenforms_workflows.org_chart config. A site that wires LDAP / Active
+ * Directory / a real HR system decorates aabenforms_workflows.org_chart and
+ * replaces these methods with real lookups.
  */
 interface OrgChartServiceInterface {
 
@@ -21,13 +20,38 @@ interface OrgChartServiceInterface {
    * @param string $employee_id
    *   Implementation-specific identifier (CPR, employee number, email).
    * @param string $fallback
-   *   Email to return if no lookup is wired or the employee is unknown.
-   *   Lets the caller pass through a webform-supplied "manager_email"
-   *   field as a graceful degrade.
+   *   Legacy graceful-degrade value. The config-backed implementation
+   *   ignores it so a self-asserted webform "manager_email" field can no
+   *   longer route an approval; pass '' from trusted callers.
    *
    * @return string
-   *   The resolved manager email, or the fallback if not found.
+   *   The resolved manager email, or '' if the employee is unknown.
    */
   public function findManagerEmail(string $employee_id, string $fallback = ''): string;
+
+  /**
+   * Returns the per-claim policy limit (in cents) for an employee.
+   *
+   * @param string $employee_id
+   *   The employee identifier.
+   *
+   * @return int
+   *   The maximum allowed claim amount in cents, or the directory default.
+   */
+  public function tierLimitCents(string $employee_id): int;
+
+  /**
+   * Resolves the employee identifier bound to a Drupal account name.
+   *
+   * Used to bind a submission to the authenticated user rather than a
+   * self-asserted form field.
+   *
+   * @param string $account_name
+   *   The Drupal account (user) name.
+   *
+   * @return string
+   *   The employee identifier, or '' if the account maps to no employee.
+   */
+  public function employeeIdForAccountName(string $account_name): string;
 
 }

--- a/web/modules/custom/aabenforms_workflows/src/Service/StubOrgChartService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/StubOrgChartService.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Drupal\aabenforms_workflows\Service;
 
 /**
- * Default no-op org-chart implementation.
+ * No-op org-chart implementation kept for tests and as a documented base.
  *
- * Returns whatever fallback the caller hands us. Sites that want a real
- * org-chart lookup install/decorate a service implementing
- * OrgChartServiceInterface (e.g. an LDAP/AD bridge module).
+ * Production uses ConfigOrgChartService. This returns empty results rather
+ * than echoing a self-asserted fallback. A site wiring LDAP / AD provides
+ * its own implementation of OrgChartServiceInterface.
  */
 final class StubOrgChartService implements OrgChartServiceInterface {
 
@@ -17,7 +17,21 @@ final class StubOrgChartService implements OrgChartServiceInterface {
    * {@inheritdoc}
    */
   public function findManagerEmail(string $employee_id, string $fallback = ''): string {
-    return $fallback;
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tierLimitCents(string $employee_id): int {
+    return 0;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function employeeIdForAccountName(string $account_name): string {
+    return '';
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/PayrollPostActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/PayrollPostActionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\PayrollPostAction;
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+use Drupal\aabenforms_workflows\Service\PayrollService;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the PayrollPostAction policy check.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\PayrollPostAction
+ * @group aabenforms_workflows
+ */
+class PayrollPostActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\PayrollPostAction
+   */
+  protected PayrollPostAction $action;
+
+  /**
+   * Mock payroll service.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\PayrollService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $payroll;
+
+  /**
+   * Mock org chart.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $orgChart;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')->willReturnCallback(function ($name, $value) use ($tokenServices) {
+      $this->tokenStorage[$name] = $value;
+      return $tokenServices;
+    });
+
+    $this->payroll = $this->getMockBuilder(PayrollService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['forward'])
+      ->getMock();
+    $this->orgChart = $this->createMock(OrgChartServiceInterface::class);
+
+    $configuration = [
+      'employee_id_token' => 'emp',
+      'amount_token' => 'amount',
+      'claim_type' => 'mileage_expense',
+      'result_token' => 'payroll_result',
+    ];
+    $this->action = new PayrollPostAction(
+      $configuration,
+      'aabenforms_payroll_post',
+      [],
+      $entityTypeManager,
+      $tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger
+    );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $reflection = new \ReflectionClass($this->action);
+    foreach (['payroll' => $this->payroll, 'orgChart' => $this->orgChart] as $prop => $value) {
+      $p = $reflection->getProperty($prop);
+      $p->setAccessible(TRUE);
+      $p->setValue($this->action, $value);
+    }
+
+    $this->tokenStorage['emp'] = 'E1001';
+  }
+
+  /**
+   * An amount within the policy limit is forwarded to payroll.
+   *
+   * @covers ::execute
+   */
+  public function testWithinLimitForwards(): void {
+    $this->tokenStorage['amount'] = '450';
+    $this->orgChart->method('tierLimitCents')->willReturn(500000);
+    $this->payroll->expects($this->once())
+      ->method('forward')
+      ->willReturn([
+        'status' => PayrollService::STATUS_SUCCESS,
+        'transaction_id' => 'TX1',
+        'reason_code' => '',
+        'message' => 'ok',
+      ]);
+
+    $this->action->execute();
+    $this->assertSame(PayrollService::STATUS_SUCCESS, $this->tokenStorage['payroll_result']['status']);
+  }
+
+  /**
+   * An amount over the policy limit is blocked and never forwarded.
+   *
+   * @covers ::execute
+   */
+  public function testOverLimitBlocked(): void {
+    $this->tokenStorage['amount'] = '6000';
+    $this->orgChart->method('tierLimitCents')->willReturn(500000);
+    $this->payroll->expects($this->never())->method('forward');
+
+    $this->action->execute();
+
+    $this->assertSame(PayrollService::STATUS_FAILURE, $this->tokenStorage['payroll_result']['status']);
+    $this->assertSame('AMOUNT_EXCEEDS_POLICY', $this->tokenStorage['payroll_result']['reason_code']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ResolveEmployeeActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ResolveEmployeeActionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\ResolveEmployeeAction;
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the ResolveEmployeeAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\ResolveEmployeeAction
+ * @group aabenforms_workflows
+ */
+class ResolveEmployeeActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\ResolveEmployeeAction
+   */
+  protected ResolveEmployeeAction $action;
+
+  /**
+   * Mock current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $account;
+
+  /**
+   * Mock org chart.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $orgChart;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')->willReturnCallback(function ($name, $value) use ($tokenServices) {
+      $this->tokenStorage[$name] = $value;
+      return $tokenServices;
+    });
+
+    $this->account = $this->createMock(AccountProxyInterface::class);
+    $this->orgChart = $this->createMock(OrgChartServiceInterface::class);
+
+    $configuration = [
+      'submitted_employee_id_token' => 'submitted_id',
+      'result_token' => 'employee_id',
+    ];
+    $this->action = new ResolveEmployeeAction(
+      $configuration,
+      'aabenforms_resolve_employee',
+      [],
+      $entityTypeManager,
+      $tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger
+    );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $reflection = new \ReflectionClass($this->action);
+    foreach (['account' => $this->account, 'orgChart' => $this->orgChart] as $prop => $value) {
+      $p = $reflection->getProperty($prop);
+      $p->setAccessible(TRUE);
+      $p->setValue($this->action, $value);
+    }
+  }
+
+  /**
+   * Anonymous submitters are rejected.
+   *
+   * @covers ::execute
+   */
+  public function testAnonymousFailsClosed(): void {
+    $this->account->method('isAnonymous')->willReturn(TRUE);
+    $this->action->execute();
+    $this->assertSame('failed', $this->tokenStorage['employee_id_status']);
+    $this->assertSame('', $this->tokenStorage['employee_id']);
+  }
+
+  /**
+   * An authenticated account mapped to an employee resolves verified.
+   *
+   * @covers ::execute
+   */
+  public function testMappedAccountResolvesVerified(): void {
+    $this->account->method('isAnonymous')->willReturn(FALSE);
+    $this->account->method('getAccountName')->willReturn('admin');
+    $this->orgChart->method('employeeIdForAccountName')->with('admin')->willReturn('E1001');
+
+    $this->action->execute();
+
+    $this->assertSame('verified', $this->tokenStorage['employee_id_status']);
+    $this->assertSame('E1001', $this->tokenStorage['employee_id']);
+  }
+
+  /**
+   * An authenticated account not in the directory fails closed.
+   *
+   * @covers ::execute
+   */
+  public function testUnmappedAccountFailsClosed(): void {
+    $this->account->method('isAnonymous')->willReturn(FALSE);
+    $this->account->method('getAccountName')->willReturn('stranger');
+    $this->orgChart->method('employeeIdForAccountName')->willReturn('');
+
+    $this->action->execute();
+
+    $this->assertSame('failed', $this->tokenStorage['employee_id_status']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ConfigOrgChartServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ConfigOrgChartServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_workflows\Service\ConfigOrgChartService;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the config-backed org-chart directory.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\ConfigOrgChartService
+ * @group aabenforms_workflows
+ */
+class ConfigOrgChartServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ConfigOrgChartService
+   */
+  protected ConfigOrgChartService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $values = [
+      'default_tier_limit_cents' => 200000,
+      'employees' => [
+        'E1001' => [
+          'name' => 'Administrator',
+          'account_name' => 'admin',
+          'manager_email' => 'leder@example.dk',
+          'tier_limit_cents' => 500000,
+        ],
+      ],
+    ];
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(fn ($key) => $values[$key] ?? NULL);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $this->service = new ConfigOrgChartService($configFactory);
+  }
+
+  /**
+   * @covers ::findManagerEmail
+   */
+  public function testFindManagerEmail(): void {
+    $this->assertSame('leder@example.dk', $this->service->findManagerEmail('E1001'));
+    // Unknown employee resolves to '' - never the self-asserted fallback.
+    $this->assertSame('', $this->service->findManagerEmail('E9999', 'spoof@evil.dk'));
+  }
+
+  /**
+   * @covers ::tierLimitCents
+   */
+  public function testTierLimitCents(): void {
+    $this->assertSame(500000, $this->service->tierLimitCents('E1001'));
+    $this->assertSame(200000, $this->service->tierLimitCents('E9999'));
+  }
+
+  /**
+   * @covers ::employeeIdForAccountName
+   */
+  public function testEmployeeIdForAccountName(): void {
+    $this->assertSame('E1001', $this->service->employeeIdForAccountName('admin'));
+    $this->assertSame('', $this->service->employeeIdForAccountName('nobody'));
+    $this->assertSame('', $this->service->employeeIdForAccountName(''));
+  }
+
+}


### PR DESCRIPTION
Internal flows routed money and tasks on a self-asserted employee_id form field, and StubOrgChartService echoed the submitted manager_email straight back, so a submitter could name any manager and any employee number.

## Changes
- **ConfigOrgChartService** (new) - a directory backed by `aabenforms_workflows.org_chart` config. Resolves the manager email, the per-employee policy limit, and the account-to-employee binding. It never echoes a self-asserted fallback: an unknown employee resolves to an empty manager email.
- **aabenforms_resolve_employee** (new action) - derives the employee id from the authenticated account and writes a verified/failed status the flow gates on. Anonymous or unmapped accounts are denied.
- **PayrollPostAction** - enforces the per-employee policy limit (in cents) before forwarding; an over-limit claim is blocked with reason AMOUNT_EXCEEDS_POLICY, not sent to payroll.
- **mileage_expense** and **hr_onboarding** flows resolve identity first, gate on it (deny -> terminal), and use the resolved employee id for the manager lookup and payroll - no longer the self-asserted form fields.

## Verified end to end (DDEV, authenticated admin session)
- Submitting `employee_id: E9999` while logged in as admin bound to the real employee (E1001) and ignored the spoofed value; the manager resolved for E1001, not E9999.
- A 6000 kr claim against E1001's 5000 limit was blocked; a 450 kr claim was forwarded.
- Anonymous submits are denied at the webform access layer (role aabenforms_employee required).
- 173 unit tests green (new tests for the service, the resolve action, and the payroll policy); phpcs clean; config exported clean.

Stacked on #107. Closes #101.