### PR TITLE
Land security remediation stack on main (#96, #97, #98, #100, #101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Local URLs: site at https://aabenforms.ddev.site, JSON:API at `/jsonapi`, mail a
 | `aabenforms_digital_post` (+ `_eca`) | Partial | SF1601 Digital Post in `fake_db`/`wiremock`; real MeMo and SOAP transport are planned (issue #77) |
 | `aabenforms_nemlogin`, `aabenforms_sbsys`, `aabenforms_get_organized` | Planned | NemLog-in Erhverv and ESDH/case-system integrations (issues #79, #84-#86) |
 
-Encryption and GDPR audit logging are built into `aabenforms_core`. A retention and right-to-erasure subsystem does not exist yet and is tracked in issue #91.
+Encryption and GDPR audit logging are built into `aabenforms_core`. CPR numbers are encrypted at rest (AES-256) on submission and decrypted only at the point of use (registry lookup, Digital Post recipient, audit hashing). The encryption key is read from the `AABENFORMS_CPR_KEY` environment variable (base64 of 32 random bytes, generated with `openssl rand -base64 32`); the key and encryption profile are provisioned automatically by a database update and never stored in git. If the variable is unset, submissions still succeed but CPR is stored unencrypted and a warning is logged. A retention and right-to-erasure subsystem does not exist yet and is tracked in issue #91.
 
 ## Recent progress
 

--- a/config/sync/aabenforms_workflows.org_chart.yml
+++ b/config/sync/aabenforms_workflows.org_chart.yml
@@ -1,0 +1,12 @@
+default_tier_limit_cents: 200000
+employees:
+  E1001:
+    name: Administrator
+    account_name: admin
+    manager_email: leder@example.dk
+    tier_limit_cents: 500000
+  E1002:
+    name: 'Medarbejder Demo'
+    account_name: medarbejder
+    manager_email: leder@example.dk
+    tier_limit_cents: 300000

--- a/config/sync/eca.eca.address_change_flow.yml
+++ b/config/sync/eca.eca.address_change_flow.yml
@@ -43,6 +43,7 @@ actions:
       event_type: address_change_submitted
       additional_data_token: '[citizen_data:name]'
       message_template: 'Address change submitted; CPR resolved against registry.'
+      status_token: citizen_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.address_change_flow.yml
+++ b/config/sync/eca.eca.address_change_flow.yml
@@ -20,11 +20,43 @@ events:
       type: 'webform_submission address_change'
     successors:
       -
-        id: cpr_lookup
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_address_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[address_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_address_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[address_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate MitID session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_address_change
+      result_token: address_mitid_valid
+      session_data_token: address_session
+    successors:
+      -
+        id: cpr_lookup
+        condition: gate_address_mitid_ok
+      -
+        id: deny_address
+        condition: gate_address_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -59,4 +91,12 @@ actions:
       body_template: '<p>Vi har registreret din adresseændring. Den nye adresse er gældende fra den angivne dato.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_address:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: address_change_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Adresseaendringen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.association_booking_flow.yml
+++ b/config/sync/eca.eca.association_booking_flow.yml
@@ -22,7 +22,25 @@ events:
       -
         id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_association_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[association_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_association_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[association_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -35,7 +53,10 @@ actions:
     successors:
       -
         id: cvr_lookup
-        condition: ''
+        condition: gate_association_mitid_ok
+      -
+        id: deny_association
+        condition: gate_association_mitid_deny
   cvr_lookup:
     label: 'CVR registry lookup'
     plugin: aabenforms_cvr_lookup
@@ -91,4 +112,12 @@ actions:
       event_type: association_booking_complete
       additional_data_token: '[webform_submission:values:association_name:raw]'
       message_template: 'Association request decisioned (stub)'
+    successors: {  }
+  deny_association:
+    label: 'Deny: MitID Erhverv not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: association_booking_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Bookingen blev ikke behandlet, fordi foreningens MitID Erhverv-identitet ikke kunne bekraeftes. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.association_booking_flow.yml
+++ b/config/sync/eca.eca.association_booking_flow.yml
@@ -54,6 +54,7 @@ actions:
       event_type: association_booking_submitted
       additional_data_token: '[webform_submission:values:association_name:raw]'
       message_template: 'Association request received and CVR resolved'
+      status_token: association_data_status
     successors:
       -
         id: log_reviewer_assigned

--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -23,11 +23,43 @@ events:
       type: 'webform_submission building_permit'
     successors:
       -
-        id: cpr_lookup
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_building_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[building_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_building_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[building_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate MitID session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_building_permit
+      result_token: building_mitid_valid
+      session_data_token: building_session
+    successors:
+      -
+        id: cpr_lookup
+        condition: gate_building_mitid_ok
+      -
+        id: deny_building
+        condition: gate_building_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -62,4 +94,12 @@ actions:
       body_template: '<p>Vi har modtaget din ansøgning om byggetilladelse. En sagsbehandler tager kontakt.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_building:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: building_permit_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Ansoegningen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -46,6 +46,7 @@ actions:
       event_type: building_permit_submitted
       additional_data_token: ''
       message_template: 'Building permit application received; CPR resolved against registry.'
+      status_token: citizen_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.citizen_service_application_flow.yml
+++ b/config/sync/eca.eca.citizen_service_application_flow.yml
@@ -54,6 +54,7 @@ actions:
       event_type: citizen_service_submitted
       additional_data_token: '[citizen_data:name]'
       message_template: 'Citizen service application received and CPR resolved'
+      status_token: citizen_data_status
     successors:
       -
         id: log_caseworker_assigned

--- a/config/sync/eca.eca.citizen_service_application_flow.yml
+++ b/config/sync/eca.eca.citizen_service_application_flow.yml
@@ -22,7 +22,25 @@ events:
       -
         id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_citizen_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[citizen_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_citizen_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[citizen_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -35,7 +53,10 @@ actions:
     successors:
       -
         id: cpr_lookup
-        condition: ''
+        condition: gate_citizen_mitid_ok
+      -
+        id: deny_citizen
+        condition: gate_citizen_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -81,4 +102,12 @@ actions:
       body_template: '<p>Der er truffet afgørelse på din ansøgning. Se bilag i Digital Post.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_citizen:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: citizen_service_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Ansoegningen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.company_verification_flow.yml
+++ b/config/sync/eca.eca.company_verification_flow.yml
@@ -46,6 +46,7 @@ actions:
       event_type: company_verification_submitted
       additional_data_token: ''
       message_template: 'Company verification request received; CVR resolved.'
+      status_token: company_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.foi_request_flow.yml
+++ b/config/sync/eca.eca.foi_request_flow.yml
@@ -33,5 +33,19 @@ actions:
     configuration:
       event_type: foi_request_submitted
       additional_data_token: ''
-      message_template: 'FOI request received; case worker will process within 7 working days.'
+      message_template: 'FOI request received; routing to case worker.'
+    successors:
+      -
+        id: route_request
+        condition: ''
+  route_request:
+    label: 'Route FOI request to case worker'
+    plugin: aabenforms_foi_route
+    configuration:
+      caseworker_email: aktindsigt@example.dk
+      response_working_days: 7
+      requester_name_token: '[webform_submission:values:requester_name:raw]'
+      requester_email_token: '[webform_submission:values:requester_email:raw]'
+      request_text_token: '[webform_submission:values:request_text:raw]'
+      reference_token: '[webform_submission:sid]'
     successors: {  }

--- a/config/sync/eca.eca.hr_onboarding_flow.yml
+++ b/config/sync/eca.eca.hr_onboarding_flow.yml
@@ -20,11 +20,42 @@ events:
       type: 'webform_submission hr_onboarding'
     successors:
       -
-        id: log_received
+        id: resolve_employee
         condition: ''
-conditions: {  }
+conditions:
+  gate_hr_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[hr_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_hr_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[hr_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  resolve_employee:
+    label: 'Bind HR submitter identity from login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[webform_submission:values:hr_submitter_email:raw]'
+      result_token: hr_employee_id
+    successors:
+      -
+        id: log_received
+        condition: gate_hr_employee_ok
+      -
+        id: deny_internal
+        condition: gate_hr_employee_deny
   log_received:
     label: 'Log: HR onboarding request received'
     plugin: aabenforms_audit_log
@@ -40,8 +71,8 @@ actions:
     label: 'Resolve manager email from org-chart'
     plugin: aabenforms_manager_lookup
     configuration:
-      employee_id_token: '[webform_submission:values:hr_submitter_email:raw]'
-      fallback_email_token: '[webform_submission:values:manager_email:raw]'
+      employee_id_token: '[hr_employee_id]'
+      fallback_email_token: ''
       result_token: hr_onboarding_manager_email
     successors:
       -
@@ -65,4 +96,12 @@ actions:
       event_type: hr_onboarding_it_notified
       additional_data_token: '[webform_submission:values:it_distribution_email:raw]'
       message_template: 'Stub. Production would email IT distribution on manager approval.'
+    successors: {  }
+  deny_internal:
+    label: 'Deny: HR submitter identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: hr_onboarding_denied
+      step_label: 'Adgang afvist'
+      message: 'Anmodningen blev ikke behandlet, fordi det ikke kunne bekraeftes, at du er logget ind som medarbejder.'
     successors: {  }

--- a/config/sync/eca.eca.marriage_booking_flow.yml
+++ b/config/sync/eca.eca.marriage_booking_flow.yml
@@ -57,6 +57,7 @@ actions:
       event_type: marriage_booking_submitted
       additional_data_token: ''
       message_template: 'Marriage booking received; both partners CPR-verified.'
+      status_token: partner2_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/eca.eca.med_election_nomination_flow.yml
+++ b/config/sync/eca.eca.med_election_nomination_flow.yml
@@ -22,7 +22,25 @@ events:
       -
         id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_nominator_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[nominator_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_nominator_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[nominator_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -35,7 +53,10 @@ actions:
     successors:
       -
         id: cpr_lookup
-        condition: ''
+        condition: gate_nominator_mitid_ok
+      -
+        id: deny_nomination
+        condition: gate_nominator_mitid_deny
   cpr_lookup:
     label: 'Resolve nominator via CPR'
     plugin: aabenforms_cpr_lookup
@@ -54,4 +75,12 @@ actions:
       event_type: med_nomination_recorded
       additional_data_token: '[webform_submission:values:nominee_name:raw]'
       message_template: 'MED election nomination recorded'
+    successors: {  }
+  deny_nomination:
+    label: 'Deny: nominator MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: med_nomination_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Indstillingen blev ikke registreret, fordi din identitet ikke kunne bekraeftes med MitID. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.med_election_voting_flow.yml
+++ b/config/sync/eca.eca.med_election_voting_flow.yml
@@ -31,7 +31,25 @@ events:
       -
         id: tabulate_due
         condition: ''
-conditions: {  }
+conditions:
+  gate_voter_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[voter_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_voter_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[voter_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   validate_voter_mitid:
@@ -44,7 +62,10 @@ actions:
     successors:
       -
         id: record_ballot
-        condition: ''
+        condition: gate_voter_mitid_ok
+      -
+        id: deny_ballot
+        condition: gate_voter_mitid_deny
   record_ballot:
     label: 'Record voter ballot'
     plugin: aabenforms_record_ballot
@@ -58,4 +79,12 @@ actions:
     label: 'Cron: open/close due elections'
     plugin: aabenforms_tabulate_election
     configuration: {  }
+    successors: {  }
+  deny_ballot:
+    label: 'Deny: voter MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: med_ballot_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Din stemme blev ikke registreret, fordi din identitet ikke kunne bekraeftes med MitID. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.mileage_expense_flow.yml
+++ b/config/sync/eca.eca.mileage_expense_flow.yml
@@ -20,11 +20,42 @@ events:
       type: 'webform_submission mileage_expense'
     successors:
       -
-        id: log_received
+        id: resolve_employee
         condition: ''
-conditions: {  }
+conditions:
+  gate_mileage_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[mileage_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mileage_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[mileage_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  resolve_employee:
+    label: 'Bind employee identity from login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[webform_submission:values:employee_id:raw]'
+      result_token: mileage_employee_id
+    successors:
+      -
+        id: log_received
+        condition: gate_mileage_employee_ok
+      -
+        id: deny_internal
+        condition: gate_mileage_employee_deny
   log_received:
     label: 'Log: expense claim received'
     plugin: aabenforms_audit_log
@@ -40,8 +71,8 @@ actions:
     label: 'Resolve manager email from org-chart'
     plugin: aabenforms_manager_lookup
     configuration:
-      employee_id_token: '[webform_submission:values:employee_id:raw]'
-      fallback_email_token: '[webform_submission:values:manager_email:raw]'
+      employee_id_token: '[mileage_employee_id]'
+      fallback_email_token: ''
       result_token: mileage_expense_manager_email
     successors:
       -
@@ -62,8 +93,16 @@ actions:
     label: 'Forward expense claim to payroll'
     plugin: aabenforms_payroll_post
     configuration:
-      employee_id_token: '[webform_submission:values:employee_id:raw]'
+      employee_id_token: '[mileage_employee_id]'
       amount_token: '[webform_submission:values:amount:raw]'
       claim_type: mileage_expense
       result_token: mileage_expense_payroll_result
+    successors: {  }
+  deny_internal:
+    label: 'Deny: employee identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: mileage_expense_denied
+      step_label: 'Adgang afvist'
+      message: 'Udlaegget blev ikke behandlet, fordi det ikke kunne bekraeftes, at du er logget ind som medarbejder.'
     successors: {  }

--- a/config/sync/eca.eca.parent1_approval_flow.yml
+++ b/config/sync/eca.eca.parent1_approval_flow.yml
@@ -75,6 +75,7 @@ actions:
       event_type: parent1_approval
       additional_data_token: '[parent1_data:name]'
       message_template: 'Parent 1 authenticated and approved'
+      status_token: parent1_mitid_valid_status
     successors:
       -
         id: mark_parent1_complete

--- a/config/sync/eca.eca.parent2_approval_flow.yml
+++ b/config/sync/eca.eca.parent2_approval_flow.yml
@@ -75,6 +75,7 @@ actions:
       event_type: parent2_approval
       additional_data_token: '[parent2_data:name]'
       message_template: 'Parent 2 authenticated and approved'
+      status_token: parent2_mitid_valid_status
     successors:
       -
         id: mark_parent2_complete

--- a/config/sync/eca.eca.parent_dual_approval_working.yml
+++ b/config/sync/eca.eca.parent_dual_approval_working.yml
@@ -25,7 +25,43 @@ events:
       -
         id: parent2_mitid
         condition: ''
-conditions: {  }
+conditions:
+  gate_parent1_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[parent1_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parent1_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[parent1_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parent2_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[parent2_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parent2_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[parent2_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   parent1_mitid:
@@ -38,7 +74,10 @@ actions:
     successors:
       -
         id: parent1_cpr
-        condition: ''
+        condition: gate_parent1_mitid_ok
+      -
+        id: deny_parent1
+        condition: gate_parent1_mitid_deny
   parent1_cpr:
     label: 'Parent 1: CPR Lookup'
     plugin: aabenforms_cpr_lookup
@@ -82,7 +121,10 @@ actions:
     successors:
       -
         id: parent2_cpr
-        condition: ''
+        condition: gate_parent2_mitid_ok
+      -
+        id: deny_parent2
+        condition: gate_parent2_mitid_deny
   parent2_cpr:
     label: 'Parent 2: CPR Lookup'
     plugin: aabenforms_cpr_lookup
@@ -123,4 +165,20 @@ actions:
       event_type: caseworker_review
       additional_data_token: 'Both parents approved'
       message_template: 'Assigned to case worker for review'
+    successors: {  }
+  deny_parent1:
+    label: 'Deny: Parent 1 MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: parent1_denied
+      step_label: 'Foraelder 1: identitet ikke bekraeftet'
+      message: 'Foraelder 1s godkendelse blev ikke registreret, fordi identiteten ikke kunne bekraeftes med MitID.'
+    successors: {  }
+  deny_parent2:
+    label: 'Deny: Parent 2 MitID not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: parent2_denied
+      step_label: 'Foraelder 2: identitet ikke bekraeftet'
+      message: 'Foraelder 2s godkendelse blev ikke registreret, fordi identiteten ikke kunne bekraeftes med MitID.'
     successors: {  }

--- a/config/sync/eca.eca.parent_dual_approval_working.yml
+++ b/config/sync/eca.eca.parent_dual_approval_working.yml
@@ -57,6 +57,7 @@ actions:
       event_type: parent1_approval
       additional_data_token: '[parent1_data:name]'
       message_template: 'Parent 1 authenticated'
+      status_token: parent1_mitid_valid_status
     successors:
       -
         id: mark_parent1_complete
@@ -100,6 +101,7 @@ actions:
       event_type: parent2_approval
       additional_data_token: '[parent2_data:name]'
       message_template: 'Parent 2 authenticated'
+      status_token: parent2_mitid_valid_status
     successors:
       -
         id: mark_parent2_complete

--- a/config/sync/eca.eca.parking_permit_flow.yml
+++ b/config/sync/eca.eca.parking_permit_flow.yml
@@ -46,6 +46,7 @@ actions:
       event_type: parking_permit_submitted
       additional_data_token: ''
       message_template: 'Parking permit application received; CPR resolved.'
+      status_token: citizen_data_status
     successors:
       -
         id: send_confirmation

--- a/config/sync/webform.webform.med_election_ballot.yml
+++ b/config/sync/webform.webform.med_election_ballot.yml
@@ -1,0 +1,218 @@
+uuid: 7a6b8c9d-0e1f-2345-ef01-678901234599
+langcode: en
+status: open
+dependencies:
+  module:
+    - aabenforms_webform
+    - aabenforms_workflows
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: med_election_ballot
+title: 'MED Election Ballot'
+description: 'Voting form for a MED or workplace health-and-safety committee election. One ballot per eligible voter; identity is verified with MitID before the ballot is recorded.'
+categories: {  }
+elements: |
+  election_id:
+    '#type': textfield
+    '#title': 'Election ID'
+    '#required': true
+    '#description': 'Identifier of the election being voted in'
+  choice_index:
+    '#type': textfield
+    '#title': 'Candidate number'
+    '#required': true
+    '#description': 'The number of the candidate you are voting for, as shown on the ballot'
+  voter_cpr:
+    '#type': cpr_field
+    '#title': 'Your CPR number'
+    '#required': true
+    '#description': 'Used to confirm eligibility and prevent double voting. Auto-filled from MitID session in production.'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Your ballot has been recorded. Thank you for voting.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_core/aabenforms_core.install
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.install
@@ -131,6 +131,57 @@ function aabenforms_core_update_11001(): string {
 }
 
 /**
+ * Ensure the env-backed CPR encryption key and profile exist.
+ *
+ * The key.key.* and encrypt.profile.* configs are gitignored (they can hold
+ * secrets), so they are not deployed via config sync. This update creates
+ * them, configured to read the key material from the AABENFORMS_CPR_KEY
+ * environment variable - which must be set on the environment (base64 of 32
+ * random bytes). Idempotent: skips anything already present.
+ */
+function aabenforms_core_update_11002(): string {
+  $changes = [];
+
+  $key_storage = \Drupal::entityTypeManager()->getStorage('key');
+  if (!$key_storage->load('aabenforms_aes')) {
+    $key_storage->create([
+      'id' => 'aabenforms_aes',
+      'label' => 'AabenForms AES-256 Key',
+      'description' => 'CPR field encryption key, read from the AABENFORMS_CPR_KEY environment variable.',
+      'key_type' => 'encryption',
+      'key_type_settings' => ['key_size' => 256],
+      'key_provider' => 'env',
+      'key_provider_settings' => [
+        'env_variable' => 'AABENFORMS_CPR_KEY',
+        'base64_encoded' => TRUE,
+        'strip_line_breaks' => TRUE,
+      ],
+      'key_input' => 'none',
+      'key_input_settings' => [],
+    ])->save();
+    $changes[] = 'created key.key.aabenforms_aes (env provider)';
+  }
+
+  $profile_storage = \Drupal::entityTypeManager()->getStorage('encryption_profile');
+  if (!$profile_storage->load('aabenforms_aes256')) {
+    $profile_storage->create([
+      'id' => 'aabenforms_aes256',
+      'label' => 'AabenForms AES-256',
+      'encryption_method' => 'real_aes',
+      'encryption_method_configuration' => ['mode' => 'cbc'],
+      'encryption_key' => 'aabenforms_aes',
+    ])->save();
+    $changes[] = 'created encrypt.profile.aabenforms_aes256';
+  }
+
+  if (getenv('AABENFORMS_CPR_KEY') === FALSE || getenv('AABENFORMS_CPR_KEY') === '') {
+    $changes[] = 'WARNING: AABENFORMS_CPR_KEY is not set; CPR will not be encrypted until it is';
+  }
+
+  return $changes ? implode('; ', $changes) : 'no changes - key and profile already present';
+}
+
+/**
  * Implements hook_uninstall().
  */
 function aabenforms_core_uninstall(): void {

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -16,6 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
+use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Implements hook_help().
@@ -318,7 +319,7 @@ function aabenforms_core_page_attachments(array &$attachments): void {
  * hashing). Encryption is idempotent, so re-saving a submission does not
  * double-encrypt.
  */
-function aabenforms_core_webform_submission_presave(\Drupal\webform\WebformSubmissionInterface $submission): void {
+function aabenforms_core_webform_submission_presave(WebformSubmissionInterface $submission): void {
   $webform = $submission->getWebform();
   if ($webform === NULL) {
     return;

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -308,3 +308,36 @@ function aabenforms_core_page_attachments(array &$attachments): void {
     ];
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for webform_submission entities.
+ *
+ * Encrypts every cpr_field value before it is written to the database, so
+ * CPR numbers are not stored in plaintext at rest. The companion reveal()
+ * happens at the points of use (CPR lookup, Digital Post recipient, audit
+ * hashing). Encryption is idempotent, so re-saving a submission does not
+ * double-encrypt.
+ */
+function aabenforms_core_webform_submission_presave(\Drupal\webform\WebformSubmissionInterface $submission): void {
+  $webform = $submission->getWebform();
+  if ($webform === NULL) {
+    return;
+  }
+  /** @var \Drupal\aabenforms_core\Service\CprAccess $cprAccess */
+  $cprAccess = \Drupal::service('aabenforms_core.cpr_access');
+  foreach ($webform->getElementsInitializedAndFlattened() as $key => $element) {
+    // A field holds a CPR when it uses the cpr_field element, or - because
+    // several citizen forms use a plain textfield - when its key is "cpr" or
+    // ends in "_cpr" (cpr, child_cpr, applicant_cpr, partner1_cpr, ...).
+    $is_cpr = ($element['#type'] ?? '') === 'cpr_field'
+      || $key === 'cpr'
+      || str_ends_with($key, '_cpr');
+    if (!$is_cpr) {
+      continue;
+    }
+    $value = $submission->getElementData($key);
+    if (is_string($value) && $value !== '') {
+      $submission->setElementData($key, $cprAccess->protect($value));
+    }
+  }
+}

--- a/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
@@ -12,6 +12,13 @@ services:
     arguments:
       - '@encrypt.encryption_profile.manager'
       - '@key.repository'
+      - '@encryption'
+      - '@logger.factory'
+
+  aabenforms_core.cpr_access:
+    class: Drupal\aabenforms_core\Service\CprAccess
+    arguments:
+      - '@aabenforms_core.encryption_service'
       - '@logger.factory'
 
   aabenforms_core.audit_logger:

--- a/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
+++ b/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_core\Service;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Encrypts CPR values at rest and reveals them at the point of use.
+ *
+ * A single touchpoint so the rest of the system does not need to know the
+ * ciphertext format. Protected values carry a prefix, which makes the
+ * encrypt/reveal operations idempotent and lets reveal() pass through any
+ * value that is not encrypted (for example a CPR taken from a MitID session
+ * rather than a stored webform field).
+ */
+class CprAccess {
+
+  /**
+   * Marker prefixing an encrypted CPR so it can be recognised on read.
+   */
+  protected const PREFIX = 'AFENC1:';
+
+  /**
+   * The encryption service.
+   *
+   * @var \Drupal\aabenforms_core\Service\EncryptionService
+   */
+  protected EncryptionService $encryption;
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructs a CprAccess helper.
+   *
+   * @param \Drupal\aabenforms_core\Service\EncryptionService $encryption
+   *   The encryption service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct(EncryptionService $encryption, LoggerChannelFactoryInterface $logger_factory) {
+    $this->encryption = $encryption;
+    $this->logger = $logger_factory->get('aabenforms_core');
+  }
+
+  /**
+   * Whether a value is already an encrypted CPR.
+   *
+   * @param string $value
+   *   The value to test.
+   *
+   * @return bool
+   *   TRUE if the value carries the encryption prefix.
+   */
+  public function isProtected(string $value): bool {
+    return str_starts_with($value, self::PREFIX);
+  }
+
+  /**
+   * Returns an encrypted, storage-safe representation of a CPR.
+   *
+   * Idempotent: an already-encrypted or empty value is returned unchanged.
+   *
+   * @param string $cpr
+   *   The plaintext CPR.
+   *
+   * @return string
+   *   The prefixed ciphertext, or the original value if empty/already
+   *   protected, or - if encryption is misconfigured - the original value
+   *   with an error logged (so a submission is never lost).
+   */
+  public function protect(string $cpr): string {
+    if ($cpr === '' || $this->isProtected($cpr)) {
+      return $cpr;
+    }
+    try {
+      return self::PREFIX . base64_encode($this->encryption->encrypt($cpr));
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('CPR encryption failed; value stored unencrypted: {error}', ['error' => $e->getMessage()]);
+      return $cpr;
+    }
+  }
+
+  /**
+   * Returns the plaintext CPR for a value, decrypting if necessary.
+   *
+   * A value without the encryption prefix is returned unchanged, so callers
+   * can pass session-sourced or already-plaintext CPRs through safely.
+   *
+   * @param string $value
+   *   The stored value.
+   *
+   * @return string
+   *   The plaintext CPR, or '' if decryption fails.
+   */
+  public function reveal(string $value): string {
+    if (!$this->isProtected($value)) {
+      return $value;
+    }
+    try {
+      return $this->encryption->decrypt(base64_decode(substr($value, strlen(self::PREFIX))));
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('CPR decryption failed: {error}', ['error' => $e->getMessage()]);
+      return '';
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Service/EncryptionService.php
+++ b/web/modules/custom/aabenforms_core/src/Service/EncryptionService.php
@@ -4,6 +4,7 @@ namespace Drupal\aabenforms_core\Service;
 
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\encrypt\EncryptionProfileManagerInterface;
+use Drupal\encrypt\EncryptServiceInterface;
 use Drupal\key\KeyRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
@@ -42,6 +43,13 @@ class EncryptionService {
   protected KeyRepositoryInterface $keyRepository;
 
   /**
+   * The encrypt service.
+   *
+   * @var \Drupal\encrypt\EncryptServiceInterface
+   */
+  protected EncryptServiceInterface $encryptService;
+
+  /**
    * The logger.
    *
    * @var \Psr\Log\LoggerInterface
@@ -55,16 +63,20 @@ class EncryptionService {
    *   The encryption profile manager.
    * @param \Drupal\key\KeyRepositoryInterface $key_repository
    *   The key repository.
+   * @param \Drupal\encrypt\EncryptServiceInterface $encrypt_service
+   *   The encrypt service that performs encrypt/decrypt with a profile.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
    */
   public function __construct(
     EncryptionProfileManagerInterface $profile_manager,
     KeyRepositoryInterface $key_repository,
+    EncryptServiceInterface $encrypt_service,
     LoggerChannelFactoryInterface $logger_factory,
   ) {
     $this->profileManager = $profile_manager;
     $this->keyRepository = $key_repository;
+    $this->encryptService = $encrypt_service;
     $this->logger = $logger_factory->get('aabenforms_core');
   }
 
@@ -92,7 +104,7 @@ class EncryptionService {
         throw new \RuntimeException("Encryption profile '{$profile_id}' not found.");
       }
 
-      $encrypted = $profile->encrypt($plaintext);
+      $encrypted = $this->encryptService->encrypt($plaintext, $profile);
 
       $this->logger->debug('Encrypted data using profile: {profile}', [
         'profile' => $profile_id,
@@ -136,7 +148,7 @@ class EncryptionService {
         throw new \RuntimeException("Encryption profile '{$profile_id}' not found.");
       }
 
-      $plaintext = $profile->decrypt($encrypted);
+      $plaintext = $this->encryptService->decrypt($encrypted, $profile);
 
       $this->logger->debug('Decrypted data using profile: {profile}', [
         'profile' => $profile_id,

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit\Service;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_core\Service\EncryptionService;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the CprAccess helper.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_core\Service\CprAccess
+ * @group aabenforms_core
+ * @group encryption
+ */
+class CprAccessTest extends UnitTestCase {
+
+  /**
+   * Mock encryption service.
+   *
+   * @var \Drupal\aabenforms_core\Service\EncryptionService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $encryption;
+
+  /**
+   * The helper under test.
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->encryption = $this->getMockBuilder(EncryptionService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['encrypt', 'decrypt'])
+      ->getMock();
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+
+    $this->cprAccess = new CprAccess($this->encryption, $loggerFactory);
+  }
+
+  /**
+   * Protect produces a prefixed ciphertext that is not the plaintext.
+   *
+   * @covers ::protect
+   * @covers ::isProtected
+   */
+  public function testProtect(): void {
+    $this->encryption->method('encrypt')->willReturn('CIPHERBYTES');
+    $protected = $this->cprAccess->protect('0101901234');
+
+    $this->assertNotSame('0101901234', $protected);
+    $this->assertTrue($this->cprAccess->isProtected($protected));
+    $this->assertStringStartsWith('AFENC1:', $protected);
+  }
+
+  /**
+   * Protect is idempotent and a no-op on empty input.
+   *
+   * @covers ::protect
+   */
+  public function testProtectIdempotentAndEmpty(): void {
+    $this->encryption->expects($this->once())->method('encrypt')->willReturn('CIPHERBYTES');
+    $protected = $this->cprAccess->protect('0101901234');
+    // Second call must not encrypt again.
+    $this->assertSame($protected, $this->cprAccess->protect($protected));
+    $this->assertSame('', $this->cprAccess->protect(''));
+  }
+
+  /**
+   * Reveal decrypts a protected value and passes plaintext through.
+   *
+   * @covers ::reveal
+   */
+  public function testReveal(): void {
+    $this->encryption->method('encrypt')->willReturn('CIPHERBYTES');
+    $this->encryption->method('decrypt')->with('CIPHERBYTES')->willReturn('0101901234');
+
+    $protected = $this->cprAccess->protect('0101901234');
+    $this->assertSame('0101901234', $this->cprAccess->reveal($protected));
+    // A non-protected value (e.g. session-sourced CPR) passes through.
+    $this->assertSame('0101901234', $this->cprAccess->reveal('0101901234'));
+  }
+
+  /**
+   * A misconfigured key never silently corrupts: protect keeps the value.
+   *
+   * @covers ::protect
+   */
+  public function testProtectFailsSafe(): void {
+    $this->encryption->method('encrypt')->willThrowException(new \RuntimeException('no key'));
+    $this->assertSame('0101901234', $this->cprAccess->protect('0101901234'));
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/EncryptionServiceTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/EncryptionServiceTest.php
@@ -4,7 +4,9 @@ namespace Drupal\Tests\aabenforms_core\Unit\Service;
 
 use Drupal\aabenforms_core\Service\EncryptionService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\encrypt\EncryptionProfileInterface;
 use Drupal\encrypt\EncryptionProfileManagerInterface;
+use Drupal\encrypt\EncryptServiceInterface;
 use Drupal\key\KeyRepositoryInterface;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
@@ -33,11 +35,11 @@ class EncryptionServiceTest extends UnitTestCase {
   protected $profileManager;
 
   /**
-   * Mock key repository.
+   * Mock encrypt service.
    *
-   * @var \Drupal\key\KeyRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\encrypt\EncryptServiceInterface|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $keyRepository;
+  protected $encryptService;
 
   /**
    * Mock logger.
@@ -52,377 +54,168 @@ class EncryptionServiceTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    // Mock dependencies.
     $this->profileManager = $this->createMock(EncryptionProfileManagerInterface::class);
-    $this->keyRepository = $this->createMock(KeyRepositoryInterface::class);
+    $keyRepository = $this->createMock(KeyRepositoryInterface::class);
+    $this->encryptService = $this->createMock(EncryptServiceInterface::class);
     $this->logger = $this->createMock(LoggerInterface::class);
 
     $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
-    $loggerFactory->method('get')
-      ->with('aabenforms_core')
-      ->willReturn($this->logger);
+    $loggerFactory->method('get')->with('aabenforms_core')->willReturn($this->logger);
 
-    // Create service.
     $this->encryptionService = new EncryptionService(
       $this->profileManager,
-      $this->keyRepository,
+      $keyRepository,
+      $this->encryptService,
       $loggerFactory
     );
   }
 
   /**
-   * Helper to create simple mock profile with encrypt/decrypt.
+   * Returns a dummy encryption profile.
    *
-   * @param string $encryptReturn
-   *   Value to return from encrypt().
-   * @param string $decryptReturn
-   *   Value to return from decrypt().
-   * @param bool $throwOnEncrypt
-   *   Whether to throw exception on encrypt().
-   * @param bool $throwOnDecrypt
-   *   Whether to throw exception on decrypt().
-   *
-   * @return object
-   *   Mock profile object.
+   * @return \Drupal\encrypt\EncryptionProfileInterface
+   *   A mocked profile, only used as a pass-through argument.
    */
-  protected function createSimpleMockProfile(
-    string $encryptReturn = '',
-    string $decryptReturn = '',
-    bool $throwOnEncrypt = FALSE,
-    bool $throwOnDecrypt = FALSE,
-  ) {
-    return new class($encryptReturn, $decryptReturn, $throwOnEncrypt, $throwOnDecrypt) {
-
-      /**
-       * Constructor.
-       */
-      public function __construct(
-        public string $encryptReturn,
-        public string $decryptReturn,
-        public bool $throwOnEncrypt,
-        public bool $throwOnDecrypt,
-      ) {}
-
-      /**
-       * Mock encrypt method.
-       */
-      public function encrypt(string $text): string {
-        if ($this->throwOnEncrypt) {
-          throw new \Exception('Encryption provider error');
-        }
-        return $this->encryptReturn;
-      }
-
-      /**
-       * Mock decrypt method.
-       */
-      public function decrypt(string $text): string {
-        if ($this->throwOnDecrypt) {
-          throw new \Exception('Decryption provider error');
-        }
-        return $this->decryptReturn;
-      }
-
-    };
+  protected function dummyProfile(): EncryptionProfileInterface {
+    return $this->createMock(EncryptionProfileInterface::class);
   }
 
   /**
-   * Tests encrypt with default profile.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithDefaultProfile(): void {
-    $plaintext = 'sensitive data';
-    $encrypted = 'base64_encrypted_data';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('aabenforms_aes256')
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('aabenforms_aes256')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('base64_encrypted_data');
 
-    $result = $this->encryptionService->encrypt($plaintext);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('base64_encrypted_data', $this->encryptionService->encrypt('sensitive data'));
   }
 
   /**
-   * Tests encrypt with custom profile.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithCustomProfile(): void {
-    $plaintext = '0101001234';
-    $encrypted = 'custom_encrypted';
-    $customProfile = 'custom_aes_profile';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with($customProfile)
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('custom_aes_profile')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('custom_encrypted');
 
-    $result = $this->encryptionService->encrypt($plaintext, $customProfile);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('custom_encrypted', $this->encryptionService->encrypt('0101001234', 'custom_aes_profile'));
   }
 
   /**
-   * Tests encrypt with profile not found.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithProfileNotFound(): void {
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('nonexistent_profile')
-      ->willReturn(NULL);
+      ->method('getEncryptionProfile')->with('nonexistent_profile')->willReturn(NULL);
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage("Encryption profile 'nonexistent_profile' not found");
-
     $this->encryptionService->encrypt('data', 'nonexistent_profile');
   }
 
   /**
-   * Tests encrypt with encryption failure.
-   *
    * @covers ::encrypt
    */
   public function testEncryptWithEncryptionFailure(): void {
-    $profile = $this->createSimpleMockProfile('', '', TRUE, FALSE);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willThrowException(new \Exception('provider error'));
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Failed to encrypt data');
-
     $this->encryptionService->encrypt('data');
   }
 
   /**
-   * Tests decrypt with default profile.
-   *
    * @covers ::decrypt
    */
   public function testDecryptWithDefaultProfile(): void {
-    $encrypted = 'base64_encrypted_data';
-    $plaintext = 'sensitive data';
-
-    $profile = $this->createSimpleMockProfile('', $plaintext);
-
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('aabenforms_aes256')
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('aabenforms_aes256')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('decrypt')->willReturn('sensitive data');
 
-    $result = $this->encryptionService->decrypt($encrypted);
-
-    $this->assertEquals($plaintext, $result);
+    $this->assertEquals('sensitive data', $this->encryptionService->decrypt('base64_encrypted_data'));
   }
 
   /**
-   * Tests decrypt with custom profile.
-   *
-   * @covers ::decrypt
-   */
-  public function testDecryptWithCustomProfile(): void {
-    $encrypted = 'custom_encrypted';
-    $plaintext = '0101001234';
-    $customProfile = 'custom_aes_profile';
-
-    $profile = $this->createSimpleMockProfile('', $plaintext);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with($customProfile)
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->decrypt($encrypted, $customProfile);
-
-    $this->assertEquals($plaintext, $result);
-  }
-
-  /**
-   * Tests decrypt with profile not found.
-   *
    * @covers ::decrypt
    */
   public function testDecryptWithProfileNotFound(): void {
     $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->with('nonexistent_profile')
-      ->willReturn(NULL);
+      ->method('getEncryptionProfile')->with('nonexistent_profile')->willReturn(NULL);
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage("Encryption profile 'nonexistent_profile' not found");
-
     $this->encryptionService->decrypt('encrypted', 'nonexistent_profile');
   }
 
   /**
-   * Tests decrypt with decryption failure.
-   *
    * @covers ::decrypt
    */
   public function testDecryptWithDecryptionFailure(): void {
-    $profile = $this->createSimpleMockProfile('', '', FALSE, TRUE);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('decrypt')->willThrowException(new \Exception('provider error'));
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Failed to decrypt data');
-
     $this->encryptionService->decrypt('corrupted_data');
   }
 
   /**
-   * Tests encryption/decryption round-trip.
-   *
    * @covers ::encrypt
    * @covers ::decrypt
    */
   public function testEncryptDecryptRoundTrip(): void {
-    $plaintext = '0101001234';
-    $encrypted = 'mock_encrypted_value';
-
-    // Use same profile for both operations.
-    $profile = $this->createSimpleMockProfile($encrypted, $plaintext);
-
     $this->profileManager->expects($this->exactly(2))
-      ->method('getEncryptionProfile')
-      ->with('aabenforms_aes256')
-      ->willReturn($profile);
+      ->method('getEncryptionProfile')->with('aabenforms_aes256')
+      ->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('mock_encrypted_value');
+    $this->encryptService->method('decrypt')->willReturn('0101001234');
 
-    // Encrypt.
-    $encryptedResult = $this->encryptionService->encrypt($plaintext);
-    $this->assertEquals($encrypted, $encryptedResult);
-
-    // Decrypt.
-    $decryptedResult = $this->encryptionService->decrypt($encryptedResult);
-    $this->assertEquals($plaintext, $decryptedResult);
+    $encrypted = $this->encryptionService->encrypt('0101001234');
+    $this->assertEquals('mock_encrypted_value', $encrypted);
+    $this->assertEquals('0101001234', $this->encryptionService->decrypt($encrypted));
   }
 
   /**
-   * Tests encryptCpr with valid CPR.
-   *
    * @covers ::encryptCpr
    */
   public function testEncryptCprWithValidCpr(): void {
-    $cpr = '0101001234';
-    $encrypted = 'encrypted_cpr';
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('encrypt')->willReturn('encrypted_cpr');
 
-    $profile = $this->createSimpleMockProfile($encrypted);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->encryptCpr($cpr);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('encrypted_cpr', $this->encryptionService->encryptCpr('0101001234'));
   }
 
   /**
-   * Tests encryptCpr with invalid CPR (too short).
-   *
    * @covers ::encryptCpr
    */
   public function testEncryptCprWithInvalidCprTooShort(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Invalid CPR number format');
-
     $this->encryptionService->encryptCpr('010100123');
   }
 
   /**
-   * Tests encryptCpr with invalid CPR (too long).
-   *
-   * @covers ::encryptCpr
-   */
-  public function testEncryptCprWithInvalidCprTooLong(): void {
-    $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('Invalid CPR number format');
-
-    $this->encryptionService->encryptCpr('01010012345');
-  }
-
-  /**
-   * Tests encryptCpr with invalid CPR (non-numeric).
-   *
    * @covers ::encryptCpr
    */
   public function testEncryptCprWithInvalidCprNonNumeric(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Invalid CPR number format');
-
     $this->encryptionService->encryptCpr('010100-123');
   }
 
   /**
-   * Tests decryptCpr.
-   *
    * @covers ::decryptCpr
    */
   public function testDecryptCpr(): void {
-    $encrypted = 'encrypted_cpr';
-    $cpr = '0101001234';
+    $this->profileManager->method('getEncryptionProfile')->willReturn($this->dummyProfile());
+    $this->encryptService->method('decrypt')->willReturn('0101001234');
 
-    $profile = $this->createSimpleMockProfile('', $cpr);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->decryptCpr($encrypted);
-
-    $this->assertEquals($cpr, $result);
-  }
-
-  /**
-   * Tests encrypt with empty string.
-   *
-   * @covers ::encrypt
-   */
-  public function testEncryptEmptyString(): void {
-    $plaintext = '';
-    $encrypted = 'encrypted_empty';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->encrypt($plaintext);
-
-    $this->assertEquals($encrypted, $result);
-  }
-
-  /**
-   * Tests encrypt with long string.
-   *
-   * @covers ::encrypt
-   */
-  public function testEncryptLongString(): void {
-    $plaintext = str_repeat('Lorem ipsum dolor sit amet, ', 100);
-    $encrypted = 'encrypted_long_text';
-
-    $profile = $this->createSimpleMockProfile($encrypted);
-
-    $this->profileManager->expects($this->once())
-      ->method('getEncryptionProfile')
-      ->willReturn($profile);
-
-    $result = $this->encryptionService->encrypt($plaintext);
-
-    $this->assertEquals($encrypted, $result);
+    $this->assertEquals('0101001234', $this->encryptionService->decryptCpr('encrypted_cpr'));
   }
 
 }

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -7,6 +7,7 @@ namespace Drupal\aabenforms_digital_post_eca\Plugin\Action;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
 use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface;
 use Drupal\aabenforms_workflows\Plugin\Action\AabenFormsActionBase;
 use Drupal\Core\Action\Attribute\Action;
@@ -54,13 +55,30 @@ class SendDigitalPostAction extends AabenFormsActionBase {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->setSender($container->get('aabenforms_digital_post.sender'));
     $instance->setConfigFactory($container->get('config.factory'));
+    $instance->setCprAccess($container->get('aabenforms_core.cpr_access'));
     return $instance;
+  }
+
+  /**
+   * Setter injection for the CPR access helper.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setCprAccess(CprAccess $cprAccess): void {
+    $this->cprAccess = $cprAccess;
   }
 
   /**
@@ -184,6 +202,12 @@ class SendDigitalPostAction extends AabenFormsActionBase {
   public function execute(): void {
     $recipientRaw = $this->resolveRecipient();
     $recipientType = (string) $this->configuration['recipient_type'];
+
+    // A CPR recipient read from a stored webform field is encrypted at rest;
+    // decrypt it before addressing the Digital Post. CVR is not encrypted.
+    if ($recipientType === Recipient::TYPE_CPR) {
+      $recipientRaw = $this->cprAccess->reveal($recipientRaw);
+    }
 
     if ($recipientRaw === '') {
       $this->recordStep(

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -103,6 +103,10 @@ class SendDigitalPostActionTest extends UnitTestCase {
     $action->setSender($this->sender);
     $action->setConfigFactory($this->configFactory);
     $action->setExecutionCollector($this->executionCollector);
+    // CPR access helper: reveal is a pass-through for these tests.
+    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $action->setCprAccess($cprAccess);
     return $action;
   }
 

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\aabenforms_digital_post_eca\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
@@ -104,7 +105,7 @@ class SendDigitalPostActionTest extends UnitTestCase {
     $action->setConfigFactory($this->configFactory);
     $action->setExecutionCollector($this->executionCollector);
     // CPR access helper: reveal is a pass-through for these tests.
-    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess = $this->createMock(CprAccess::class);
     $cprAccess->method('reveal')->willReturnArgument(0);
     $action->setCprAccess($cprAccess);
     return $action;

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -83,6 +83,40 @@ function aabenforms_workflows_mail(string $key, array &$message, array $params):
         '@sid' => $params['submission_id'],
       ]);
       break;
+
+    case 'foi_acknowledgement':
+      $message['subject'] = t('Modtaget: din anmodning om aktindsigt (@ref)', [
+        '@ref' => $params['reference'],
+      ]);
+      $message['body'][] = t('Kaere @name,', ['@name' => $params['requester_name']]);
+      $message['body'][] = '';
+      $message['body'][] = t('Vi har modtaget din anmodning om aktindsigt. Din sag har referencenummer @ref.', [
+        '@ref' => $params['reference'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Kommunen skal efter offentlighedsloven besvare din anmodning hurtigst muligt og som udgangspunkt inden 7 arbejdsdage. Forventet svardato er @due.', [
+        '@due' => $params['due_date'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Du modtager svar pa denne e-mailadresse.');
+      break;
+
+    case 'foi_caseworker_notification':
+      $message['subject'] = t('Ny anmodning om aktindsigt (@ref)', [
+        '@ref' => $params['reference'],
+      ]);
+      $message['body'][] = t('En ny anmodning om aktindsigt er modtaget og skal behandles.');
+      $message['body'][] = '';
+      $message['body'][] = t('Reference: @ref', ['@ref' => $params['reference']]);
+      $message['body'][] = t('Frist: @due (7 arbejdsdage)', ['@due' => $params['due_date']]);
+      $message['body'][] = t('Anmoder: @name (@email)', [
+        '@name' => $params['requester_name'],
+        '@email' => $params['requester_email'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Anmodning:');
+      $message['body'][] = $params['request_text'];
+      break;
   }
 }
 

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -65,11 +65,13 @@ services:
     arguments:
       - '@logger.factory'
 
-  # Stub default for the org-chart lookup. A real LDAP/AD/HR-system
+  # Directory-backed org-chart lookup, sourced from the
+  # aabenforms_workflows.org_chart config. A real LDAP/AD/HR-system
   # integration replaces this via service decoration without touching
   # the action plugin.
   aabenforms_workflows.org_chart:
-    class: Drupal\aabenforms_workflows\Service\StubOrgChartService
+    class: Drupal\aabenforms_workflows\Service\ConfigOrgChartService
+    arguments: ['@config.factory']
 
   # MED voting service: window open/close, ballot recording (with
   # CPR-hash uniqueness), tabulation. Used by the cron-driven ECA flow

--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -121,3 +121,6 @@ aabenforms_workflows.settings:
     allow_cpr_demo_mode:
       type: boolean
       label: 'Force CPR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'
+    allow_cvr_demo_mode:
+      type: boolean
+      label: 'Force CVR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'

--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -124,3 +124,32 @@ aabenforms_workflows.settings:
     allow_cvr_demo_mode:
       type: boolean
       label: 'Force CVR lookup to run in demo mode (otherwise auto-detected when no Serviceplatformen certificate is configured)'
+
+# Directory used to resolve managers, policy limits, and the account-to-
+# employee binding for internal and HR flows.
+aabenforms_workflows.org_chart:
+  type: config_object
+  label: 'Org chart directory'
+  mapping:
+    default_tier_limit_cents:
+      type: integer
+      label: 'Default per-claim limit in cents'
+    employees:
+      type: sequence
+      label: 'Employees keyed by employee id'
+      sequence:
+        type: mapping
+        label: 'Employee'
+        mapping:
+          name:
+            type: label
+            label: 'Name'
+          account_name:
+            type: string
+            label: 'Drupal account name bound to this employee'
+          manager_email:
+            type: email
+            label: 'Manager email'
+          tier_limit_cents:
+            type: integer
+            label: 'Per-claim limit in cents'

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
@@ -3,6 +3,7 @@
 namespace Drupal\aabenforms_workflows\Plugin\Action;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -31,11 +32,19 @@ class AuditLogAction extends AabenFormsActionBase {
   protected AuditLogger $auditLogger;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
     return $instance;
   }
 
@@ -145,6 +154,8 @@ class AuditLogAction extends AabenFormsActionBase {
       $cpr = NULL;
       if (!empty($this->configuration['cpr_token'])) {
         $cpr = $this->getTokenValue($this->configuration['cpr_token'], '');
+        // Decrypt if stored encrypted at rest before hashing for the audit.
+        $cpr = $this->cprAccess->reveal((string) $cpr);
         if ($cpr) {
           $cpr = preg_replace('/[^0-9]/', '', $cpr);
         }

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/AuditLogAction.php
@@ -48,6 +48,8 @@ class AuditLogAction extends AabenFormsActionBase {
       'cpr_token' => 'cpr',
       'message_template' => 'Workflow action executed',
       'additional_data_token' => '',
+      'status' => 'success',
+      'status_token' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -93,6 +95,26 @@ class AuditLogAction extends AabenFormsActionBase {
       '#default_value' => $this->configuration['additional_data_token'],
     ];
 
+    $form['status_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Status token'),
+      '#description' => $this->t('Optional token whose value determines the logged status. A prior step result such as <code>citizen_data_status</code> or <code>citizen_mitid_valid_status</code>. Values like found/verified/match/completed map to success; denied maps to denied; anything else (not_found, failed, error) maps to failure. Leave empty to use the fixed status below.'),
+      '#default_value' => $this->configuration['status_token'],
+    ];
+
+    $form['status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Status'),
+      '#description' => $this->t('Status to log when no status token is configured.'),
+      '#options' => [
+        'success' => $this->t('Success'),
+        'failure' => $this->t('Failure'),
+        'denied' => $this->t('Denied'),
+        'skipped' => $this->t('Skipped'),
+      ],
+      '#default_value' => $this->configuration['status'],
+    ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -104,6 +126,8 @@ class AuditLogAction extends AabenFormsActionBase {
     $this->configuration['cpr_token'] = $form_state->getValue('cpr_token');
     $this->configuration['message_template'] = $form_state->getValue('message_template');
     $this->configuration['additional_data_token'] = $form_state->getValue('additional_data_token');
+    $this->configuration['status_token'] = $form_state->getValue('status_token');
+    $this->configuration['status'] = $form_state->getValue('status');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -141,13 +165,17 @@ class AuditLogAction extends AabenFormsActionBase {
         }
       }
 
+      // Derive the status from the real outcome of a prior step rather than
+      // always recording success. This is what keeps the audit trail honest.
+      $status = $this->resolveStatus();
+
       // Create audit log entry.
       if ($cpr && $eventType === 'cpr_access') {
         $this->auditLogger->log(
           'cpr_access',
           $cpr,
           'workflow_action',
-          'success',
+          $status,
           array_merge(['message' => $message], $additionalData)
         );
       }
@@ -156,13 +184,14 @@ class AuditLogAction extends AabenFormsActionBase {
           $eventType,
           $cpr ?? 'system',
           $message,
-          'success',
+          $status,
           array_merge(['action_id' => $this->getPluginId()], $additionalData)
         );
       }
 
-      $this->log('Audit log entry created: {type}', [
+      $this->log('Audit log entry created: {type} ({status})', [
         'type' => $eventType,
+        'status' => $status,
       ]);
       $this->recordStep('GDPR Audit Trail', 'Audit log entry created for regulatory compliance');
 
@@ -170,6 +199,53 @@ class AuditLogAction extends AabenFormsActionBase {
     catch (\Exception $e) {
       $this->handleError($e, 'Creating audit log entry');
     }
+  }
+
+  /**
+   * Resolves the status to log.
+   *
+   * When a status token is configured, the real outcome of the prior step is
+   * read and normalised; otherwise the configured fixed status is used. This
+   * stops the audit log from recording success for a step that failed or was
+   * never verified.
+   *
+   * @return string
+   *   One of 'success', 'failure', 'denied' or 'skipped'.
+   */
+  protected function resolveStatus(): string {
+    $statusToken = (string) ($this->configuration['status_token'] ?? '');
+    if ($statusToken !== '') {
+      $raw = $this->getTokenValue($statusToken, '');
+      if ($raw !== '') {
+        return $this->normalizeStatus($raw);
+      }
+    }
+    $fixed = (string) ($this->configuration['status'] ?? 'success');
+    return $fixed !== '' ? $this->normalizeStatus($fixed) : 'success';
+  }
+
+  /**
+   * Maps a raw status marker to the audit-log vocabulary.
+   *
+   * @param string $raw
+   *   The raw status from a result token or config (for example 'found',
+   *   'verified', 'match', 'not_found', 'failed', 'denied').
+   *
+   * @return string
+   *   One of 'success', 'failure', 'denied' or 'skipped'.
+   */
+  protected function normalizeStatus(string $raw): string {
+    $value = strtolower(trim($raw));
+    if (in_array($value, ['success', 'completed', 'found', 'verified', 'match', 'true', '1', 'ok'], TRUE)) {
+      return 'success';
+    }
+    if ($value === 'denied') {
+      return 'denied';
+    }
+    if ($value === 'skipped') {
+      return 'skipped';
+    }
+    return 'failure';
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_workflows\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -39,12 +40,20 @@ class CprLookupAction extends AabenFormsActionBase {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->serviceplatformenClient = $container->get('aabenforms_core.serviceplatformen_client');
     $instance->configFactory = $container->get('config.factory');
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
     return $instance;
   }
 
@@ -119,6 +128,10 @@ class CprLookupAction extends AabenFormsActionBase {
    */
   public function execute(): void {
     $cpr = $this->getTokenValue($this->configuration['cpr_token'], '');
+
+    // Decrypt if the CPR was stored encrypted at rest (webform fields); a
+    // session-sourced or plaintext CPR passes through unchanged.
+    $cpr = $this->cprAccess->reveal((string) $cpr);
 
     // Clean CPR (remove hyphens/spaces).
     $cpr = $cpr ? preg_replace('/[^0-9]/', '', $cpr) : '';

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CprLookupAction.php
@@ -126,6 +126,7 @@ class CprLookupAction extends AabenFormsActionBase {
     if (empty($cpr)) {
       $this->log('CPR lookup skipped: no CPR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('skipped');
       $this->recordStep('CPR Registry Lookup', 'Skipped - no CPR available to look up', 'skipped');
       return;
     }
@@ -140,6 +141,7 @@ class CprLookupAction extends AabenFormsActionBase {
         'demo' => TRUE,
       ];
       $this->setTokenValue($this->configuration['result_token'], $demoPerson);
+      $this->setResultStatus('found');
       $this->log('CPR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
       $this->recordStep('CPR Registry Lookup', 'Demo: CPR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
       return;
@@ -168,6 +170,7 @@ class CprLookupAction extends AabenFormsActionBase {
           'cpr' => substr($cpr, 0, 6) . 'XXXX',
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
+        $this->setResultStatus('not_found');
         $this->recordStep('CPR Registry Lookup', 'No person found in the national CPR registry (SF1520)', 'failed');
         return;
       }
@@ -177,6 +180,7 @@ class CprLookupAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], $personData);
+      $this->setResultStatus('found');
       $this->recordStep('CPR Registry Lookup', 'Personal data retrieved from the national CPR registry (SF1520)');
 
     }
@@ -185,7 +189,26 @@ class CprLookupAction extends AabenFormsActionBase {
       // cURL/SSL/Serviceplatformen error to the citizen.
       $this->log('CPR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('error');
       $this->recordStep('CPR Registry Lookup', 'CPR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
+    }
+  }
+
+  /**
+   * Writes an explicit scalar status companion token for downstream gating.
+   *
+   * The result_token holds the person array (or NULL); ECA conditions and the
+   * audit action read this `<result_token>_status` scalar (`found`,
+   * `not_found`, `skipped` or `error`) because comparing an array or NULL
+   * token is unreliable.
+   *
+   * @param string $status
+   *   One of 'found', 'not_found', 'skipped' or 'error'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
@@ -126,6 +126,7 @@ class CvrLookupAction extends AabenFormsActionBase {
     if (empty($cvr)) {
       $this->log('CVR lookup skipped: no CVR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('skipped');
       $this->recordStep('CVR Registry Lookup', 'Skipped - no CVR available to look up', 'skipped');
       return;
     }
@@ -140,6 +141,7 @@ class CvrLookupAction extends AabenFormsActionBase {
         'demo' => TRUE,
       ];
       $this->setTokenValue($this->configuration['result_token'], $demoCompany);
+      $this->setResultStatus('found');
       $this->log('CVR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
       $this->recordStep('CVR Registry Lookup', 'Demo: CVR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
       return;
@@ -170,6 +172,7 @@ class CvrLookupAction extends AabenFormsActionBase {
           'cvr' => $cvr,
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
+        $this->setResultStatus('not_found');
         $this->recordStep('CVR Registry Lookup', 'No company found in the central business registry (SF1530)', 'failed');
         return;
       }
@@ -179,6 +182,7 @@ class CvrLookupAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], $companyData);
+      $this->setResultStatus('found');
       $this->recordStep('CVR Registry Lookup', 'Company data retrieved from the central business registry (SF1530)');
 
     }
@@ -187,7 +191,26 @@ class CvrLookupAction extends AabenFormsActionBase {
       // cURL/SSL/Serviceplatformen error to the citizen.
       $this->log('CVR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('error');
       $this->recordStep('CVR Registry Lookup', 'CVR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
+    }
+  }
+
+  /**
+   * Writes an explicit scalar status companion token for downstream gating.
+   *
+   * The result_token holds the company array (or NULL); ECA conditions and the
+   * audit action read this `<result_token>_status` scalar (`found`,
+   * `not_found`, `skipped` or `error`) because comparing an array or NULL
+   * token is unreliable.
+   *
+   * @param string $status
+   *   One of 'found', 'not_found', 'skipped' or 'error'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CvrLookupAction.php
@@ -4,6 +4,7 @@ namespace Drupal\aabenforms_workflows\Plugin\Action;
 
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\eca\Attribute\EcaAction;
@@ -31,12 +32,35 @@ class CvrLookupAction extends AabenFormsActionBase {
   protected ServiceplatformenClient $serviceplatformenClient;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->serviceplatformenClient = $container->get('aabenforms_core.serviceplatformen_client');
+    $instance->configFactory = $container->get('config.factory');
     return $instance;
+  }
+
+  /**
+   * Whether to run CVR lookup in demo mode (no real Serviceplatformen call).
+   *
+   * True when the demo flag is set, or - the common case for a POC - when no
+   * Serviceplatformen client certificate is provisioned. Once a certificate is
+   * configured, real SF1530 lookups resume automatically.
+   */
+  protected function demoModeAllowed(): bool {
+    if ($this->configFactory->get('aabenforms_workflows.settings')->get('allow_cvr_demo_mode')) {
+      return TRUE;
+    }
+    $certs = $this->configFactory->get('aabenforms_core.settings')->get('serviceplatformen.certificates') ?? [];
+    return empty($certs['cert_path']) && empty($certs['key_path']);
   }
 
   /**
@@ -96,14 +120,30 @@ class CvrLookupAction extends AabenFormsActionBase {
   public function execute(): void {
     $cvr = $this->getTokenValue($this->configuration['cvr_token'], '');
 
+    // Clean CVR (remove spaces/hyphens).
+    $cvr = $cvr ? preg_replace('/[^0-9]/', '', $cvr) : '';
+
     if (empty($cvr)) {
-      $this->log('CVR lookup failed: No CVR number provided', [], 'warning');
+      $this->log('CVR lookup skipped: no CVR available to look up', [], 'warning');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->recordStep('CVR Registry Lookup', 'Skipped - no CVR available to look up', 'skipped');
       return;
     }
 
-    // Clean CVR (remove spaces/hyphens).
-    $cvr = preg_replace('/[^0-9]/', '', $cvr);
+    if ($this->demoModeAllowed()) {
+      // No Serviceplatformen certificate is provisioned (the POC case). Do not
+      // call SF1530; record an honest, clearly-labelled demo step with test
+      // data so the flow continues without surfacing a connection error.
+      $demoCompany = [
+        'cvr' => $cvr,
+        'name' => 'Demovirksomhed ApS (testdata)',
+        'demo' => TRUE,
+      ];
+      $this->setTokenValue($this->configuration['result_token'], $demoCompany);
+      $this->log('CVR lookup ran in demo mode (no Serviceplatformen certificate).', [], 'info');
+      $this->recordStep('CVR Registry Lookup', 'Demo: CVR-opslag simuleret med testdata. Rigtige Serviceplatformen-opslag kraever klientcertifikat.', 'completed');
+      return;
+    }
 
     try {
       $this->log('Performing CVR lookup via SF1530 for: {cvr}', [
@@ -130,6 +170,7 @@ class CvrLookupAction extends AabenFormsActionBase {
           'cvr' => $cvr,
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], NULL);
+        $this->recordStep('CVR Registry Lookup', 'No company found in the central business registry (SF1530)', 'failed');
         return;
       }
 
@@ -138,11 +179,15 @@ class CvrLookupAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], $companyData);
+      $this->recordStep('CVR Registry Lookup', 'Company data retrieved from the central business registry (SF1530)');
 
     }
     catch (\Exception $e) {
-      $this->handleError($e, 'CVR lookup via SF1530');
+      // Keep the technical detail in the server log, but never surface a raw
+      // cURL/SSL/Serviceplatformen error to the citizen.
+      $this->log('CVR lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->recordStep('CVR Registry Lookup', 'CVR-opslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/DenyAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/DenyAction.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Deny and stop the flow.
+ *
+ * A terminal node placed on the failure branch of an identity or consent
+ * gate. ECA has no flow-abort primitive, so a denied flow is modelled by
+ * routing to this action and giving it no successors: nothing downstream
+ * (CPR lookup, Digital Post, payment, approval) runs. It records a
+ * citizen-facing failed step so the synchronous response reads as failed,
+ * and writes a 'denied' audit row.
+ */
+#[Action(
+  id: 'aabenforms_workflow_deny',
+  label: new TranslatableMarkup('Deny and stop flow'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Stops the flow on a failed identity or consent gate and records a denied outcome.'),
+  version_introduced: '2.1.0',
+)]
+class DenyAction extends AabenFormsActionBase {
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'event_type' => 'workflow_denied',
+      'step_label' => 'Adgang afvist',
+      'message' => 'Sagen blev ikke behandlet, fordi identiteten ikke kunne bekraeftes.',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['event_type'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Audit event type'),
+      '#description' => $this->t('Audit log action recorded for the denial, for example citizen_service_denied.'),
+      '#default_value' => $this->configuration['event_type'],
+      '#required' => TRUE,
+    ];
+
+    $form['step_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Step label'),
+      '#description' => $this->t('Short label shown to the citizen in the execution steps.'),
+      '#default_value' => $this->configuration['step_label'],
+      '#required' => TRUE,
+    ];
+
+    $form['message'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Citizen message'),
+      '#description' => $this->t('Citizen-facing reason for the denial. Keep it free of technical detail.'),
+      '#default_value' => $this->configuration['message'],
+      '#required' => TRUE,
+      '#rows' => 2,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['event_type'] = $form_state->getValue('event_type');
+    $this->configuration['step_label'] = $form_state->getValue('step_label');
+    $this->configuration['message'] = $form_state->getValue('message');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $eventType = (string) ($this->configuration['event_type'] ?? 'workflow_denied');
+    $label = (string) ($this->configuration['step_label'] ?? 'Adgang afvist');
+    $message = (string) ($this->configuration['message'] ?? 'Sagen blev ikke behandlet.');
+
+    $this->log('Flow denied at gate: {type}', ['type' => $eventType], 'warning');
+    $this->recordStep($label, $message, 'failed');
+
+    try {
+      $this->auditLogger->log(
+        $eventType,
+        'system',
+        $message,
+        'denied',
+        ['action_id' => $this->getPluginId()]
+      );
+    }
+    catch (\Exception $e) {
+      $this->handleError($e, 'Recording denial audit entry');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FoiRouteAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FoiRouteAction.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Route a freedom-of-information request.
+ *
+ * Replaces the previous log-and-forget FOI flow. It assigns a case
+ * reference, computes the statutory response due date (7 working days),
+ * emails an acknowledgement to the requester and a routing notification
+ * to the case worker inbox, and records an audit entry. This is what
+ * backs the confirmation message's promise of a response within 7
+ * working days.
+ */
+#[Action(
+  id: 'aabenforms_foi_route',
+  label: new TranslatableMarkup('Route FOI request'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Assigns a reference and due date, acknowledges the requester, and routes the FOI request to a case worker.'),
+  version_introduced: '2.1.0',
+)]
+class FoiRouteAction extends AabenFormsActionBase {
+
+  /**
+   * The mail manager.
+   *
+   * @var \Drupal\Core\Mail\MailManagerInterface
+   */
+  protected MailManagerInterface $mailManager;
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected TimeInterface $timeService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->mailManager = $container->get('plugin.manager.mail');
+    $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    $instance->timeService = $container->get('datetime.time');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'caseworker_email' => 'aktindsigt@example.dk',
+      'response_working_days' => 7,
+      'requester_name_token' => '[webform_submission:values:requester_name:raw]',
+      'requester_email_token' => '[webform_submission:values:requester_email:raw]',
+      'request_text_token' => '[webform_submission:values:request_text:raw]',
+      'reference_token' => '[webform_submission:sid]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['caseworker_email'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case worker inbox'),
+      '#description' => $this->t('Email address the FOI request is routed to.'),
+      '#default_value' => $this->configuration['caseworker_email'],
+      '#required' => TRUE,
+    ];
+    $form['response_working_days'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Response deadline (working days)'),
+      '#default_value' => $this->configuration['response_working_days'],
+      '#min' => 1,
+      '#required' => TRUE,
+    ];
+    $form['requester_name_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Requester name token'),
+      '#default_value' => $this->configuration['requester_name_token'],
+    ];
+    $form['requester_email_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Requester email token'),
+      '#default_value' => $this->configuration['requester_email_token'],
+      '#required' => TRUE,
+    ];
+    $form['request_text_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Request text token'),
+      '#default_value' => $this->configuration['request_text_token'],
+    ];
+    $form['reference_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Reference token'),
+      '#description' => $this->t('Token used to build the case reference, for example the submission id.'),
+      '#default_value' => $this->configuration['reference_token'],
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $keys = [
+      'caseworker_email',
+      'response_working_days',
+      'requester_name_token',
+      'requester_email_token',
+      'request_text_token',
+      'reference_token',
+    ];
+    foreach ($keys as $key) {
+      $this->configuration[$key] = $form_state->getValue($key);
+    }
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $requesterEmail = $this->getTokenValue((string) $this->configuration['requester_email_token'], '');
+    $requesterName = $this->getTokenValue((string) $this->configuration['requester_name_token'], '');
+    $requestText = $this->getTokenValue((string) $this->configuration['request_text_token'], '');
+    $sid = $this->getTokenValue((string) $this->configuration['reference_token'], '');
+    $reference = 'FOI-' . ($sid !== '' ? $sid : 'NEW');
+    $caseworkerEmail = (string) $this->configuration['caseworker_email'];
+    $days = (int) ($this->configuration['response_working_days'] ?? 7);
+
+    $dueTimestamp = $this->addWorkingDays($this->timeService->getRequestTime(), $days);
+    $dueDate = date('Y-m-d', $dueTimestamp);
+
+    $params = [
+      'reference' => $reference,
+      'requester_name' => $requesterName !== '' ? $requesterName : $this->t('anmoder'),
+      'requester_email' => $requesterEmail,
+      'request_text' => $requestText,
+      'due_date' => $dueDate,
+    ];
+    $langcode = LanguageInterface::LANGCODE_DEFAULT;
+
+    // Route to the case worker inbox.
+    $this->mailManager->mail('aabenforms_workflows', 'foi_caseworker_notification', $caseworkerEmail, $langcode, $params);
+    $this->recordStep('FOI routed to case worker', sprintf('Sag %s sendt til sagsbehandling. Frist: %s.', $reference, $dueDate), 'completed');
+
+    // Acknowledge the requester, if an address was given.
+    if ($requesterEmail !== '') {
+      $this->mailManager->mail('aabenforms_workflows', 'foi_acknowledgement', $requesterEmail, $langcode, $params);
+      $this->recordStep('FOI acknowledgement sent', sprintf('Kvittering sendt til anmoder med referencenummer %s.', $reference), 'completed');
+    }
+    else {
+      $this->recordStep('FOI acknowledgement skipped', 'Ingen e-mailadresse angivet til kvittering.', 'skipped');
+    }
+
+    try {
+      $this->auditLogger->log(
+        'foi_request_routed',
+        'system',
+        sprintf('FOI %s routed; due %s', $reference, $dueDate),
+        'success',
+        ['reference' => $reference, 'due_date' => $dueDate]
+      );
+    }
+    catch (\Exception $e) {
+      $this->handleError($e, 'Recording FOI routing audit entry');
+    }
+  }
+
+  /**
+   * Adds a number of working days to a timestamp, skipping weekends.
+   *
+   * @param int $timestamp
+   *   The starting Unix timestamp.
+   * @param int $days
+   *   The number of working days to add.
+   *
+   * @return int
+   *   The resulting Unix timestamp.
+   */
+  protected function addWorkingDays(int $timestamp, int $days): int {
+    $result = $timestamp;
+    $added = 0;
+    while ($added < $days) {
+      $result += 86400;
+      $dayOfWeek = (int) date('N', $result);
+      if ($dayOfWeek < 6) {
+        $added++;
+      }
+    }
+    return $result;
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -68,12 +68,32 @@ class MitIdValidateAction extends AabenFormsActionBase {
     if ($this->demoModeAllowed()) {
       $this->log('MitID validation: ' . $context . ' - demo mode (allow_mitid_demo_mode on)', [], 'info');
       $this->setTokenValue($this->configuration['result_token'], TRUE);
+      $this->setResultStatus('verified');
       $this->recordStep('MitID Identity Validation', 'Demo mode: identity was NOT verified (no MitID session)', 'completed');
       return;
     }
     $this->log('MitID validation failed: ' . $context . ' (demo mode off)', [], 'warning');
     $this->setTokenValue($this->configuration['result_token'], FALSE);
+    $this->setResultStatus('failed');
     $this->recordStep('MitID Identity Validation', 'No valid MitID session - identity could not be verified', 'failed');
+  }
+
+  /**
+   * Writes an explicit scalar status companion token for downstream gating.
+   *
+   * The boolean result_token is kept for backward compatibility, but ECA
+   * conditions and the audit action read this `<result_token>_status` scalar
+   * (`verified` or `failed`) because comparing a rendered boolean token is
+   * unreliable.
+   *
+   * @param string $status
+   *   Either 'verified' or 'failed'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
+    }
   }
 
   /**
@@ -155,6 +175,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
           'workflow_id' => $workflowId,
         ], 'warning');
         $this->setTokenValue($this->configuration['result_token'], FALSE);
+        $this->setResultStatus('failed');
         $this->recordStep('MitID Identity Validation', 'Session expired - re-authentication required', 'failed');
         return;
       }
@@ -165,6 +186,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
       ]);
 
       $this->setTokenValue($this->configuration['result_token'], TRUE);
+      $this->setResultStatus('verified');
       $this->setTokenValue($this->configuration['session_data_token'], $sessionData);
       $this->recordStep('MitID Identity Validation', 'Citizen identity verified via NemID/MitID national eID');
 
@@ -172,6 +194,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
     catch (\Exception $e) {
       $this->handleError($e, 'MitID Identity Validation');
       $this->setTokenValue($this->configuration['result_token'], FALSE);
+      $this->setResultStatus('failed');
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/PayrollPostAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/PayrollPostAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\aabenforms_workflows\Plugin\Action;
 
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
 use Drupal\aabenforms_workflows\Service\PayrollService;
 use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Form\FormStateInterface;
@@ -39,11 +40,19 @@ class PayrollPostAction extends AabenFormsActionBase {
   protected PayrollService $payroll;
 
   /**
+   * The org-chart directory, used for the per-employee policy limit.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface
+   */
+  protected OrgChartServiceInterface $orgChart;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->payroll = $container->get('aabenforms_workflows.payroll');
+    $instance->orgChart = $container->get('aabenforms_workflows.org_chart');
     return $instance;
   }
 
@@ -111,6 +120,26 @@ class PayrollPostAction extends AabenFormsActionBase {
       $amount_raw = $this->getTokenValue((string) $this->configuration['amount_token'], '0');
       $amount_cents = (int) round(((float) str_replace(',', '.', $amount_raw)) * 100);
       $claim_type = (string) ($this->configuration['claim_type'] ?? 'unspecified');
+
+      // Enforce the per-employee policy limit before forwarding money.
+      $limit_cents = $this->orgChart->tierLimitCents($employee_id);
+      if ($limit_cents > 0 && $amount_cents > $limit_cents) {
+        $name = (string) $this->configuration['result_token'];
+        if ($name !== '') {
+          $this->setTokenValue($name, [
+            'status' => PayrollService::STATUS_FAILURE,
+            'transaction_id' => '',
+            'reason_code' => 'AMOUNT_EXCEEDS_POLICY',
+            'message' => 'Beloeb overstiger den tilladte graense for medarbejderen.',
+          ]);
+        }
+        $this->recordStep(
+          label: 'Payroll forwarding blocked',
+          description: sprintf('%s: beloebet (%.2f kr.) overstiger graensen (%.2f kr.) og blev ikke sendt til loen.', $claim_type, $amount_cents / 100, $limit_cents / 100),
+          status: 'failed',
+        );
+        return;
+      }
 
       $result = $this->payroll->forward($employee_id, $claim_type, $amount_cents, [
         'submission_id' => $this->getSubmission($entity)?->id(),

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ResolveEmployeeAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ResolveEmployeeAction.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Resolve and bind the employee identity.
+ *
+ * Internal and HR flows previously routed money and tasks on a
+ * self-asserted employee_id form field. This action derives the employee
+ * identifier from the authenticated account via the org-chart directory
+ * and writes it to a result token, plus a companion status token
+ * (verified | failed) so the flow can gate on it. Anonymous submissions,
+ * or accounts that map to no employee, resolve to failed.
+ */
+#[Action(
+  id: 'aabenforms_resolve_employee',
+  label: new TranslatableMarkup('Resolve employee identity'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Binds the submission to the authenticated employee via the org-chart directory.'),
+  version_introduced: '2.1.0',
+)]
+class ResolveEmployeeAction extends AabenFormsActionBase {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected AccountProxyInterface $account;
+
+  /**
+   * The org-chart directory.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface
+   */
+  protected OrgChartServiceInterface $orgChart;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->account = $container->get('current_user');
+    $instance->orgChart = $container->get('aabenforms_workflows.org_chart');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'submitted_employee_id_token' => '[webform_submission:values:employee_id:raw]',
+      'result_token' => 'employee_id',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['submitted_employee_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Submitted employee id token'),
+      '#description' => $this->t('Self-asserted employee id from the form. Used only to detect a mismatch; the authenticated identity is authoritative.'),
+      '#default_value' => $this->configuration['submitted_employee_id_token'],
+    ];
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Receives the resolved employee id. A companion <token>_status (verified/failed) is also set.'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['submitted_employee_id_token'] = $form_state->getValue('submitted_employee_id_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    if ($this->account->isAnonymous()) {
+      $this->setResult('', 'failed');
+      $this->recordStep('Employee identity', 'Afvist: interne anmodninger kraever, at medarbejderen er logget ind.', 'failed');
+      return;
+    }
+
+    $resolvedId = $this->orgChart->employeeIdForAccountName($this->account->getAccountName());
+    if ($resolvedId === '') {
+      $this->setResult('', 'failed');
+      $this->recordStep('Employee identity', 'Afvist: den loggede bruger er ikke knyttet til en medarbejder i organisationen.', 'failed');
+      return;
+    }
+
+    $submitted = $this->getTokenValue((string) $this->configuration['submitted_employee_id_token'], '');
+    $mismatch = $submitted !== '' && $submitted !== $resolvedId;
+
+    $this->setResult($resolvedId, 'verified');
+    $this->recordStep(
+      'Employee identity',
+      $mismatch
+        ? 'Medarbejderidentitet bekraeftet fra login. Det indtastede medarbejdernummer blev ignoreret, da det ikke matchede.'
+        : 'Medarbejderidentitet bekraeftet fra login.',
+      'completed'
+    );
+  }
+
+  /**
+   * Writes the resolved employee id and its companion status token.
+   *
+   * @param string $employeeId
+   *   The resolved employee identifier (may be empty on failure).
+   * @param string $status
+   *   Either 'verified' or 'failed'.
+   */
+  protected function setResult(string $employeeId, string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken, $employeeId);
+      $this->setTokenValue($resultToken . '_status', $status);
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/ConfigOrgChartService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ConfigOrgChartService.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Directory-backed org-chart, sourced from aabenforms_workflows.org_chart.
+ *
+ * Resolves the manager email, the per-claim policy limit, and the
+ * account-to-employee binding from config. Unlike the previous stub, it
+ * never echoes a self-asserted fallback: an unknown employee resolves to
+ * an empty manager email so a submitted "manager_email" field cannot route
+ * an approval.
+ */
+final class ConfigOrgChartService implements OrgChartServiceInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * Constructs a ConfigOrgChartService.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Returns the employee directory keyed by employee id.
+   *
+   * @return array<string, array<string, mixed>>
+   *   The employees map from config.
+   */
+  protected function employees(): array {
+    $employees = $this->configFactory->get('aabenforms_workflows.org_chart')->get('employees');
+    return is_array($employees) ? $employees : [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function findManagerEmail(string $employee_id, string $fallback = ''): string {
+    $employee = $this->employees()[$employee_id] ?? NULL;
+    if (is_array($employee) && !empty($employee['manager_email'])) {
+      return (string) $employee['manager_email'];
+    }
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tierLimitCents(string $employee_id): int {
+    $employee = $this->employees()[$employee_id] ?? NULL;
+    if (is_array($employee) && isset($employee['tier_limit_cents'])) {
+      return (int) $employee['tier_limit_cents'];
+    }
+    $default = $this->configFactory->get('aabenforms_workflows.org_chart')->get('default_tier_limit_cents');
+    return $default !== NULL ? (int) $default : 0;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function employeeIdForAccountName(string $account_name): string {
+    if ($account_name === '') {
+      return '';
+    }
+    foreach ($this->employees() as $employee_id => $employee) {
+      if (is_array($employee) && ($employee['account_name'] ?? '') === $account_name) {
+        return (string) $employee_id;
+      }
+    }
+    return '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/OrgChartServiceInterface.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/OrgChartServiceInterface.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Drupal\aabenforms_workflows\Service;
 
 /**
- * Resolves an employee's manager from their employee identifier.
+ * Resolves an employee's manager and policy data from their identifier.
  *
- * Two implementations ship: StubOrgChartService (default) returns the
- * fallback email it's given so existing webform-driven approval flows
- * keep working. A site that wires LDAP / Active Directory / a real HR
- * system can decorate aabenforms_workflows.org_chart and replace
- * findManagerEmail() with a real lookup.
+ * The default implementation is ConfigOrgChartService, a directory backed
+ * by aabenforms_workflows.org_chart config. A site that wires LDAP / Active
+ * Directory / a real HR system decorates aabenforms_workflows.org_chart and
+ * replaces these methods with real lookups.
  */
 interface OrgChartServiceInterface {
 
@@ -21,13 +20,38 @@ interface OrgChartServiceInterface {
    * @param string $employee_id
    *   Implementation-specific identifier (CPR, employee number, email).
    * @param string $fallback
-   *   Email to return if no lookup is wired or the employee is unknown.
-   *   Lets the caller pass through a webform-supplied "manager_email"
-   *   field as a graceful degrade.
+   *   Legacy graceful-degrade value. The config-backed implementation
+   *   ignores it so a self-asserted webform "manager_email" field can no
+   *   longer route an approval; pass '' from trusted callers.
    *
    * @return string
-   *   The resolved manager email, or the fallback if not found.
+   *   The resolved manager email, or '' if the employee is unknown.
    */
   public function findManagerEmail(string $employee_id, string $fallback = ''): string;
+
+  /**
+   * Returns the per-claim policy limit (in cents) for an employee.
+   *
+   * @param string $employee_id
+   *   The employee identifier.
+   *
+   * @return int
+   *   The maximum allowed claim amount in cents, or the directory default.
+   */
+  public function tierLimitCents(string $employee_id): int;
+
+  /**
+   * Resolves the employee identifier bound to a Drupal account name.
+   *
+   * Used to bind a submission to the authenticated user rather than a
+   * self-asserted form field.
+   *
+   * @param string $account_name
+   *   The Drupal account (user) name.
+   *
+   * @return string
+   *   The employee identifier, or '' if the account maps to no employee.
+   */
+  public function employeeIdForAccountName(string $account_name): string;
 
 }

--- a/web/modules/custom/aabenforms_workflows/src/Service/StubOrgChartService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/StubOrgChartService.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Drupal\aabenforms_workflows\Service;
 
 /**
- * Default no-op org-chart implementation.
+ * No-op org-chart implementation kept for tests and as a documented base.
  *
- * Returns whatever fallback the caller hands us. Sites that want a real
- * org-chart lookup install/decorate a service implementing
- * OrgChartServiceInterface (e.g. an LDAP/AD bridge module).
+ * Production uses ConfigOrgChartService. This returns empty results rather
+ * than echoing a self-asserted fallback. A site wiring LDAP / AD provides
+ * its own implementation of OrgChartServiceInterface.
  */
 final class StubOrgChartService implements OrgChartServiceInterface {
 
@@ -17,7 +17,21 @@ final class StubOrgChartService implements OrgChartServiceInterface {
    * {@inheritdoc}
    */
   public function findManagerEmail(string $employee_id, string $fallback = ''): string {
-    return $fallback;
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tierLimitCents(string $employee_id): int {
+    return 0;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function employeeIdForAccountName(string $account_name): string {
+    return '';
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/FlowWebformReferencesTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/FlowWebformReferencesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards that every ECA content-entity event references an existing webform.
+ *
+ * The MED voting flow listened on a med_election_ballot webform that did not
+ * exist, so the flow was dead. This test asserts the invariant across all
+ * exported ECA flows so a dangling reference fails CI instead of shipping.
+ *
+ * @group aabenforms_workflows
+ */
+class FlowWebformReferencesTest extends UnitTestCase {
+
+  /**
+   * Every webform_submission event type must have a matching webform config.
+   */
+  public function testEveryFlowEventReferencesAnExistingWebform(): void {
+    $syncDir = $this->locateConfigSync();
+    $this->assertNotNull($syncDir, 'Could not locate the config/sync directory.');
+
+    $missing = [];
+    foreach (glob($syncDir . '/eca.eca.*.yml') as $flowFile) {
+      $flow = Yaml::parseFile($flowFile);
+      foreach (($flow['events'] ?? []) as $event) {
+        $plugin = $event['plugin'] ?? '';
+        if (!str_starts_with($plugin, 'content_entity:')) {
+          continue;
+        }
+        $type = $event['configuration']['type'] ?? '';
+        // The type is "webform_submission <webform_id>".
+        if (!preg_match('/^webform_submission\s+([a-z0-9_]+)$/', $type, $m)) {
+          continue;
+        }
+        $webformId = $m[1];
+        if (!is_file($syncDir . '/webform.webform.' . $webformId . '.yml')) {
+          $missing[] = sprintf('%s -> webform "%s"', basename($flowFile), $webformId);
+        }
+      }
+    }
+
+    $this->assertSame([], $missing, "ECA flows reference webforms that do not exist:\n" . implode("\n", $missing));
+  }
+
+  /**
+   * Walks up from this file to find the config/sync directory.
+   *
+   * @return string|null
+   *   The absolute path to config/sync, or NULL if not found.
+   */
+  protected function locateConfigSync(): ?string {
+    $dir = __DIR__;
+    for ($i = 0; $i < 10; $i++) {
+      $candidate = $dir . '/config/sync';
+      if (is_dir($candidate)) {
+        return $candidate;
+      }
+      $parent = dirname($dir);
+      if ($parent === $dir) {
+        break;
+      }
+      $dir = $parent;
+    }
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -117,6 +117,13 @@ class AuditLogActionTest extends UnitTestCase {
     $auditLoggerProperty = $reflectionClass->getProperty('auditLogger');
     $auditLoggerProperty->setAccessible(TRUE);
     $auditLoggerProperty->setValue($this->action, $this->auditLogger);
+
+    // CPR access helper: reveal is a pass-through for these tests.
+    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
+    $cprAccessProperty->setAccessible(TRUE);
+    $cprAccessProperty->setValue($this->action, $cprAccess);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -338,6 +338,94 @@ class AuditLogActionTest extends UnitTestCase {
   }
 
   /**
+   * A status token resolving to a failed outcome is logged as failure.
+   *
+   * @covers ::execute
+   * @covers ::resolveStatus
+   * @covers ::normalizeStatus
+   */
+  public function testStatusTokenReflectsFailure(): void {
+    // A prior CPR lookup that found nothing.
+    $this->tokenStorage['citizen_data_status'] = 'not_found';
+
+    $reflectionClass = new \ReflectionClass($this->action);
+    $configProperty = $reflectionClass->getProperty('configuration');
+    $configProperty->setAccessible(TRUE);
+    $config = $configProperty->getValue($this->action);
+    $config['status_token'] = 'citizen_data_status';
+    $configProperty->setValue($this->action, $config);
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        'failure',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
+   * A status token resolving to a verified outcome is logged as success.
+   *
+   * @covers ::execute
+   * @covers ::resolveStatus
+   * @covers ::normalizeStatus
+   */
+  public function testStatusTokenReflectsSuccess(): void {
+    $this->tokenStorage['citizen_mitid_valid_status'] = 'verified';
+
+    $reflectionClass = new \ReflectionClass($this->action);
+    $configProperty = $reflectionClass->getProperty('configuration');
+    $configProperty->setAccessible(TRUE);
+    $config = $configProperty->getValue($this->action);
+    $config['status_token'] = 'citizen_mitid_valid_status';
+    $configProperty->setValue($this->action, $config);
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        'success',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
+   * The fixed status is used (and normalised) when no status token is set.
+   *
+   * @covers ::execute
+   * @covers ::resolveStatus
+   */
+  public function testFixedStatusUsedWhenNoToken(): void {
+    $reflectionClass = new \ReflectionClass($this->action);
+    $configProperty = $reflectionClass->getProperty('configuration');
+    $configProperty->setAccessible(TRUE);
+    $config = $configProperty->getValue($this->action);
+    $config['status'] = 'denied';
+    $configProperty->setValue($this->action, $config);
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        $this->anything(),
+        $this->anything(),
+        $this->anything(),
+        'denied',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
    * Tests default configuration.
    *
    * @covers ::defaultConfiguration
@@ -356,6 +444,12 @@ class AuditLogActionTest extends UnitTestCase {
 
     $this->assertArrayHasKey('additional_data_token', $defaults);
     $this->assertEquals('', $defaults['additional_data_token']);
+
+    $this->assertArrayHasKey('status', $defaults);
+    $this->assertEquals('success', $defaults['status']);
+
+    $this->assertArrayHasKey('status_token', $defaults);
+    $this->assertEquals('', $defaults['status_token']);
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/AuditLogActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\AuditLogAction;
@@ -119,7 +120,7 @@ class AuditLogActionTest extends UnitTestCase {
     $auditLoggerProperty->setValue($this->action, $this->auditLogger);
 
     // CPR access helper: reveal is a pass-through for these tests.
-    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess = $this->createMock(CprAccess::class);
     $cprAccess->method('reveal')->willReturnArgument(0);
     $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
     $cprAccessProperty->setAccessible(TRUE);

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\CprLookupAction;
@@ -144,7 +145,7 @@ class CprLookupActionTest extends UnitTestCase {
 
     // CPR access helper: reveal is a pass-through for these tests (CPR is
     // supplied as plaintext, not encrypted at rest).
-    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess = $this->createMock(CprAccess::class);
     $cprAccess->method('reveal')->willReturnArgument(0);
     $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
     $cprAccessProperty->setAccessible(TRUE);

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CprLookupActionTest.php
@@ -141,6 +141,14 @@ class CprLookupActionTest extends UnitTestCase {
     $configFactoryProperty = $reflectionClass->getProperty('configFactory');
     $configFactoryProperty->setAccessible(TRUE);
     $configFactoryProperty->setValue($this->action, $configFactory);
+
+    // CPR access helper: reveal is a pass-through for these tests (CPR is
+    // supplied as plaintext, not encrypted at rest).
+    $cprAccess = $this->createMock(\Drupal\aabenforms_core\Service\CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $cprAccessProperty = $reflectionClass->getProperty('cprAccess');
+    $cprAccessProperty->setAccessible(TRUE);
+    $cprAccessProperty->setValue($this->action, $cprAccess);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CvrLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CvrLookupActionTest.php
@@ -6,6 +6,8 @@ use Drupal\aabenforms_core\Service\ServiceplatformenClient;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_workflows\Plugin\Action\CvrLookupAction;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -55,6 +57,13 @@ class CvrLookupActionTest extends UnitTestCase {
    * @var array
    */
   protected array $tokenStorage = [];
+
+  /**
+   * Whether CVR demo mode is forced on for the current test.
+   *
+   * @var bool
+   */
+  protected bool $cvrDemoMode = FALSE;
 
   /**
    * {@inheritdoc}
@@ -113,6 +122,45 @@ class CvrLookupActionTest extends UnitTestCase {
     $clientProperty = $reflectionClass->getProperty('serviceplatformenClient');
     $clientProperty->setAccessible(TRUE);
     $clientProperty->setValue($this->action, $this->serviceplatformenClient);
+
+    // Config factory: demo flag reads $this->cvrDemoMode; certs are present by
+    // default so the existing tests exercise the real SF1530 path. A test sets
+    // $this->cvrDemoMode = TRUE to exercise the demo branch.
+    $wfSettings = $this->createMock(ImmutableConfig::class);
+    $wfSettings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'allow_cvr_demo_mode' ? $this->cvrDemoMode : NULL
+    );
+    $coreSettings = $this->createMock(ImmutableConfig::class);
+    $coreSettings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'serviceplatformen.certificates' ? ['cert_path' => '/cert.pem', 'key_path' => '/key.pem'] : NULL
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturnCallback(
+      fn ($name) => $name === 'aabenforms_core.settings' ? $coreSettings : $wfSettings
+    );
+    $configFactoryProperty = $reflectionClass->getProperty('configFactory');
+    $configFactoryProperty->setAccessible(TRUE);
+    $configFactoryProperty->setValue($this->action, $configFactory);
+  }
+
+  /**
+   * Demo mode records a labelled simulated step and never calls SF1530.
+   *
+   * @covers ::execute
+   */
+  public function testDemoModeSimulatesWithoutCallingServiceplatformen(): void {
+    $this->cvrDemoMode = TRUE;
+    $this->tokenStorage['cvr'] = '12345678';
+
+    // Serviceplatformen must not be called in demo mode.
+    $this->serviceplatformenClient->expects($this->never())->method('request');
+
+    $this->action->execute();
+
+    $company = $this->tokenStorage['company_data'];
+    $this->assertIsArray($company);
+    $this->assertTrue($company['demo']);
+    $this->assertSame('Demovirksomhed ApS (testdata)', $company['name']);
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/DenyActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/DenyActionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\DenyAction;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the DenyAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\DenyAction
+ * @group aabenforms_workflows
+ */
+class DenyActionTest extends UnitTestCase {
+
+  /**
+   * The DenyAction plugin.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\DenyAction
+   */
+  protected DenyAction $action;
+
+  /**
+   * Mock audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $auditLogger;
+
+  /**
+   * Mock execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $collector;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+
+    $this->auditLogger = $this->getMockBuilder(AuditLogger::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['log'])
+      ->getMock();
+    $this->collector = $this->createMock(WorkflowExecutionCollector::class);
+
+    $configuration = [
+      'event_type' => 'citizen_service_denied',
+      'step_label' => 'Identitet ikke bekraeftet',
+      'message' => 'Sagen blev ikke behandlet.',
+    ];
+
+    $this->action = new DenyAction(
+      $configuration,
+      'aabenforms_workflow_deny',
+      [],
+      $entityTypeManager,
+      $tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger
+    );
+    $this->action->setExecutionCollector($this->collector);
+
+    $reflectionClass = new \ReflectionClass($this->action);
+    $auditLoggerProperty = $reflectionClass->getProperty('auditLogger');
+    $auditLoggerProperty->setAccessible(TRUE);
+    $auditLoggerProperty->setValue($this->action, $this->auditLogger);
+  }
+
+  /**
+   * Records a failed step and writes a denied audit row.
+   *
+   * @covers ::execute
+   */
+  public function testDenyRecordsFailedStepAndDeniedAudit(): void {
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with(
+        'aabenforms_workflow_deny',
+        'Identitet ikke bekraeftet',
+        'Sagen blev ikke behandlet.',
+        'failed'
+      );
+
+    $this->auditLogger->expects($this->once())
+      ->method('log')
+      ->with(
+        'citizen_service_denied',
+        'system',
+        'Sagen blev ikke behandlet.',
+        'denied',
+        $this->anything()
+      );
+
+    $this->action->execute();
+  }
+
+  /**
+   * Tests default configuration.
+   *
+   * @covers ::defaultConfiguration
+   */
+  public function testDefaultConfiguration(): void {
+    $defaults = $this->action->defaultConfiguration();
+    $this->assertArrayHasKey('event_type', $defaults);
+    $this->assertArrayHasKey('step_label', $defaults);
+    $this->assertArrayHasKey('message', $defaults);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/PayrollPostActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/PayrollPostActionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\PayrollPostAction;
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+use Drupal\aabenforms_workflows\Service\PayrollService;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the PayrollPostAction policy check.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\PayrollPostAction
+ * @group aabenforms_workflows
+ */
+class PayrollPostActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\PayrollPostAction
+   */
+  protected PayrollPostAction $action;
+
+  /**
+   * Mock payroll service.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\PayrollService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $payroll;
+
+  /**
+   * Mock org chart.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $orgChart;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')->willReturnCallback(function ($name, $value) use ($tokenServices) {
+      $this->tokenStorage[$name] = $value;
+      return $tokenServices;
+    });
+
+    $this->payroll = $this->getMockBuilder(PayrollService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['forward'])
+      ->getMock();
+    $this->orgChart = $this->createMock(OrgChartServiceInterface::class);
+
+    $configuration = [
+      'employee_id_token' => 'emp',
+      'amount_token' => 'amount',
+      'claim_type' => 'mileage_expense',
+      'result_token' => 'payroll_result',
+    ];
+    $this->action = new PayrollPostAction(
+      $configuration,
+      'aabenforms_payroll_post',
+      [],
+      $entityTypeManager,
+      $tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger
+    );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $reflection = new \ReflectionClass($this->action);
+    foreach (['payroll' => $this->payroll, 'orgChart' => $this->orgChart] as $prop => $value) {
+      $p = $reflection->getProperty($prop);
+      $p->setAccessible(TRUE);
+      $p->setValue($this->action, $value);
+    }
+
+    $this->tokenStorage['emp'] = 'E1001';
+  }
+
+  /**
+   * An amount within the policy limit is forwarded to payroll.
+   *
+   * @covers ::execute
+   */
+  public function testWithinLimitForwards(): void {
+    $this->tokenStorage['amount'] = '450';
+    $this->orgChart->method('tierLimitCents')->willReturn(500000);
+    $this->payroll->expects($this->once())
+      ->method('forward')
+      ->willReturn([
+        'status' => PayrollService::STATUS_SUCCESS,
+        'transaction_id' => 'TX1',
+        'reason_code' => '',
+        'message' => 'ok',
+      ]);
+
+    $this->action->execute();
+    $this->assertSame(PayrollService::STATUS_SUCCESS, $this->tokenStorage['payroll_result']['status']);
+  }
+
+  /**
+   * An amount over the policy limit is blocked and never forwarded.
+   *
+   * @covers ::execute
+   */
+  public function testOverLimitBlocked(): void {
+    $this->tokenStorage['amount'] = '6000';
+    $this->orgChart->method('tierLimitCents')->willReturn(500000);
+    $this->payroll->expects($this->never())->method('forward');
+
+    $this->action->execute();
+
+    $this->assertSame(PayrollService::STATUS_FAILURE, $this->tokenStorage['payroll_result']['status']);
+    $this->assertSame('AMOUNT_EXCEEDS_POLICY', $this->tokenStorage['payroll_result']['reason_code']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ResolveEmployeeActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/ResolveEmployeeActionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\ResolveEmployeeAction;
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the ResolveEmployeeAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\ResolveEmployeeAction
+ * @group aabenforms_workflows
+ */
+class ResolveEmployeeActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\ResolveEmployeeAction
+   */
+  protected ResolveEmployeeAction $action;
+
+  /**
+   * Mock current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $account;
+
+  /**
+   * Mock org chart.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\OrgChartServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $orgChart;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    $ecaState = $this->createMock(EcaState::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')->willReturnCallback(function ($name, $value) use ($tokenServices) {
+      $this->tokenStorage[$name] = $value;
+      return $tokenServices;
+    });
+
+    $this->account = $this->createMock(AccountProxyInterface::class);
+    $this->orgChart = $this->createMock(OrgChartServiceInterface::class);
+
+    $configuration = [
+      'submitted_employee_id_token' => 'submitted_id',
+      'result_token' => 'employee_id',
+    ];
+    $this->action = new ResolveEmployeeAction(
+      $configuration,
+      'aabenforms_resolve_employee',
+      [],
+      $entityTypeManager,
+      $tokenServices,
+      $currentUser,
+      $time,
+      $ecaState,
+      $logger
+    );
+    $this->action->setExecutionCollector($this->createMock(WorkflowExecutionCollector::class));
+
+    $reflection = new \ReflectionClass($this->action);
+    foreach (['account' => $this->account, 'orgChart' => $this->orgChart] as $prop => $value) {
+      $p = $reflection->getProperty($prop);
+      $p->setAccessible(TRUE);
+      $p->setValue($this->action, $value);
+    }
+  }
+
+  /**
+   * Anonymous submitters are rejected.
+   *
+   * @covers ::execute
+   */
+  public function testAnonymousFailsClosed(): void {
+    $this->account->method('isAnonymous')->willReturn(TRUE);
+    $this->action->execute();
+    $this->assertSame('failed', $this->tokenStorage['employee_id_status']);
+    $this->assertSame('', $this->tokenStorage['employee_id']);
+  }
+
+  /**
+   * An authenticated account mapped to an employee resolves verified.
+   *
+   * @covers ::execute
+   */
+  public function testMappedAccountResolvesVerified(): void {
+    $this->account->method('isAnonymous')->willReturn(FALSE);
+    $this->account->method('getAccountName')->willReturn('admin');
+    $this->orgChart->method('employeeIdForAccountName')->with('admin')->willReturn('E1001');
+
+    $this->action->execute();
+
+    $this->assertSame('verified', $this->tokenStorage['employee_id_status']);
+    $this->assertSame('E1001', $this->tokenStorage['employee_id']);
+  }
+
+  /**
+   * An authenticated account not in the directory fails closed.
+   *
+   * @covers ::execute
+   */
+  public function testUnmappedAccountFailsClosed(): void {
+    $this->account->method('isAnonymous')->willReturn(FALSE);
+    $this->account->method('getAccountName')->willReturn('stranger');
+    $this->orgChart->method('employeeIdForAccountName')->willReturn('');
+
+    $this->action->execute();
+
+    $this->assertSame('failed', $this->tokenStorage['employee_id_status']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ConfigOrgChartServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ConfigOrgChartServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_workflows\Service\ConfigOrgChartService;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the config-backed org-chart directory.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\ConfigOrgChartService
+ * @group aabenforms_workflows
+ */
+class ConfigOrgChartServiceTest extends UnitTestCase {
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ConfigOrgChartService
+   */
+  protected ConfigOrgChartService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $values = [
+      'default_tier_limit_cents' => 200000,
+      'employees' => [
+        'E1001' => [
+          'name' => 'Administrator',
+          'account_name' => 'admin',
+          'manager_email' => 'leder@example.dk',
+          'tier_limit_cents' => 500000,
+        ],
+      ],
+    ];
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(fn ($key) => $values[$key] ?? NULL);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $this->service = new ConfigOrgChartService($configFactory);
+  }
+
+  /**
+   * @covers ::findManagerEmail
+   */
+  public function testFindManagerEmail(): void {
+    $this->assertSame('leder@example.dk', $this->service->findManagerEmail('E1001'));
+    // Unknown employee resolves to '' - never the self-asserted fallback.
+    $this->assertSame('', $this->service->findManagerEmail('E9999', 'spoof@evil.dk'));
+  }
+
+  /**
+   * @covers ::tierLimitCents
+   */
+  public function testTierLimitCents(): void {
+    $this->assertSame(500000, $this->service->tierLimitCents('E1001'));
+    $this->assertSame(200000, $this->service->tierLimitCents('E9999'));
+  }
+
+  /**
+   * @covers ::employeeIdForAccountName
+   */
+  public function testEmployeeIdForAccountName(): void {
+    $this->assertSame('E1001', $this->service->employeeIdForAccountName('admin'));
+    $this->assertSame('', $this->service->employeeIdForAccountName('nobody'));
+    $this->assertSame('', $this->service->employeeIdForAccountName(''));
+  }
+
+}


### PR DESCRIPTION
The stacked PRs #105-#109 were each merged into their base branch (fix/99, fix/97, fix/96, fix/100, fix/101) instead of main, so only #104 actually reached main and their issues stayed open. This PR brings the full stack forward to main in one merge.

Brings in, on top of #104 (already on main):
- **#97** - audit log records the real outcome, not a hardcoded success (status token + per-action status companions)
- **#96** - ECA flows gate on MitID; a failed identity check stops the flow (deny terminal); address/building gain the MitID step (part of #102)
- **#100** - MED voting flow revived (ballot webform), FOI routing made real (caseworker + acknowledgement + due date), CI assertion that every ECA event references an existing webform
- **#101** - internal/HR flows bound to the authenticated employee (config org-chart, anti-spoof, per-employee amount policy)
- **#98** - CPR encrypted at rest with an env-backed key (AABENFORMS_CPR_KEY), decrypted only at the points of use

Conflicts resolved by taking the stack's superset versions of CvrLookupAction and the workflows schema (both already contained #104). README keeps both the data-flow link (#103) and the new encryption note. phpcs clean over web/modules/custom; 230 unit tests green; config imports with no differences.

Closes #96
Closes #97
Closes #98
Closes #100
Closes #101