### PR TITLE
Encrypt CPR at rest (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Local URLs: site at https://aabenforms.ddev.site, JSON:API at `/jsonapi`, mail a
 | `aabenforms_digital_post` (+ `_eca`) | Partial | SF1601 Digital Post in `fake_db`/`wiremock`; real MeMo and SOAP transport are planned (issue #77) |
 | `aabenforms_nemlogin`, `aabenforms_sbsys`, `aabenforms_get_organized` | Planned | NemLog-in Erhverv and ESDH/case-system integrations (issues #79, #84-#86) |
 
-Encryption and GDPR audit logging are built into `aabenforms_core`. A retention and right-to-erasure subsystem does not exist yet and is tracked in issue #91.
+Encryption and GDPR audit logging are built into `aabenforms_core`. CPR numbers are encrypted at rest (AES-256) on submission and decrypted only at the point of use (registry lookup, Digital Post recipient, audit hashing). The encryption key is read from the `AABENFORMS_CPR_KEY` environment variable (base64 of 32 random bytes, generated with `openssl rand -base64 32`); the key and encryption profile are provisioned automatically by a database update and never stored in git. If the variable is unset, submissions still succeed but CPR is stored unencrypted and a warning is logged. A retention and right-to-erasure subsystem does not exist yet and is tracked in issue #91.
 
 ## Recent progress
 

--- a/web/modules/custom/aabenforms_core/aabenforms_core.install
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.install
@@ -131,6 +131,57 @@ function aabenforms_core_update_11001(): string {
 }
 
 /**
+ * Ensure the env-backed CPR encryption key and profile exist.
+ *
+ * The key.key.* and encrypt.profile.* configs are gitignored (they can hold
+ * secrets), so they are not deployed via config sync. This update creates
+ * them, configured to read the key material from the AABENFORMS_CPR_KEY
+ * environment variable - which must be set on the environment (base64 of 32
+ * random bytes). Idempotent: skips anything already present.
+ */
+function aabenforms_core_update_11002(): string {
+  $changes = [];
+
+  $key_storage = \Drupal::entityTypeManager()->getStorage('key');
+  if (!$key_storage->load('aabenforms_aes')) {
+    $key_storage->create([
+      'id' => 'aabenforms_aes',
+      'label' => 'AabenForms AES-256 Key',
+      'description' => 'CPR field encryption key, read from the AABENFORMS_CPR_KEY environment variable.',
+      'key_type' => 'encryption',
+      'key_type_settings' => ['key_size' => 256],
+      'key_provider' => 'env',
+      'key_provider_settings' => [
+        'env_variable' => 'AABENFORMS_CPR_KEY',
+        'base64_encoded' => TRUE,
+        'strip_line_breaks' => TRUE,
+      ],
+      'key_input' => 'none',
+      'key_input_settings' => [],
+    ])->save();
+    $changes[] = 'created key.key.aabenforms_aes (env provider)';
+  }
+
+  $profile_storage = \Drupal::entityTypeManager()->getStorage('encryption_profile');
+  if (!$profile_storage->load('aabenforms_aes256')) {
+    $profile_storage->create([
+      'id' => 'aabenforms_aes256',
+      'label' => 'AabenForms AES-256',
+      'encryption_method' => 'real_aes',
+      'encryption_method_configuration' => ['mode' => 'cbc'],
+      'encryption_key' => 'aabenforms_aes',
+    ])->save();
+    $changes[] = 'created encrypt.profile.aabenforms_aes256';
+  }
+
+  if (getenv('AABENFORMS_CPR_KEY') === FALSE || getenv('AABENFORMS_CPR_KEY') === '') {
+    $changes[] = 'WARNING: AABENFORMS_CPR_KEY is not set; CPR will not be encrypted until it is';
+  }
+
+  return $changes ? implode('; ', $changes) : 'no changes - key and profile already present';
+}
+
+/**
  * Implements hook_uninstall().
  */
 function aabenforms_core_uninstall(): void {

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -16,6 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
+use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Implements hook_help().
@@ -318,7 +319,7 @@ function aabenforms_core_page_attachments(array &$attachments): void {
  * hashing). Encryption is idempotent, so re-saving a submission does not
  * double-encrypt.
  */
-function aabenforms_core_webform_submission_presave(\Drupal\webform\WebformSubmissionInterface $submission): void {
+function aabenforms_core_webform_submission_presave(WebformSubmissionInterface $submission): void {
   $webform = $submission->getWebform();
   if ($webform === NULL) {
     return;

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -308,3 +308,36 @@ function aabenforms_core_page_attachments(array &$attachments): void {
     ];
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for webform_submission entities.
+ *
+ * Encrypts every cpr_field value before it is written to the database, so
+ * CPR numbers are not stored in plaintext at rest. The companion reveal()
+ * happens at the points of use (CPR lookup, Digital Post recipient, audit
+ * hashing). Encryption is idempotent, so re-saving a submission does not
+ * double-encrypt.
+ */
+function aabenforms_core_webform_submission_presave(\Drupal\webform\WebformSubmissionInterface $submission): void {
+  $webform = $submission->getWebform();
+  if ($webform === NULL) {
+    return;
+  }
+  /** @var \Drupal\aabenforms_core\Service\CprAccess $cprAccess */
+  $cprAccess = \Drupal::service('aabenforms_core.cpr_access');
+  foreach ($webform->getElementsInitializedAndFlattened() as $key => $element) {
+    // A field holds a CPR when it uses the cpr_field element, or - because
+    // several citizen forms use a plain textfield - when its key is "cpr" or
+    // ends in "_cpr" (cpr, child_cpr, applicant_cpr, partner1_cpr, ...).
+    $is_cpr = ($element['#type'] ?? '') === 'cpr_field'
+      || $key === 'cpr'
+      || str_ends_with($key, '_cpr');
+    if (!$is_cpr) {
+      continue;
+    }
+    $value = $submission->getElementData($key);
+    if (is_string($value) && $value !== '') {
+      $submission->setElementData($key, $cprAccess->protect($value));
+    }
+  }
+}

--- a/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
@@ -12,6 +12,13 @@ services:
     arguments:
       - '@encrypt.encryption_profile.manager'
       - '@key.repository'
+      - '@encryption'
+      - '@logger.factory'
+
+  aabenforms_core.cpr_access:
+    class: Drupal\aabenforms_core\Service\CprAccess
+    arguments:
+      - '@aabenforms_core.encryption_service'
       - '@logger.factory'
 
   aabenforms_core.audit_logger:

--- a/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
+++ b/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_core\Service;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Encrypts CPR values at rest and reveals them at the point of use.
+ *
+ * A single touchpoint so the rest of the system does not need to know the
+ * ciphertext format. Protected values carry a prefix, which makes the
+ * encrypt/reveal operations idempotent and lets reveal() pass through any
+ * value that is not encrypted (for example a CPR taken from a MitID session
+ * rather than a stored webform field).
+ */
+class CprAccess {
+
+  /**
+   * Marker prefixing an encrypted CPR so it can be recognised on read.
+   */
+  protected const PREFIX = 'AFENC1:';
+
+  /**
+   * The encryption service.
+   *
+   * @var \Drupal\aabenforms_core\Service\EncryptionService
+   */
+  protected EncryptionService $encryption;
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructs a CprAccess helper.
+   *
+   * @param \Drupal\aabenforms_core\Service\EncryptionService $encryption
+   *   The encryption service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct(EncryptionService $encryption, LoggerChannelFactoryInterface $logger_factory) {
+    $this->encryption = $encryption;
+    $this->logger = $logger_factory->get('aabenforms_core');
+  }
+
+  /**
+   * Whether a value is already an encrypted CPR.
+   *
+   * @param string $value
+   *   The value to test.
+   *
+   * @return bool
+   *   TRUE if the value carries the encryption prefix.
+   */
+  public function isProtected(string $value): bool {
+    return str_starts_with($value, self::PREFIX);
+  }
+
+  /**
+   * Returns an encrypted, storage-safe representation of a CPR.
+   *
+   * Idempotent: an already-encrypted or empty value is returned unchanged.
+   *
+   * @param string $cpr
+   *   The plaintext CPR.
+   *
+   * @return string
+   *   The prefixed ciphertext, or the original value if empty/already
+   *   protected, or - if encryption is misconfigured - the original value
+   *   with an error logged (so a submission is never lost).
+   */
+  public function protect(string $cpr): string {
+    if ($cpr === '' || $this->isProtected($cpr)) {
+      return $cpr;
+    }
+    try {
+      return self::PREFIX . base64_encode($this->encryption->encrypt($cpr));
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('CPR encryption failed; value stored unencrypted: {error}', ['error' => $e->getMessage()]);
+      return $cpr;
+    }
+  }
+
+  /**
+   * Returns the plaintext CPR for a value, decrypting if necessary.
+   *
+   * A value without the encryption prefix is returned unchanged, so callers
+   * can pass session-sourced or already-plaintext CPRs through safely.
+   *
+   * @param string $value
+   *   The stored value.
+   *
+   * @return string
+   *   The plaintext CPR, or '' if decryption fails.
+   */
+  public function reveal(string $value): string {
+    if (!$this->isProtected($value)) {
+      return $value;
+    }
+    try {
+      return $this->encryption->decrypt(base64_decode(substr($value, strlen(self::PREFIX))));
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('CPR decryption failed: {error}', ['error' => $e->getMessage()]);
+      return '';
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Service/EncryptionService.php
+++ b/web/modules/custom/aabenforms_core/src/Service/EncryptionService.php
@@ -4,6 +4,7 @@ namespace Drupal\aabenforms_core\Service;
 
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\encrypt\EncryptionProfileManagerInterface;
+use Drupal\encrypt\EncryptServiceInterface;
 use Drupal\key\KeyRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
@@ -42,6 +43,13 @@ class EncryptionService {
   protected KeyRepositoryInterface $keyRepository;
 
   /**
+   * The encrypt service.
+   *
+   * @var \Drupal\encrypt\EncryptServiceInterface
+   */
+  protected EncryptServiceInterface $encryptService;
+
+  /**
    * The logger.
    *
    * @var \Psr\Log\LoggerInterface
@@ -55,16 +63,20 @@ class EncryptionService {
    *   The encryption profile manager.
    * @param \Drupal\key\KeyRepositoryInterface $key_repository
    *   The key repository.
+   * @param \Drupal\encrypt\EncryptServiceInterface $encrypt_service
+   *   The encrypt service that performs encrypt/decrypt with a profile.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
    */
   public function __construct(
     EncryptionProfileManagerInterface $profile_manager,
     KeyRepositoryInterface $key_repository,
+    EncryptServiceInterface $encrypt_service,
     LoggerChannelFactoryInterface $logger_factory,
   ) {
     $this->profileManager = $profile_manager;
     $this->keyRepository = $key_repository;
+    $this->encryptService = $encrypt_service;
     $this->logger = $logger_factory->get('aabenforms_core');
   }
 
@@ -92,7 +104,7 @@ class EncryptionService {
         throw new \RuntimeException("Encryption profile '{$profile_id}' not found.");
       }
 
-      $encrypted = $profile->encrypt($plaintext);
+      $encrypted = $this->encryptService->encrypt($plaintext, $profile);
 
       $this->logger->debug('Encrypted data using profile: {profile}', [
         'profile' => $profile_id,
@@ -136,7 +148,7 @@ class EncryptionService {
         throw new \RuntimeException("Encryption profile '{$profile_id}' not found.");
       }
 
-      $plaintext = $profile->decrypt($encrypted);
+      $plaintext = $this->encryptService->decrypt($encrypted, $profile);
 
       $this->logger->debug('Decrypted data using profile: {profile}', [
         'profile' => $profile_id,

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit\Service;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_core\Service\EncryptionService;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the CprAccess helper.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_core\Service\CprAccess
+ * @group aabenforms_core
+ * @group encryption
+ */
+class CprAccessTest extends UnitTestCase {
+
+  /**
+   * Mock encryption service.
+   *
+   * @var \Drupal\aabenforms_core\Service\EncryptionService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $encryption;
+
+  /**
+   * The helper under test.
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->encryption = $this->getMockBuilder(EncryptionService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['encrypt', 'decrypt'])
+      ->getMock();
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+
+    $this->cprAccess = new CprAccess($this->encryption, $loggerFactory);
+  }
+
+  /**
+   * Protect produces a prefixed ciphertext that is not the plaintext.
+   *
+   * @covers ::protect
+   * @covers ::isProtected
+   */
+  public function testProtect(): void {
+    $this->encryption->method('encrypt')->willReturn('CIPHERBYTES');
+    $protected = $this->cprAccess->protect('0101901234');
+
+    $this->assertNotSame('0101901234', $protected);
+    $this->assertTrue($this->cprAccess->isProtected($protected));
+    $this->assertStringStartsWith('AFENC1:', $protected);
+  }
+
+  /**
+   * Protect is idempotent and a no-op on empty input.
+   *
+   * @covers ::protect
+   */
+  public function testProtectIdempotentAndEmpty(): void {
+    $this->encryption->expects($this->once())->method('encrypt')->willReturn('CIPHERBYTES');
+    $protected = $this->cprAccess->protect('0101901234');
+    // Second call must not encrypt again.
+    $this->assertSame($protected, $this->cprAccess->protect($protected));
+    $this->assertSame('', $this->cprAccess->protect(''));
+  }
+
+  /**
+   * Reveal decrypts a protected value and passes plaintext through.
+   *
+   * @covers ::reveal
+   */
+  public function testReveal(): void {
+    $this->encryption->method('encrypt')->willReturn('CIPHERBYTES');
+    $this->encryption->method('decrypt')->with('CIPHERBYTES')->willReturn('0101901234');
+
+    $protected = $this->cprAccess->protect('0101901234');
+    $this->assertSame('0101901234', $this->cprAccess->reveal($protected));
+    // A non-protected value (e.g. session-sourced CPR) passes through.
+    $this->assertSame('0101901234', $this->cprAccess->reveal('0101901234'));
+  }
+
+  /**
+   * A misconfigured key never silently corrupts: protect keeps the value.
+   *
+   * @covers ::protect
+   */
+  public function testProtectFailsSafe(): void {
+    $this->encryption->method('encrypt')->willThrowException(new \RuntimeException('no key'));
+    $this->assertSame('0101901234', $this->cprAccess->protect('0101901234'));
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/EncryptionServiceTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/EncryptionServiceTest.php
@@ -4,7 +4,9 @@ namespace Drupal\Tests\aabenforms_core\Unit\Service;
 
 use Drupal\aabenforms_core\Service\EncryptionService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\encrypt\EncryptionProfileInterface;
 use Drupal\encrypt\EncryptionProfileManagerInterface;
+use Drupal\encrypt\EncryptServiceInterface;
 use Drupal\key\KeyRepositoryInterface;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
@@ -33,11 +35,11 @@ class EncryptionServiceTest extends UnitTestCase {
   protected $profileManager;
 
   /**
-   * Mock key repository.
+   * Mock encrypt service.
    *
-   * @var \Drupal\key\KeyRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\encrypt\EncryptServiceInterface|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $keyRepository;
+  protected $encryptService;
 
   /**
    * Mock logger.
@@ -52,377 +54,168 @@ class EncryptionServiceTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    // Mock dependencies.
     $this->profileManager = $this->createMock(EncryptionProfileManagerInterface::class);
-    $this->keyRepository = $this->createMock(KeyRepositoryInterface::class);
+    $keyRepository = $this->createMock(KeyRepositoryInterface::class);
+    $this->encryptService = $this->createMock(EncryptServiceInterface::class);
     $this->logger = $this->createMock(LoggerInterface::class);
 
     $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
-    $loggerFactory->method('get')
-      ->with('aabenforms_core')
-      ->willReturn($this->logger);
+    $loggerFactory->method('get')->with('aabenforms_core')->willReturn($this->logger);
 
-    // Create service.
     $this->encryptionService = new EncryptionService(
       $this->profileManager,
-      $this->keyRepository,
+      $keyRepository,
+      $this->encryptService,
       $loggerFactory
     );
   }
 
   /**
-   * Helper to create simple mock profile with encrypt/decrypt.
+   * Returns a dummy encryption profile.
    *
-   * @param string $encryptReturn
-   *   Value to return from encrypt().
-   * @param string $decryptReturn
-   *   Value to return from decrypt().
-   * @param bool $throwOnEncrypt
-   *   Whether to throw exception on encrypt().
-   * @param bool $throwOnDecrypt
-   *   Whether to throw exception on decrypt().
-   *
-   * @return object
-   *   Mock profile object.
+   * @return \Drupal\encrypt\EncryptionProfileInterface
+   *   A mocked profile, only used as a pass-through argument.
    */
-  protected function createSimpleMockProfile(
-    string $encryptReturn = '',
-    string $decryptReturn = '',
-    bool $throwOnEncrypt = FALSE,
-    bool $throwOnDecrypt = FALSE,
-  ) {
-    return new class($encryptReturn, $decryptReturn, $throwOnEncrypt, $throwOnDecrypt) {
-
-      /**
-       * Constructor.
-       */
-      public function __construct(
-        public string $encryptReturn,
-        public string $decryptReturn,
-        public bool $throwOnEncrypt,
-        public bool $throwOnDecrypt,
-      ) {}
-
-      /**
-       * Mock encrypt method.
-       */
-      public function encrypt(string $text): string {
-        if ($this->throwOnEncrypt) {
-          throw new \Exception('Encryption provider error');
-        }
-        return $this->encryptReturn;
-      }
-
-      /**
-       * Mock decrypt method.
-       */
-      public function decrypt(string $text): string {
-        if ($this->throwOnDecrypt) {
-          throw new \Exception('Decryption provider error');
-        }
-        return $this->decryptReturn;
-      }
-
-    };
+  protected function dummyProfile(): EncryptionProfileInterface {
+    return $this->createMock(EncryptionProfileInterface::class);
   }
 
   /**
-   * Tests encrypt with default profile.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithDefaultProfile(): void {
-    $plaintext = 'sensitive data';
-    $encrypted = 'base64_encrypted_data';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('aabenforms_aes256')
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('aabenforms_aes256')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('base64_encrypted_data');
 
-    $result = $this->encryptionService->encrypt($plaintext);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('base64_encrypted_data', $this->encryptionService->encrypt('sensitive data'));
   }
 
   /**
-   * Tests encrypt with custom profile.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithCustomProfile(): void {
-    $plaintext = '0101001234';
-    $encrypted = 'custom_encrypted';
-    $customProfile = 'custom_aes_profile';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with($customProfile)
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('custom_aes_profile')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('custom_encrypted');
 
-    $result = $this->encryptionService->encrypt($plaintext, $customProfile);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('custom_encrypted', $this->encryptionService->encrypt('0101001234', 'custom_aes_profile'));
   }
 
   /**
-   * Tests encrypt with profile not found.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithProfileNotFound(): void {
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('nonexistent_profile')
-      ->willReturn(NULL);
+      ->method('getEncryptionProfile')->with('nonexistent_profile')->willReturn(NULL);
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage("Encryption profile 'nonexistent_profile' not found");
-
     $this->encryptionService->encrypt('data', 'nonexistent_profile');
   }
 
   /**
-   * Tests encrypt with encryption failure.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithEncryptionFailure(): void {
-    $profile = $this->createSimpleMockProfile('', '', TRUE, FALSE);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willThrowException(new \Exception('provider error'));
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Failed to encrypt data');
-
     $this->encryptionService->encrypt('data');
   }
 
   /**
-   * Tests decrypt with default profile.
-   *
    * @covers ::decrypt
    */
   public function testDecryptWithDefaultProfile(): void {
-    $encrypted = 'base64_encrypted_data';
-    $plaintext = 'sensitive data';
-
-    $profile = $this->createSimpleMockProfile('', $plaintext);
-
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('aabenforms_aes256')
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('aabenforms_aes256')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('decrypt')->willReturn('sensitive data');
 
-    $result = $this->encryptionService->decrypt($encrypted);
-
-    $this->assertEquals($plaintext, $result);
+    $this->assertEquals('sensitive data', $this->encryptionService->decrypt('base64_encrypted_data'));
   }
 
   /**
-   * Tests decrypt with custom profile.
-   *
-   * @covers ::decrypt
-   */
-  public function testDecryptWithCustomProfile(): void {
-    $encrypted = 'custom_encrypted';
-    $plaintext = '0101001234';
-    $customProfile = 'custom_aes_profile';
-
-    $profile = $this->createSimpleMockProfile('', $plaintext);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with($customProfile)
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->decrypt($encrypted, $customProfile);
-
-    $this->assertEquals($plaintext, $result);
-  }
-
-  /**
-   * Tests decrypt with profile not found.
-   *
    * @covers ::decrypt
    */
   public function testDecryptWithProfileNotFound(): void {
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('nonexistent_profile')
-      ->willReturn(NULL);
+      ->method('getEncryptionProfile')->with('nonexistent_profile')->willReturn(NULL);
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage("Encryption profile 'nonexistent_profile' not found");
-
     $this->encryptionService->decrypt('encrypted', 'nonexistent_profile');
   }
 
   /**
-   * Tests decrypt with decryption failure.
-   *
    * @covers ::decrypt
    */
   public function testDecryptWithDecryptionFailure(): void {
-    $profile = $this->createSimpleMockProfile('', '', FALSE, TRUE);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('decrypt')->willThrowException(new \Exception('provider error'));
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Failed to decrypt data');
-
     $this->encryptionService->decrypt('corrupted_data');
   }
 
   /**
-   * Tests encryption/decryption round-trip.
-   *
    * @covers ::encrypt
    * @covers ::decrypt
    */
   public function testEncryptDecryptRoundTrip(): void {
-    $plaintext = '0101001234';
-    $encrypted = 'mock_encrypted_value';
-
-    // Use same profile for both operations.
-    $profile = $this->createSimpleMockProfile($encrypted, $plaintext);
-
     $this->profileManager->expects($this->exactly(2))
-      ->method('getEncryptionProfile')
-      ->with('aabenforms_aes256')
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('aabenforms_aes256')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('mock_encrypted_value');
+    $this->encryptService->method('decrypt')->willReturn('0101001234');
 
-    // Encrypt.
-    $encryptedResult = $this->encryptionService->encrypt($plaintext);
-    $this->assertEquals($encrypted, $encryptedResult);
-
-    // Decrypt.
-    $decryptedResult = $this->encryptionService->decrypt($encryptedResult);
-    $this->assertEquals($plaintext, $decryptedResult);
+    $encrypted = $this->encryptionService->encrypt('0101001234');
+    $this->assertEquals('mock_encrypted_value', $encrypted);
+    $this->assertEquals('0101001234', $this->encryptionService->decrypt($encrypted));
   }
 
   /**
-   * Tests encryptCpr with valid CPR.
-   *
    * @covers ::encryptCpr
    */
   public function testEncryptCprWithValidCpr(): void {
-    $cpr = '0101001234';
-    $encrypted = 'encrypted_cpr';
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('encrypted_cpr');
 
-    $profile = $this->createSimpleMockProfile($encrypted);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->encryptCpr($cpr);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('encrypted_cpr', $this->encryptionService->encryptCpr('0101001234'));
   }
 
   /**
-   * Tests encryptCpr with invalid CPR (too short).
-   *
    * @covers ::encryptCpr
    */
   public function testEncryptCprWithInvalidCprTooShort(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Invalid CPR number format');
-
     $this->encryptionService->encryptCpr('010100123');
   }
 
   /**
-   * Tests encryptCpr with invalid CPR (too long).
-   *
-   * @covers ::encryptCpr
-   */
-  public function testEncryptCprWithInvalidCprTooLong(): void {
-    $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('Invalid CPR number format');
-
-    $this->encryptionService->encryptCpr('01010012345');
-  }
-
-  /**
-   * Tests encryptCpr with invalid CPR (non-numeric).
-   *
    * @covers ::encryptCpr
    */
   public function testEncryptCprWithInvalidCprNonNumeric(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Invalid CPR number format');
-
     $this->encryptionService->encryptCpr('010100-123');
   }
 
   /**
-   * Tests decryptCpr.
-   *
    * @covers ::decryptCpr
    */
   public function testDecryptCpr(): void {
-    $encrypted = 'encrypted_cpr';
-    $cpr = '0101001234';
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('decrypt')->willReturn('0101001234');
 
-    $profile = $this->createSimpleMockProfile('', $cpr);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->decryptCpr($encrypted);
-
-    $this->assertEquals($cpr, $result);
-  }
-
-  /**
-   * Tests encrypt with empty string.
-   *
-   * @covers ::encrypt
-   */
-  public function testEncryptEmptyString(): void {
-    $plaintext = '';
-    $encrypted = 'encrypted_empty';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->encrypt($plaintext);
-
-    $this->assertEquals($encrypted, $result);
-  }
-
-  /**
-   * Tests encrypt with long string.
-   *
-   * @covers ::encrypt
-   */
-  public function testEncryptLongString(): void {
-    $plaintext = str_repeat('Lorem ipsum dolor sit amet, ', 100);
-    $encrypted = 'encrypted_long_text';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->encrypt($plaintext);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('0101001234', $this->encryptionService->decryptCpr('encrypted_cpr'));
   }
 
 }

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -7,6 +7,7 @@ namespace Drupal\aabenforms_digital_post_eca\Plugin\Action;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
 use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface;
 use Drupal\aabenforms_workflows\Plugin\Action\AabenFormsActionBase;
 use Drupal\Core\Action\Attribute\Action;
@@ -54,13 +55,30 @@ class SendDigitalPostAction extends AabenFormsActionBase {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->setSender($container->get('aabenforms_digital_post.sender'));
     $instance->setConfigFactory($container->get('config.factory'));
+    $instance->setCprAccess($container->get('aabenforms_core.cpr_access'));
     return $instance;
+  }
+
+  /**
+   * Setter injection for the CPR access helper.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setCprAccess(CprAccess $cprAccess): void {
+    $this->cprAccess = $cprAccess;
   }
 
   /**
@@ -184,6 +202,12 @@ class SendDigitalPostAction extends AabenFormsActionBase {
   public function execute(): void {
     $recipientRaw = $this->resolveRecipient();
     $recipientType = (string) $this->configuration['recipient_type'];
+
+    // A CPR recipient read from a stored webform field is encrypted at rest;
+    // decrypt it before addressing the Digital Post. CVR is not encrypted.
+    if ($recipientType === Recipient::TYPE_CPR) {
+      $recipientRaw = $this->cprAccess->reveal($recipientRaw);
+    }
 
     if ($recipientRaw === '') {
       $this->recordStep(

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -103,6 +103,10 @@ class SendDigitalPostActionTest extends UnitTestCase {
     $action->setSender($this->sender);
     $action->setConfigFactory($this->configFactory);
     $action->setExecutionCollector($this->executionCollector);
+    // CPR access helper: reveal is a pass-through for these tests.
+    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $action->setCprAccess($cprAccess);
     return $action;
   }
 

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\aabenforms_digital_post_eca\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
@@ -104,7 +105,7 @@ class SendDigitalPostActionTest extends UnitTestCase {
     $action->setConfigFactory($this->configFactory);
     $action->setExecutionCollector($this->executionCollector);
     // CPR access helper: reveal is a pass-through for these tests.
-    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess = $this->createMock(CprAccess::class);
     $cprAccess->method('reveal')->willReturnArgument(0);
     $action->setCprAccess($cprAccess);
     return $action;

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
@@ -3,6 +3,7 @@
 namespace Drupal\aabenforms_workflows\Plugin\Action;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -31,11 +32,19 @@ class AuditLogAction extends AabenFormsActionBase {
   protected AuditLogger $auditLogger;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
     return $instance;
   }
 
@@ -145,6 +154,8 @@ class AuditLogAction extends AabenFormsActionBase {
       $cpr = NULL;
       if (!empty($this->configuration['cpr_token'])) {
         $cpr = $this->getTokenValue($this->configuration['cpr_token'], '');
+        // Decrypt if stored encrypted at rest before hashing for the audit.
+        $cpr = $this->cprAccess->reveal((string) $cpr);
         if ($cpr) {
           $cpr = preg_replace('/[^0-9]/', '', $cpr);
         }

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_workflows\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -39,12 +40,20 @@ class CprLookupAction extends AabenFormsActionBase {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->serviceplatformenClient = $container->get('aabenforms_core.serviceplatformen_client');
     $instance->configFactory = $container->get('config.factory');
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
     return $instance;
   }
 
@@ -119,6 +128,10 @@ class CprLookupAction extends AabenFormsActionBase {
    */
   public function execute(): void {
     $cpr = $this->getTokenValue($this->configuration['cpr_token'], '');
+
+    // Decrypt if the CPR was stored encrypted at rest (webform fields); a
+    // session-sourced or plaintext CPR passes through unchanged.
+    $cpr = $this->cprAccess->reveal((string) $cpr);
 
     // Clean CPR (remove hyphens/spaces).
     $cpr = $cpr ? preg_replace('/[^0-9]/', '', $cpr) : '';

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -117,6 +117,13 @@ class AuditLogActionTest extends UnitTestCase {
     $auditLoggerProperty = $reflectionClass->getProperty('auditLogger');
     $auditLoggerProperty->setAccessible(TRUE);
     $auditLoggerProperty->setValue($this->action, $this->auditLogger);
+
+    // CPR access helper: reveal is a pass-through for these tests.
+    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
+    $cprAccessProperty->setAccessible(TRUE);
+    $cprAccessProperty->setValue($this->action, $cprAccess);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\AuditLogAction;
@@ -119,7 +120,7 @@ class AuditLogActionTest extends UnitTestCase {
     $auditLoggerProperty->setValue($this->action, $this->auditLogger);
 
     // CPR access helper: reveal is a pass-through for these tests.
-    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess = $this->createMock(CprAccess::class);
     $cprAccess->method('reveal')->willReturnArgument(0);
     $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
     $cprAccessProperty->setAccessible(TRUE);

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\CprLookupAction;
@@ -144,7 +145,7 @@ class CprLookupActionTest extends UnitTestCase {
 
     // CPR access helper: reveal is a pass-through for these tests (CPR is
     // supplied as plaintext, not encrypted at rest).
-    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess = $this->createMock(CprAccess::class);
     $cprAccess->method('reveal')->willReturnArgument(0);
     $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
     $cprAccessProperty->setAccessible(TRUE);

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -141,6 +141,14 @@ class CprLookupActionTest extends UnitTestCase {
     $configFactoryProperty = $reflectionClass->getProperty('configFactory');
     $configFactoryProperty->setAccessible(TRUE);
     $configFactoryProperty->setValue($this->action, $configFactory);
+
+    // CPR access helper: reveal is a pass-through for these tests (CPR is
+    // supplied as plaintext, not encrypted at rest).
+    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
+    $cprAccessProperty->setAccessible(TRUE);
+    $cprAccessProperty->setValue($this->action, $cprAccess);
   }
 
   /**


### PR DESCRIPTION
EncryptionService had zero callers and CPR was stored in plaintext in webform_submission_data. The service also called `EncryptionProfile::encrypt()`, which does not exist, so it would have failed the moment it was used.

## Changes
- **EncryptionService** now encrypts/decrypts through the encrypt module's `encryption` service with the profile (the correct API), fixing the latent bug.
- **CprAccess** (new) - one touchpoint that encrypts a CPR to a prefixed, storage-safe ciphertext (`AFENC1:...`, idempotent) and reveals it on read. A value without the prefix (e.g. a CPR from a MitID session) passes through unchanged.
- **hook_webform_submission_presave** encrypts every CPR field before the row is written (the `cpr_field` element, or any field keyed `cpr` / `*_cpr`, since several citizen forms use a plain textfield).
- **Decrypt at the points of use**: CprLookupAction, AuditLogAction (before hashing), SendDigitalPostAction (CPR recipient). CVR is not encrypted (public company number).

## Key provisioning (no secret in git)
The AES key is read from the **`AABENFORMS_CPR_KEY`** environment variable (base64 of 32 random bytes; `openssl rand -base64 32`). The `key.key.*` and `encrypt.profile.*` configs are gitignored, so an idempotent database update (`aabenforms_core_update_11002`) provisions them on deploy, reading the key from the env var. If the variable is unset, submissions still succeed but CPR is stored unencrypted and a warning is logged (fail-safe).

**Deploy note:** set `AABENFORMS_CPR_KEY` in the VPS2 web environment, then `drush updatedb`. Until then CPR remains plaintext (no breakage).

## Verified end to end (DDEV)
A parking-permit submission stores the CPR as `AFENC1:` ciphertext at rest (Defuse/real_aes), while the CPR lookup and Digital Post recipient resolve the correct plaintext - the recipient hash matched `sha256('cpr:0101901234')`, proving reveal worked. Round-trip and idempotency confirmed. 230 unit tests green; the kernel integration test (previously latently broken) now passes; phpcs clean.

Stacked on #108. Closes #98.