### PR TITLE
Commit env-backed CPR key + profile so config:import keeps them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,15 @@
 /web/sites/*/settings.*.php
 /web/sites/*/services*.yml
 
-# Ignore encryption keys and profiles - secrets, never to git
+# Ignore encryption keys and profiles that embed secret material, never to git.
+# The aabenforms CPR key uses the env-provider (key material lives only in the
+# AABENFORMS_CPR_KEY environment variable, not in the YAML), so its key and
+# profile are secret-free and ARE committed - otherwise config:import deletes
+# them on deploy and CPR is silently stored unencrypted.
 /config/sync/key.key.*.yml
 /config/sync/encrypt.profile.*.yml
+!/config/sync/key.key.aabenforms_aes.yml
+!/config/sync/encrypt.profile.aabenforms_aes256.yml
 
 # Ignore Drupal's file directory
 /web/sites/*/files/

--- a/config/sync/encrypt.profile.aabenforms_aes256.yml
+++ b/config/sync/encrypt.profile.aabenforms_aes256.yml
@@ -1,0 +1,14 @@
+uuid: d4e5f6a7-b8c9-0123-defa-234567890123
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.aabenforms_aes
+  module:
+    - real_aes
+id: aabenforms_aes256
+label: 'AabenForms AES-256'
+encryption_method: real_aes
+encryption_method_configuration:
+  mode: cbc
+encryption_key: aabenforms_aes

--- a/config/sync/key.key.aabenforms_aes.yml
+++ b/config/sync/key.key.aabenforms_aes.yml
@@ -1,0 +1,19 @@
+uuid: c3d4e5f6-a7b8-9012-cdef-123456789012
+langcode: en
+status: true
+dependencies:
+  module:
+    - key
+id: aabenforms_aes
+label: 'AabenForms AES-256 Key'
+description: 'Encryption key for CPR field-level encryption. The key material is read from the AABENFORMS_CPR_KEY environment variable (base64 of 32 random bytes) and is never stored in config or git.'
+key_type: encryption
+key_type_settings:
+  key_size: 256
+key_provider: env
+key_provider_settings:
+  env_variable: AABENFORMS_CPR_KEY
+  base64_encoded: true
+  strip_line_breaks: true
+key_input: none
+key_input_settings: {  }


### PR DESCRIPTION
Follow-up to #98. When setting AABENFORMS_CPR_KEY on VPS2 I found CPR encryption was not actually active in production: the schema marker for update 11002 was set, but the key.key and encrypt.profile configs did not exist.

## Root cause
`key.key.*` and `encrypt.profile.*` were gitignored, so they were never in `config/sync`. The deploy runs `config:import`, which deletes any active config not present in sync - so it wiped the key and profile that update 11002 created. Production was left silently storing CPR in plaintext (the fail-safe path, with a logged warning).

## Fix
The CPR key uses the **env provider**: the key material lives only in the `AABENFORMS_CPR_KEY` environment variable, never in the YAML. So these two configs are secret-free and belong in version control. This narrows `.gitignore` to keep ignoring config-provider keys (which embed `key_value`) while committing the two env-backed files, so `config:import` creates and keeps them on every deploy.

Verified the committed key config contains no key material (env provider only). `AABENFORMS_CPR_KEY` is already set in the VPS2 web environment; once this merges and deploys, `config:import` provisions the profile and CPR-at-rest encryption goes live (no data was lost - nothing was encrypted yet, and the env key is durable so future ciphertext stays decryptable).