### PR TITLE
Fire parent-approval flows via a one-shot custom event

### DIFF
--- a/config/sync/eca.eca.parent1_approval_flow.yml
+++ b/config/sync/eca.eca.parent1_approval_flow.yml
@@ -14,76 +14,24 @@ id: parent1_approval_flow
 weight: null
 template: null
 events:
-  parent1_starts_approval:
-    plugin: 'content_entity:update'
+  on_parent1_approved:
+    plugin: 'content_entity:custom'
     configuration:
+      event_id: parent1_approved
       type: 'webform_submission parent_request_form'
-    successors:
-      -
-        id: check_parent1_pending
-        condition: ''
-conditions:
-  check_parent1_pending:
-    plugin: eca_scalar
-    configuration:
-      operator: '=='
-      left_value: '[webform_submission:data:parent1_status]'
-      right_value: pending
-    successors:
-      -
-        id: parent1_mitid
-        condition: 'true'
-gateways: {  }
-actions:
-  parent1_mitid:
-    label: 'Parent 1: Validate MitID'
-    plugin: aabenforms_mitid_validate
-    configuration:
-      workflow_id_token: workflow_id_parent1
-      result_token: parent1_mitid_valid
-      session_data_token: parent1_session
-    successors:
-      -
-        id: parent1_cpr_verify
-        condition: ''
-  parent1_cpr_verify:
-    label: 'Parent 1: Verify CPR Consent'
-    plugin: aabenforms_parent_cpr_verify
-    configuration:
-      parent_number: '1'
-      workflow_id_token: ''
-      result_token: parent1_cpr_consent
-    successors:
-      -
-        id: parent1_cpr
-        condition: ''
-  parent1_cpr:
-    label: 'Parent 1: CPR Lookup'
-    plugin: aabenforms_cpr_lookup
-    configuration:
-      cpr_token: '[parent1_session:cpr]'
-      result_token: parent1_data
-      use_cache: true
     successors:
       -
         id: parent1_audit
         condition: ''
+conditions: {  }
+gateways: {  }
+actions:
   parent1_audit:
-    label: 'Parent 1: Audit Log'
+    label: 'Parent 1: Audit approval'
     plugin: aabenforms_audit_log
     configuration:
       event_type: parent1_approval
-      additional_data_token: '[parent1_data:name]'
-      message_template: 'Parent 1 authenticated and approved'
-      status_token: parent1_mitid_valid_status
-    successors:
-      -
-        id: mark_parent1_complete
-        condition: ''
-  mark_parent1_complete:
-    label: 'Mark Parent 1 Complete'
-    plugin: eca_token_set_value
-    configuration:
-      token_name: parent1_status
-      token_value: complete
+      additional_data_token: ''
+      message_template: 'Parent 1 approved (identity and CPR consent verified at submission).'
+      status: success
     successors: {  }

--- a/config/sync/eca.eca.parent2_approval_flow.yml
+++ b/config/sync/eca.eca.parent2_approval_flow.yml
@@ -14,76 +14,24 @@ id: parent2_approval_flow
 weight: null
 template: null
 events:
-  parent2_starts_approval:
-    plugin: 'content_entity:update'
+  on_parent2_approved:
+    plugin: 'content_entity:custom'
     configuration:
+      event_id: parent2_approved
       type: 'webform_submission parent_request_form'
-    successors:
-      -
-        id: check_parent2_pending
-        condition: ''
-conditions:
-  check_parent2_pending:
-    plugin: eca_scalar
-    configuration:
-      operator: '=='
-      left_value: '[webform_submission:data:parent2_status]'
-      right_value: pending
-    successors:
-      -
-        id: parent2_mitid
-        condition: 'true'
-gateways: {  }
-actions:
-  parent2_mitid:
-    label: 'Parent 2: Validate MitID'
-    plugin: aabenforms_mitid_validate
-    configuration:
-      workflow_id_token: workflow_id_parent2
-      result_token: parent2_mitid_valid
-      session_data_token: parent2_session
-    successors:
-      -
-        id: parent2_cpr_verify
-        condition: ''
-  parent2_cpr_verify:
-    label: 'Parent 2: Verify CPR Consent'
-    plugin: aabenforms_parent_cpr_verify
-    configuration:
-      parent_number: '2'
-      workflow_id_token: ''
-      result_token: parent2_cpr_consent
-    successors:
-      -
-        id: parent2_cpr
-        condition: ''
-  parent2_cpr:
-    label: 'Parent 2: CPR Lookup'
-    plugin: aabenforms_cpr_lookup
-    configuration:
-      cpr_token: '[parent2_session:cpr]'
-      result_token: parent2_data
-      use_cache: true
     successors:
       -
         id: parent2_audit
         condition: ''
+conditions: {  }
+gateways: {  }
+actions:
   parent2_audit:
-    label: 'Parent 2: Audit Log'
+    label: 'Parent 2: Audit approval'
     plugin: aabenforms_audit_log
     configuration:
       event_type: parent2_approval
-      additional_data_token: '[parent2_data:name]'
-      message_template: 'Parent 2 authenticated and approved'
-      status_token: parent2_mitid_valid_status
-    successors:
-      -
-        id: mark_parent2_complete
-        condition: ''
-  mark_parent2_complete:
-    label: 'Mark Parent 2 Complete'
-    plugin: eca_token_set_value
-    configuration:
-      token_name: parent2_status
-      token_value: complete
+      additional_data_token: ''
+      message_template: 'Parent 2 approved (identity and CPR consent verified at submission).'
+      status: success
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/src/Form/ParentApprovalForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/ParentApprovalForm.php
@@ -8,7 +8,11 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
 use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
+use Drupal\eca\Service\ContentEntityTypes;
+use Drupal\eca_content\Event\ContentEntityCustomEvent;
+use Drupal\eca_content\Event\ContentEntityEvents;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -83,6 +87,20 @@ class ParentApprovalForm extends FormBase {
   protected bool $parentsTogether;
 
   /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
+   * The ECA content entity types service.
+   *
+   * @var \Drupal\eca\Service\ContentEntityTypes
+   */
+  protected ContentEntityTypes $entityTypes;
+
+  /**
    * Constructs a ParentApprovalForm object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -95,6 +113,10 @@ class ParentApprovalForm extends FormBase {
    *   The parent-approval CPR verifier (issue #54 consent gate).
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   *   The event dispatcher, used to fire the one-shot approval custom event.
+   * @param \Drupal\eca\Service\ContentEntityTypes $entity_types
+   *   The ECA content entity types service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -102,12 +124,16 @@ class ParentApprovalForm extends FormBase {
     MitIdSessionManager $mitid_session_manager,
     ParentCprVerifier $cpr_verifier,
     LoggerInterface $logger,
+    EventDispatcherInterface $event_dispatcher,
+    ContentEntityTypes $entity_types,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->tokenService = $token_service;
     $this->mitidSessionManager = $mitid_session_manager;
     $this->cprVerifier = $cpr_verifier;
     $this->logger = $logger;
+    $this->eventDispatcher = $event_dispatcher;
+    $this->entityTypes = $entity_types;
   }
 
   /**
@@ -119,7 +145,9 @@ class ParentApprovalForm extends FormBase {
       $container->get('aabenforms_workflows.approval_token'),
       $container->get('aabenforms_mitid.session_manager'),
       $container->get('aabenforms_workflows.parent_cpr_verifier'),
-      $container->get('logger.factory')->get('aabenforms_workflows')
+      $container->get('logger.factory')->get('aabenforms_workflows'),
+      $container->get('event_dispatcher'),
+      $container->get('eca.service.content_entity_types')
     );
   }
 
@@ -325,9 +353,24 @@ class ParentApprovalForm extends FormBase {
       $submission->setElementData($comment_field, $comments);
     }
 
-    // Save submission - this will trigger the ECA workflow.
+    // Save submission.
     try {
       $submission->save();
+
+      // Dispatch a one-shot ECA custom event for a recorded approval. The
+      // identity and consent were already verified in validateForm() above,
+      // so this fires exactly once per approval and the flow can record it
+      // honestly - unlike the old content_entity:update trigger, which never
+      // matched and would have re-fired on every later save.
+      if ($action === 'approve') {
+        $event = new ContentEntityCustomEvent(
+          $submission,
+          $this->entityTypes,
+          sprintf('parent%d_approved', $parent_number),
+          []
+        );
+        $this->eventDispatcher->dispatch($event, ContentEntityEvents::CUSTOM);
+      }
 
       $this->logger->info('Parent @parent @action submission @sid', [
         '@parent' => $parent_number,


### PR DESCRIPTION
Completes the parent-approval piece deferred from #96 and #100.

`parent1_approval_flow` and `parent2_approval_flow` never ran:
- they listened on `content_entity:update` with condition `parent1_status == pending`, but ParentApprovalForm sets the status to `complete` before saving;
- the condition used the wrong `eca_scalar` contract (`left_value`/`==`, which the plugin does not recognise), so it could never match;
- the in-flow MitID gate keyed the session on `workflow_id_parent1` instead of the real `parent_approval_<sid>_p<n>`.

Identity and CPR consent are already verified in `ParentApprovalForm::validateForm()` (#68) before save. So the form now dispatches a one-shot `content_entity:custom` event (`parent1_approved`/`parent2_approved`) after a recorded approval, and each flow listens on it and writes an honest audit entry. Fires exactly once per approval, no re-trigger (the old update trigger would have re-processed an already-approved parent on any later save, and a naive fix would write a denial over a prior approval).

Verified on DDEV: dispatching the custom event on a parent_request_form submission writes the parentN_approval audit row; phpcs clean; 173 workflow unit tests green; config imports clean with no ECA errors.

Closes #111