### PR TITLE
Make remaining audit nodes log the real lookup outcome (#97 residual)

### DIFF
--- a/config/sync/eca.eca.hr_onboarding_flow.yml
+++ b/config/sync/eca.eca.hr_onboarding_flow.yml
@@ -63,6 +63,7 @@ actions:
       event_type: hr_onboarding_submitted
       additional_data_token: '[webform_submission:values:new_hire_name:raw]'
       message_template: 'New hire request submitted by HR'
+      status_token: hr_employee_id_status
     successors:
       -
         id: lookup_manager
@@ -85,6 +86,7 @@ actions:
       event_type: hr_onboarding_manager_notified
       additional_data_token: '[hr_onboarding_manager_email]'
       message_template: 'Stub. Production would send approval email to manager via a generalized SendApprovalEmailAction.'
+      status_token: hr_onboarding_manager_email_status
     successors:
       -
         id: log_it_notified
@@ -96,6 +98,7 @@ actions:
       event_type: hr_onboarding_it_notified
       additional_data_token: '[webform_submission:values:it_distribution_email:raw]'
       message_template: 'Stub. Production would email IT distribution on manager approval.'
+      status_token: hr_onboarding_manager_email_status
     successors: {  }
   deny_internal:
     label: 'Deny: HR submitter identity not verified'

--- a/config/sync/eca.eca.med_election_nomination_flow.yml
+++ b/config/sync/eca.eca.med_election_nomination_flow.yml
@@ -75,6 +75,7 @@ actions:
       event_type: med_nomination_recorded
       additional_data_token: '[webform_submission:values:nominee_name:raw]'
       message_template: 'MED election nomination recorded'
+      status_token: nominator_data_status
     successors: {  }
   deny_nomination:
     label: 'Deny: nominator MitID not verified'

--- a/config/sync/eca.eca.mileage_expense_flow.yml
+++ b/config/sync/eca.eca.mileage_expense_flow.yml
@@ -63,6 +63,7 @@ actions:
       event_type: mileage_expense_submitted
       additional_data_token: '[webform_submission:values:employee_name:raw]'
       message_template: 'Expense claim submitted'
+      status_token: mileage_employee_id_status
     successors:
       -
         id: lookup_manager
@@ -85,6 +86,7 @@ actions:
       event_type: mileage_expense_manager_notified
       additional_data_token: '[mileage_expense_manager_email]'
       message_template: 'Stub. Production would send approval email.'
+      status_token: mileage_expense_manager_email_status
     successors:
       -
         id: forward_to_payroll

--- a/config/sync/eca.eca.parent_submission_simple.yml
+++ b/config/sync/eca.eca.parent_submission_simple.yml
@@ -54,4 +54,5 @@ actions:
       event_type: parent_submission
       additional_data_token: '[cpr_person_data:name]'
       message_template: '[webform_submission:sid]'
+      status_token: cpr_person_data_status
     successors: {  }

--- a/config/sync/eca.eca.phone_declaration_flow.yml
+++ b/config/sync/eca.eca.phone_declaration_flow.yml
@@ -54,6 +54,7 @@ actions:
       event_type: phone_declaration_manager_notified
       additional_data_token: '[phone_declaration_manager_email]'
       message_template: 'Stub. Production would send approval email.'
+      status_token: phone_declaration_manager_email_status
     successors:
       -
         id: log_archived

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ManagerLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/ManagerLookupAction.php
@@ -106,6 +106,12 @@ class ManagerLookupAction extends AabenFormsActionBase {
 
       $resolved = $this->orgChart->findManagerEmail($employee_id, $fallback);
       $this->setTokenValue((string) $this->configuration['result_token'], $resolved);
+      // Emit a companion status token so a following audit node logs the real
+      // outcome instead of a hardcoded success.
+      $resultToken = (string) $this->configuration['result_token'];
+      if ($resultToken !== '') {
+        $this->setTokenValue($resultToken . '_status', $resolved !== '' ? 'found' : 'not_found');
+      }
 
       $this->recordStep(
         label: 'Manager email resolved',


### PR DESCRIPTION
Cleanup of the residual audit-honesty gaps the verification re-run surfaced. Audit nodes after **non-identity** lookups still logged a hardcoded success even when the lookup failed.

- ManagerLookupAction now emits a `<result_token>_status` companion (`found`/`not_found`), like the CPR/CVR/identity actions.
- Wired `status_token` on the audit nodes after manager lookups (mileage_expense, hr_onboarding, phone_declaration) and after employee/CPR resolution (mileage_expense, hr_onboarding, med_election_nomination, parent_submission_simple).

Same mechanism as #97; these are the internal/stub flows not wired in the first pass. phpcs clean; 174 workflow unit tests green; config exported clean.