### PR TITLE
Decrypt CPR at the parent-approval consumers (encryption regression)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -38,6 +38,7 @@ services:
       - '@aabenforms_mitid.session_manager'
       - '@aabenforms_core.audit_logger'
       - '@logger.factory'
+      - '@aabenforms_core.cpr_access'
 
   aabenforms_workflows.payment_service:
     class: Drupal\aabenforms_workflows\Service\PaymentService

--- a/web/modules/custom/aabenforms_workflows/src/Form/ParentApprovalForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/ParentApprovalForm.php
@@ -5,6 +5,7 @@ namespace Drupal\aabenforms_workflows\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
 use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
@@ -101,6 +102,13 @@ class ParentApprovalForm extends FormBase {
   protected ContentEntityTypes $entityTypes;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * Constructs a ParentApprovalForm object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -117,6 +125,8 @@ class ParentApprovalForm extends FormBase {
    *   The event dispatcher, used to fire the one-shot approval custom event.
    * @param \Drupal\eca\Service\ContentEntityTypes $entity_types
    *   The ECA content entity types service.
+   * @param \Drupal\aabenforms_core\Service\CprAccess $cpr_access
+   *   The CPR access helper, used to decrypt the stored child CPR for display.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -126,6 +136,7 @@ class ParentApprovalForm extends FormBase {
     LoggerInterface $logger,
     EventDispatcherInterface $event_dispatcher,
     ContentEntityTypes $entity_types,
+    CprAccess $cpr_access,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->tokenService = $token_service;
@@ -134,6 +145,7 @@ class ParentApprovalForm extends FormBase {
     $this->logger = $logger;
     $this->eventDispatcher = $event_dispatcher;
     $this->entityTypes = $entity_types;
+    $this->cprAccess = $cpr_access;
   }
 
   /**
@@ -147,7 +159,8 @@ class ParentApprovalForm extends FormBase {
       $container->get('aabenforms_workflows.parent_cpr_verifier'),
       $container->get('logger.factory')->get('aabenforms_workflows'),
       $container->get('event_dispatcher'),
-      $container->get('eca.service.content_entity_types')
+      $container->get('eca.service.content_entity_types'),
+      $container->get('aabenforms_core.cpr_access')
     );
   }
 
@@ -180,7 +193,7 @@ class ParentApprovalForm extends FormBase {
     ];
 
     // CPR - mask if parents apart per GDPR.
-    $child_cpr = $submission->getElementData('child_cpr');
+    $child_cpr = $this->cprAccess->reveal((string) $submission->getElementData('child_cpr'));
     if (!$this->parentsTogether) {
       // Mask CPR: show only first 6 digits (birthdate) and last digit.
       $child_cpr = substr($child_cpr, 0, 6) . '-XXX' . substr($child_cpr, -1);

--- a/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\aabenforms_workflows\Service;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\webform\WebformSubmissionInterface;
@@ -76,6 +77,13 @@ class ParentCprVerifier {
   protected LoggerInterface $logger;
 
   /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
    * Constructs a ParentCprVerifier.
    *
    * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $session_manager
@@ -84,15 +92,19 @@ class ParentCprVerifier {
    *   The audit logger - records mismatch / missing-claim events.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
+   * @param \Drupal\aabenforms_core\Service\CprAccess $cpr_access
+   *   The CPR access helper, used to decrypt the stored parent CPR.
    */
   public function __construct(
     MitIdSessionManager $session_manager,
     AuditLogger $audit_logger,
     LoggerChannelFactoryInterface $logger_factory,
+    CprAccess $cpr_access,
   ) {
     $this->sessionManager = $session_manager;
     $this->auditLogger = $audit_logger;
     $this->logger = $logger_factory->get('aabenforms_workflows');
+    $this->cprAccess = $cpr_access;
   }
 
   /**
@@ -109,7 +121,9 @@ class ParentCprVerifier {
    *   One of the RESULT_* constants on this class.
    */
   public function verify(WebformSubmissionInterface $submission, int $parent_number, string $workflow_id): string {
-    $expected_raw = (string) ($submission->getElementData("parent{$parent_number}_cpr") ?? '');
+    // The stored parent CPR is encrypted at rest; decrypt it before
+    // comparing against the (plaintext) MitID-asserted CPR.
+    $expected_raw = $this->cprAccess->reveal((string) ($submission->getElementData("parent{$parent_number}_cpr") ?? ''));
     $asserted_raw = (string) ($this->sessionManager->getCprFromSession($workflow_id) ?? '');
 
     $expected = $this->normaliseCpr($expected_raw);

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -67,10 +68,32 @@ class ParentCprVerifierTest extends UnitTestCase {
     $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
     $logger_factory->method('get')->willReturn($this->logger);
 
+    // CprAccess mock: reveal() simulates decryption by stripping an AFENC1:
+    // prefix, so tests can pass either plaintext or "encrypted" CPR.
+    $cprAccess = $this->createMock(CprAccess::class);
+    $cprAccess->method('reveal')->willReturnCallback(
+      static fn (string $v): string => str_starts_with($v, 'AFENC1:') ? substr($v, 7) : $v
+    );
+
     $this->verifier = new ParentCprVerifier(
       $this->sessionManager,
       $this->auditLogger,
       $logger_factory,
+      $cprAccess,
+    );
+  }
+
+  /**
+   * The stored parent CPR, encrypted at rest, is decrypted before comparison.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyDecryptsStoredCprBeforeMatch(): void {
+    $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
+    $this->assertEquals(
+      ParentCprVerifier::RESULT_MATCH,
+      // Stored value is encrypted; without reveal() this would never match.
+      $this->verifier->verify($this->submission(1, 'AFENC1:0101001234'), 1, 'wf-enc'),
     );
   }
 


### PR DESCRIPTION
Found by re-running the multi-agent verification against main. #98 encrypted CPR at rest, but two consumers read the stored CPR field directly and got AFENC1: ciphertext.

- **ParentCprVerifier::verify()** compared the encrypted parent CPR to the plaintext MitID-asserted CPR; normaliseCpr() mangled the ciphertext so it never matched. With `require_parent_cpr_match` on (default) this **blocked every parent approval** - a regression in the #54/#68 consent gate.
- **ParentApprovalForm** masked the child CPR with substr() on the encrypted value, rendering the literal `AFENC1` prefix instead of the birthdate.

Both now `reveal()` the stored CPR via `aabenforms_core.cpr_access`. ParentCprVerifierTest adds a case with an encrypted stored CPR that matches only because verify() decrypts it (the prior tests mocked plaintext, which hid the bug). phpcs clean; 175 workflow unit tests green.

Closes #115