### PR TITLE
Align BPMN templates with flows (#102)

### DIFF
--- a/config/sync/eca.eca.company_verification_flow.yml
+++ b/config/sync/eca.eca.company_verification_flow.yml
@@ -23,11 +23,43 @@ events:
       type: 'webform_submission company_verification'
     successors:
       -
-        id: cvr_lookup
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_company_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[company_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_company_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[company_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate MitID Erhverv session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_company
+      result_token: company_mitid_valid
+      session_data_token: company_session
+    successors:
+      -
+        id: cvr_lookup
+        condition: gate_company_mitid_ok
+      -
+        id: deny_company
+        condition: gate_company_mitid_deny
   cvr_lookup:
     label: 'CVR registry lookup'
     plugin: aabenforms_cvr_lookup
@@ -62,4 +94,12 @@ actions:
       body_template: '<p>Resultatet af jeres CVR-verifikation er klar. Se vedlagte bilag.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_company:
+    label: 'Deny: MitID Erhverv not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: company_verification_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Anmodningen blev ikke behandlet, fordi virksomhedens MitID Erhverv-identitet ikke kunne bekraeftes. Log ind og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.contact_form_flow.yml
+++ b/config/sync/eca.eca.contact_form_flow.yml
@@ -1,0 +1,38 @@
+uuid: e5f6a7b8-c9d0-4567-89ab-contactform001
+langcode: en
+status: true
+dependencies:
+  config:
+    - webform.webform.contact
+  module:
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: contact_form_flow
+id: contact_form_flow
+weight: 0
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission contact'
+    successors:
+      -
+        id: route_contact
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  route_contact:
+    label: 'Route contact submission'
+    plugin: aabenforms_contact_route
+    configuration:
+      inbox_email: kontakt@example.dk
+      name_token: '[webform_submission:values:name:raw]'
+      email_token: '[webform_submission:values:email:raw]'
+      message_token: '[webform_submission:values:message:raw]'
+    successors: {  }

--- a/config/sync/eca.eca.marriage_booking_flow.yml
+++ b/config/sync/eca.eca.marriage_booking_flow.yml
@@ -23,11 +23,43 @@ events:
       type: 'webform_submission marriage_booking'
     successors:
       -
-        id: cpr_lookup_partner1
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_marriage_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[marriage_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_marriage_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[marriage_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate booking submitter MitID'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_marriage
+      result_token: marriage_mitid_valid
+      session_data_token: marriage_session
+    successors:
+      -
+        id: cpr_lookup_partner1
+        condition: gate_marriage_mitid_ok
+      -
+        id: deny_marriage
+        condition: gate_marriage_mitid_deny
   cpr_lookup_partner1:
     label: 'CPR registry lookup (partner 1)'
     plugin: aabenforms_cpr_lookup
@@ -73,4 +105,12 @@ actions:
       body_template: '<p>Vi har modtaget jeres ansøgning om civil vielse. I modtager bekræftelse på dato i Digital Post.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_marriage:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: marriage_booking_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Bookingen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/config/sync/eca.eca.parking_permit_flow.yml
+++ b/config/sync/eca.eca.parking_permit_flow.yml
@@ -23,11 +23,43 @@ events:
       type: 'webform_submission parking_permit'
     successors:
       -
-        id: cpr_lookup
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_parking_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[parking_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_parking_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[parking_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validate MitID session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_parking
+      result_token: parking_mitid_valid
+      session_data_token: parking_session
+    successors:
+      -
+        id: cpr_lookup
+        condition: gate_parking_mitid_ok
+      -
+        id: deny_parking
+        condition: gate_parking_mitid_deny
   cpr_lookup:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
@@ -62,4 +94,12 @@ actions:
       body_template: '<p>Vi har modtaget din ansøgning om parkeringstilladelse. Afgørelse leveres i Digital Post.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors: {  }
+  deny_parking:
+    label: 'Deny: identity not verified'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: parking_permit_denied
+      step_label: 'Identitet ikke bekraeftet'
+      message: 'Ansoegningen blev ikke behandlet, fordi din identitet ikke kunne bekraeftes med MitID. Log ind med MitID og proev igen.'
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -117,6 +117,26 @@ function aabenforms_workflows_mail(string $key, array &$message, array $params):
       $message['body'][] = t('Anmodning:');
       $message['body'][] = $params['request_text'];
       break;
+
+    case 'contact_inbox':
+      $message['subject'] = t('Ny henvendelse fra @name', ['@name' => $params['sender_name']]);
+      $message['body'][] = t('En ny henvendelse er modtaget via kontaktformularen.');
+      $message['body'][] = '';
+      $message['body'][] = t('Afsender: @name (@email)', [
+        '@name' => $params['sender_name'],
+        '@email' => $params['sender_email'],
+      ]);
+      $message['body'][] = '';
+      $message['body'][] = t('Besked:');
+      $message['body'][] = $params['message'];
+      break;
+
+    case 'contact_acknowledgement':
+      $message['subject'] = t('Vi har modtaget din henvendelse');
+      $message['body'][] = t('Kaere @name,', ['@name' => $params['sender_name']]);
+      $message['body'][] = '';
+      $message['body'][] = t('Tak for din henvendelse. Vi vender tilbage hurtigst muligt.');
+      break;
   }
 }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ContactRouteAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ContactRouteAction.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Route a contact-form submission.
+ *
+ * Sends the message to a department inbox, acknowledges the sender, and
+ * records an audit entry. Backs the contact_form template, which was
+ * previously a wizard blueprint with no active flow.
+ */
+#[Action(
+  id: 'aabenforms_contact_route',
+  label: new TranslatableMarkup('Route contact submission'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Routes a contact-form message to a department inbox and acknowledges the sender.'),
+  version_introduced: '2.1.0',
+)]
+class ContactRouteAction extends AabenFormsActionBase {
+
+  /**
+   * The mail manager.
+   *
+   * @var \Drupal\Core\Mail\MailManagerInterface
+   */
+  protected MailManagerInterface $mailManager;
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->mailManager = $container->get('plugin.manager.mail');
+    $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'inbox_email' => 'kontakt@example.dk',
+      'name_token' => '[webform_submission:values:name:raw]',
+      'email_token' => '[webform_submission:values:email:raw]',
+      'message_token' => '[webform_submission:values:message:raw]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['inbox_email'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Department inbox'),
+      '#default_value' => $this->configuration['inbox_email'],
+      '#required' => TRUE,
+    ];
+    $form['name_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Sender name token'),
+      '#default_value' => $this->configuration['name_token'],
+    ];
+    $form['email_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Sender email token'),
+      '#default_value' => $this->configuration['email_token'],
+      '#required' => TRUE,
+    ];
+    $form['message_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Message token'),
+      '#default_value' => $this->configuration['message_token'],
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    foreach (['inbox_email', 'name_token', 'email_token', 'message_token'] as $key) {
+      $this->configuration[$key] = $form_state->getValue($key);
+    }
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $name = $this->getTokenValue((string) $this->configuration['name_token'], '');
+    $email = $this->getTokenValue((string) $this->configuration['email_token'], '');
+    $message = $this->getTokenValue((string) $this->configuration['message_token'], '');
+    $inbox = (string) $this->configuration['inbox_email'];
+    $langcode = LanguageInterface::LANGCODE_DEFAULT;
+
+    $params = [
+      'sender_name' => $name !== '' ? $name : $this->t('borger'),
+      'sender_email' => $email,
+      'message' => $message,
+    ];
+
+    $this->mailManager->mail('aabenforms_workflows', 'contact_inbox', $inbox, $langcode, $params);
+    $this->recordStep('Contact routed', 'Henvendelsen blev sendt til afdelingens postkasse.', 'completed');
+
+    if ($email !== '') {
+      $this->mailManager->mail('aabenforms_workflows', 'contact_acknowledgement', $email, $langcode, $params);
+      $this->recordStep('Acknowledgement sent', 'Kvittering sendt til afsenderen.', 'completed');
+    }
+    else {
+      $this->recordStep('Acknowledgement skipped', 'Ingen e-mailadresse angivet.', 'skipped');
+    }
+
+    try {
+      $this->auditLogger->log('contact_submitted', 'system', 'Contact form routed', 'success', []);
+    }
+    catch (\Exception $e) {
+      $this->handleError($e, 'Recording contact audit entry');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/FlowTemplateParityTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/FlowTemplateParityTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Guards parity between BPMN templates and active ECA flows.
+ *
+ * Each *.bpmn template in workflows/ is surfaced in the template wizard, so
+ * it must be backed by an active eca.eca.<name>_flow config, and it must not
+ * advertise a MitID identity step that the active flow does not actually run
+ * (the divergence that left address_change/building_permit looking gated when
+ * they were not).
+ *
+ * @group aabenforms_workflows
+ */
+class FlowTemplateParityTest extends UnitTestCase {
+
+  /**
+   * The MitID validate plugin id, referenced by both .bpmn and flow YAML.
+   */
+  protected const MITID = 'aabenforms_mitid_validate';
+
+  /**
+   * Every template has a matching flow, and MitID claims match.
+   */
+  public function testTemplatesMatchActiveFlows(): void {
+    $moduleDir = dirname(__DIR__, 3);
+    $workflowsDir = $moduleDir . '/workflows';
+    $syncDir = $this->locateConfigSync();
+    $this->assertNotNull($syncDir, 'Could not locate config/sync.');
+    $this->assertDirectoryExists($workflowsDir);
+
+    $missingFlow = [];
+    $mitidDivergence = [];
+
+    foreach (glob($workflowsDir . '/*.bpmn') as $template) {
+      $name = basename($template, '.bpmn');
+      $flowFile = $syncDir . '/eca.eca.' . $name . '_flow.yml';
+
+      if (!is_file($flowFile)) {
+        $missingFlow[] = $name;
+        continue;
+      }
+
+      $templateHasMitid = str_contains((string) file_get_contents($template), self::MITID);
+      $flowHasMitid = str_contains((string) file_get_contents($flowFile), self::MITID);
+      if ($templateHasMitid && !$flowHasMitid) {
+        $mitidDivergence[] = $name;
+      }
+    }
+
+    $this->assertSame([], $missingFlow, "BPMN templates with no active flow:\n" . implode("\n", $missingFlow));
+    $this->assertSame([], $mitidDivergence, "BPMN templates advertise a MitID step their flow does not run:\n" . implode("\n", $mitidDivergence));
+  }
+
+  /**
+   * Walks up from this file to find the config/sync directory.
+   *
+   * @return string|null
+   *   The absolute path to config/sync, or NULL if not found.
+   */
+  protected function locateConfigSync(): ?string {
+    $dir = __DIR__;
+    for ($i = 0; $i < 10; $i++) {
+      $candidate = $dir . '/config/sync';
+      if (is_dir($candidate)) {
+        return $candidate;
+      }
+      $parent = dirname($dir);
+      if ($parent === $dir) {
+        break;
+      }
+      $dir = $parent;
+    }
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
Resolves the remaining template/flow divergence after #96 fixed address_change/building_permit. The wizard's BPMN templates advertised a MitID step that three more active flows did not run, and contact_form.bpmn had no active flow.

## Changes
- **MitID gates** added to parking_permit, marriage_booking and company_verification (MitID Erhverv), matching their templates and the #96 pattern; a failed check routes to a deny terminal. (Per your call to add gates to the flows rather than strip the templates.)
- **contact_form_flow** built for the orphaned template: new `aabenforms_contact_route` action emails the department inbox, acknowledges the sender, and writes an audit entry (two hook_mail templates).
- **CI guard** (`FlowTemplateParityTest`): asserts every `.bpmn` template has a matching active flow and never advertises a MitID step its flow does not run - so this divergence fails CI instead of shipping.

## Verified (DDEV)
- Anonymous parking_permit now denies at the MitID gate (no CPR lookup / Digital Post).
- A contact submission routes and is acknowledged - both emails delivered to Mailpit.
- phpcs clean; 174 workflow unit tests green; config exported clean.

Closes #102