### PR TITLE
Make wizard-instantiated workflows gate identity and evaluate gateways

### DIFF
--- a/web/modules/custom/aabenforms_workflows/src/Service/WorkflowTemplateInstantiator.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/WorkflowTemplateInstantiator.php
@@ -276,6 +276,14 @@ class WorkflowTemplateInstantiator {
       }
     }
 
+    // Build the actions and the conditions that gate them. Exclusive-gateway
+    // edges populate $conditions during the walk; gateIdentityActions() then
+    // adds the MitID / consent gates so the generated flow stops on a failed
+    // identity check, matching the hand-built config/sync flows.
+    $conditions = [];
+    $actions = $this->buildEcaActions($xml, $configuration, $conditions);
+    $this->gateIdentityActions($actions, $conditions);
+
     // Build ECA config structure.
     $eca_config = [
       'langcode' => 'en',
@@ -289,8 +297,8 @@ class WorkflowTemplateInstantiator {
       'version' => '1.0.0',
       'events' => $this->buildEcaEvents($xml, $configuration),
       'gateways' => [],
-      'conditions' => [],
-      'actions' => $this->buildEcaActions($xml, $configuration),
+      'conditions' => $conditions,
+      'actions' => $actions,
     ];
 
     // Save ECA config.
@@ -339,11 +347,13 @@ class WorkflowTemplateInstantiator {
    *   The BPMN XML.
    * @param array $configuration
    *   The configuration array.
+   * @param array $conditions
+   *   Conditions block, populated in place from exclusive-gateway edges.
    *
    * @return array
    *   ECA actions configuration.
    */
-  protected function buildEcaActions(\SimpleXMLElement $xml, array $configuration): array {
+  protected function buildEcaActions(\SimpleXMLElement $xml, array $configuration, array &$conditions): array {
     $namespaces = $xml->getNamespaces(TRUE);
     $bpmnNs = $namespaces['bpmn'] ?? $namespaces['bpmn2'] ?? NULL;
     if (!$bpmnNs) {
@@ -401,7 +411,7 @@ class WorkflowTemplateInstantiator {
 
     $visited = [];
     foreach ($startIds as $startId) {
-      $this->walkBpmnNode($startId, 'start_workflow', '', $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration);
+      $this->walkBpmnNode($startId, 'start_workflow', '', $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration, $conditions);
     }
 
     return $actions;
@@ -428,6 +438,7 @@ class WorkflowTemplateInstantiator {
     string $aabenformsNs,
     string $bpmnNs,
     array $configuration,
+    array &$conditions,
   ): void {
     $info = $nodes[$nodeId] ?? NULL;
     if (!$info) {
@@ -439,7 +450,7 @@ class WorkflowTemplateInstantiator {
     // startEvent: pass through without emitting an action.
     if ($type === 'startEvent') {
       foreach ($outEdges as $edge) {
-        $this->walkBpmnNode($edge['target'], $prevActionId, $edge['label'], $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration);
+        $this->walkBpmnNode($edge['target'], $prevActionId, $edge['label'], $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration, $conditions);
       }
       return;
     }
@@ -449,13 +460,38 @@ class WorkflowTemplateInstantiator {
       return;
     }
 
-    // Gateways: fan out. Exclusive attaches edge label as condition; parallel
-    // treats all branches as unconditional. Real condition evaluation is a
-    // followup (edge label is plain text, not yet a Drupal condition).
-    if ($type === 'exclusiveGateway' || $type === 'parallelGateway') {
+    // Parallel gateway: every branch runs, unconditionally.
+    if ($type === 'parallelGateway') {
       foreach ($outEdges as $edge) {
-        $edgeCondition = $type === 'exclusiveGateway' ? $edge['label'] : '';
-        $this->walkBpmnNode($edge['target'], $prevActionId, $edgeCondition, $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration);
+        $this->walkBpmnNode($edge['target'], $prevActionId, '', $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration, $conditions);
+      }
+      return;
+    }
+
+    // Exclusive gateway: evaluate a real eca_scalar condition per labelled
+    // branch. The gateway declares the token it tests via an aabenforms:gateway
+    // extension; each outgoing edge's label is the value to compare. A gateway
+    // with no declared token falls back to a per-gateway decision token
+    // ([<id>_decision]). That token is unset until an action writes it, so the
+    // generated conditions all evaluate false and the flow safely waits at the
+    // decision (no branch runs) - never the unsafe "run every branch", and
+    // never a dead plain-text condition. Downstream actions are still emitted
+    // so the draft flow is complete and the kommune can wire the decision.
+    if ($type === 'exclusiveGateway') {
+      $gatewayToken = $this->readGatewayToken($info['el'], $aabenformsNs, $bpmnNs);
+      if ($gatewayToken === '') {
+        $gatewayToken = '[' . preg_replace('/[^a-z0-9_]+/i', '_', $nodeId) . '_decision]';
+        if ($outEdges) {
+          $this->logger->warning(
+            'Instantiator: exclusive gateway @id has no aabenforms:gateway token; using @token, which stays false until an action sets it (the flow waits at this decision).',
+            ['@id' => $nodeId, '@token' => $gatewayToken],
+          );
+        }
+      }
+      foreach ($outEdges as $edge) {
+        $label = trim((string) $edge['label']);
+        $edgeCondition = $label !== '' ? $this->makeEdgeCondition($nodeId, $gatewayToken, $label, $conditions) : '';
+        $this->walkBpmnNode($edge['target'], $prevActionId, $edgeCondition, $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration, $conditions);
       }
       return;
     }
@@ -485,7 +521,144 @@ class WorkflowTemplateInstantiator {
     }
 
     foreach ($outEdges as $edge) {
-      $this->walkBpmnNode($edge['target'], $actionId, $edge['label'], $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration);
+      $this->walkBpmnNode($edge['target'], $actionId, $edge['label'], $nodes, $edges, $actions, $visited, $aabenformsNs, $bpmnNs, $configuration, $conditions);
+    }
+  }
+
+  /**
+   * Reads the token an exclusive gateway evaluates, from its extension.
+   *
+   * Convention: <bpmn:extensionElements><aabenforms:gateway token="[x]"/>.
+   *
+   * @return string
+   *   The token expression (e.g. "[decision_status]"), or '' if not declared.
+   */
+  protected function readGatewayToken(\SimpleXMLElement $gateway, string $aabenformsNs, string $bpmnNs): string {
+    foreach ($gateway->children($bpmnNs) as $child) {
+      if ($child->getName() !== 'extensionElements') {
+        continue;
+      }
+      foreach ($child->children($aabenformsNs) as $ext) {
+        if ($ext->getName() === 'gateway') {
+          $attrs = $ext->attributes();
+          return trim((string) ($attrs['token'] ?? ''));
+        }
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Creates an eca_scalar condition for one exclusive-gateway edge.
+   *
+   * Compares the gateway token against the edge label. Registers the
+   * condition in $conditions and returns its id for the successor to
+   * reference.
+   *
+   * @return string
+   *   The generated condition id.
+   */
+  protected function makeEdgeCondition(string $gatewayId, string $token, string $label, array &$conditions): string {
+    $slug = preg_replace('/[^a-z0-9]+/', '_', strtolower($label)) ?: 'branch';
+    $id = 'gate_' . preg_replace('/[^a-z0-9_]+/i', '_', $gatewayId) . '_' . trim($slug, '_');
+    $conditions[$id] = $this->scalarCondition($token, $label, FALSE);
+    return $id;
+  }
+
+  /**
+   * Builds an eca_scalar condition comparing a token to a value.
+   *
+   * @param string $left
+   *   The left operand, typically a "[token]" expression.
+   * @param string $right
+   *   The value to compare against.
+   * @param bool $negate
+   *   TRUE for the complementary (not-equal) branch.
+   *
+   * @return array
+   *   An eca_scalar condition definition.
+   */
+  protected function scalarCondition(string $left, string $right, bool $negate): array {
+    return [
+      'plugin' => 'eca_scalar',
+      'configuration' => [
+        'left' => $left,
+        'right' => $right,
+        'operator' => 'equal',
+        'type' => 'value',
+        'case' => FALSE,
+        'negate' => $negate,
+      ],
+    ];
+  }
+
+  /**
+   * Adds MitID / consent identity gates to the generated actions.
+   *
+   * For every aabenforms_mitid_validate (or aabenforms_parent_cpr_verify)
+   * action, routes its successors through a verified/match gate and adds a
+   * terminal aabenforms_workflow_deny on failure, so an instantiated flow
+   * stops on a failed identity check just like the hand-built flows. The
+   * runtime status companion token (<result_token>_status) is emitted by
+   * those actions already.
+   *
+   * @param array $actions
+   *   The actions, keyed by id (modified in place).
+   * @param array $conditions
+   *   The conditions block (gates appended in place).
+   */
+  protected function gateIdentityActions(array &$actions, array &$conditions): void {
+    $gated = [
+      'aabenforms_mitid_validate' => [
+        'token_default' => 'mitid_valid',
+        'value' => 'verified',
+        'message' => 'Adgangen blev afvist, fordi identiteten ikke kunne bekraeftes med MitID.',
+      ],
+      'aabenforms_parent_cpr_verify' => [
+        'token_default' => 'cpr_consent_result',
+        'value' => 'match',
+        'message' => 'Adgangen blev afvist, fordi CPR-samtykket ikke kunne bekraeftes.',
+      ],
+    ];
+
+    foreach ($actions as $actionId => $action) {
+      $plugin = $action['plugin'] ?? '';
+      if (!isset($gated[$plugin])) {
+        continue;
+      }
+      $spec = $gated[$plugin];
+      $resultToken = (string) ($action['configuration']['result_token'] ?? $spec['token_default']);
+      if ($resultToken === '') {
+        continue;
+      }
+      $statusToken = '[' . $resultToken . '_status]';
+      $okId = 'gate_' . $actionId . '_ok';
+      $denyId = 'gate_' . $actionId . '_deny';
+      $denyAction = 'deny_' . $actionId;
+
+      $conditions[$okId] = $this->scalarCondition($statusToken, $spec['value'], FALSE);
+      $conditions[$denyId] = $this->scalarCondition($statusToken, $spec['value'], TRUE);
+
+      // Route every existing successor through the verified gate, then add
+      // the deny branch.
+      foreach ($actions[$actionId]['successors'] as &$successor) {
+        if (($successor['id'] ?? '') !== $denyAction) {
+          $successor['condition'] = $okId;
+        }
+      }
+      unset($successor);
+      $actions[$actionId]['successors'][] = ['id' => $denyAction, 'condition' => $denyId];
+
+      $actions[$denyAction] = [
+        'label' => 'Deny: identity not verified',
+        'plugin' => 'aabenforms_workflow_deny',
+        'configuration' => [
+          'event_type' => $plugin === 'aabenforms_parent_cpr_verify' ? 'consent_denied' : 'identity_denied',
+          'step_label' => 'Adgang afvist',
+          'message' => $spec['message'],
+        ],
+        'successors' => [],
+      ];
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Service/WorkflowTemplateInstantiatorTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/Service/WorkflowTemplateInstantiatorTest.php
@@ -231,6 +231,149 @@ class WorkflowTemplateInstantiatorTest extends KernelTestBase {
   }
 
   /**
+   * An instantiated flow gates its MitID action and denies on failure.
+   *
+   * @covers ::gateIdentityActions
+   */
+  public function testInstantiatedFlowGatesIdentity(): void {
+    $result = $this->instantiator->instantiate('building_permit', $this->buildingPermitConfig());
+    $this->assertTrue($result['success'], $result['message'] ?? '');
+
+    $eca = $this->config('eca.eca.' . $result['workflow_id']);
+    $actions = $eca->get('actions') ?? [];
+    $conditions = $eca->get('conditions') ?? [];
+
+    $mitid = NULL;
+    foreach ($actions as $id => $a) {
+      if (($a['plugin'] ?? '') === 'aabenforms_mitid_validate') {
+        $mitid = $id;
+        break;
+      }
+    }
+    $this->assertNotNull($mitid, 'building_permit instantiates a MitID action.');
+
+    $okId = 'gate_' . $mitid . '_ok';
+    $denyId = 'gate_' . $mitid . '_deny';
+    $this->assertArrayHasKey($okId, $conditions);
+    $this->assertArrayHasKey($denyId, $conditions);
+    $this->assertSame('eca_scalar', $conditions[$okId]['plugin']);
+    $this->assertFalse((bool) $conditions[$okId]['configuration']['negate']);
+    $this->assertTrue((bool) $conditions[$denyId]['configuration']['negate']);
+
+    $okSuccessor = FALSE;
+    $denyTarget = NULL;
+    foreach ($actions[$mitid]['successors'] as $s) {
+      if (($s['condition'] ?? '') === $okId) {
+        $okSuccessor = TRUE;
+      }
+      if (($s['condition'] ?? '') === $denyId) {
+        $denyTarget = $s['id'];
+      }
+    }
+    $this->assertTrue($okSuccessor, 'A successor runs only when MitID is verified.');
+    $this->assertNotNull($denyTarget, 'A deny branch exists for failed MitID.');
+    $this->assertSame('aabenforms_workflow_deny', $actions[$denyTarget]['plugin']);
+    $this->assertSame([], $actions[$denyTarget]['successors'], 'Deny is terminal.');
+
+    // No successor anywhere references an undefined condition (no dead labels).
+    foreach ($actions as $a) {
+      foreach (($a['successors'] ?? []) as $s) {
+        $c = $s['condition'] ?? '';
+        if ($c !== '') {
+          $this->assertArrayHasKey($c, $conditions, "Condition '$c' is defined.");
+        }
+      }
+    }
+  }
+
+  /**
+   * An annotated exclusive gateway emits a real eca_scalar condition per edge.
+   *
+   * @covers ::walkBpmnNode
+   * @covers ::makeEdgeCondition
+   */
+  public function testExclusiveGatewayEmitsRealCondition(): void {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:aabenforms="http://aabenforms.dk/bpmn/eca"
+  id="Definitions_gw" targetNamespace="http://aabenforms.dk/bpmn">
+  <bpmn:process id="gw_process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1"/>
+    <bpmn:serviceTask id="Task_Decide" name="Decide">
+      <bpmn:extensionElements>
+        <aabenforms:ecaAction plugin="aabenforms_log">
+          <aabenforms:config key="message">decide</aabenforms:config>
+        </aabenforms:ecaAction>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_Decide" name="Decision?">
+      <bpmn:extensionElements>
+        <aabenforms:gateway token="[decision_status]"/>
+      </bpmn:extensionElements>
+    </bpmn:exclusiveGateway>
+    <bpmn:serviceTask id="Task_Approve" name="Approve">
+      <bpmn:extensionElements>
+        <aabenforms:ecaAction plugin="aabenforms_log">
+          <aabenforms:config key="message">a</aabenforms:config>
+        </aabenforms:ecaAction>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_Reject" name="Reject">
+      <bpmn:extensionElements>
+        <aabenforms:ecaAction plugin="aabenforms_log">
+          <aabenforms:config key="message">r</aabenforms:config>
+        </aabenforms:ecaAction>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="End_A"/>
+    <bpmn:endEvent id="End_R"/>
+    <bpmn:sequenceFlow id="F1" sourceRef="StartEvent_1" targetRef="Task_Decide"/>
+    <bpmn:sequenceFlow id="F2" sourceRef="Task_Decide" targetRef="Gateway_Decide"/>
+    <bpmn:sequenceFlow id="F_app" name="approve" sourceRef="Gateway_Decide" targetRef="Task_Approve"/>
+    <bpmn:sequenceFlow id="F_rej" name="reject" sourceRef="Gateway_Decide" targetRef="Task_Reject"/>
+    <bpmn:sequenceFlow id="F3" sourceRef="Task_Approve" targetRef="End_A"/>
+    <bpmn:sequenceFlow id="F4" sourceRef="Task_Reject" targetRef="End_R"/>
+  </bpmn:process>
+</bpmn:definitions>
+XML;
+
+    $result = $this->instantiator->instantiate('contact_form', $this->contactFormConfig(), $xml);
+    $this->assertTrue($result['success'], $result['message'] ?? '');
+
+    $eca = $this->config('eca.eca.' . $result['workflow_id']);
+    $actions = $eca->get('actions') ?? [];
+    $conditions = $eca->get('conditions') ?? [];
+
+    // One eca_scalar condition per labelled edge, comparing the gateway token.
+    $scalarRights = [];
+    foreach ($conditions as $c) {
+      if (($c['plugin'] ?? '') === 'eca_scalar') {
+        $this->assertSame('[decision_status]', $c['configuration']['left']);
+        $this->assertSame('equal', $c['configuration']['operator']);
+        $scalarRights[] = $c['configuration']['right'];
+      }
+    }
+    $this->assertContains('approve', $scalarRights);
+    $this->assertContains('reject', $scalarRights);
+
+    // The decide action's successors reference real condition ids, not labels.
+    $decide = NULL;
+    foreach ($actions as $id => $a) {
+      if (str_contains($id, 'Task_Decide')) {
+        $decide = $id;
+        break;
+      }
+    }
+    $this->assertNotNull($decide);
+    $this->assertNotEmpty($actions[$decide]['successors']);
+    foreach ($actions[$decide]['successors'] as $s) {
+      $this->assertArrayHasKey($s['condition'], $conditions, 'Successor references a real condition, not a raw label.');
+    }
+  }
+
+  /**
    * Tests that an unknown template id surfaces the validator error path.
    *
    * The metadata service returns no parameters for an unknown id, so the only


### PR DESCRIPTION
Workflows created through the **template wizard** were both insecure and non-functional - the hardening we applied to the hand-built `config/sync` flows never reached the *creation* path. `WorkflowTemplateInstantiator` converted BPMN to ECA naively:

- **No identity gate** - templates ran MitID -> CPR linearly, so a wizard-built flow did not stop on a failed MitID.
- **Dead gateway branches** - each exclusive-gateway edge label ('Yes'/'Approve') was written into the successor's `condition` as plain text, referencing a `conditions` block that was always empty. The branches never evaluated (same dead-condition class as the old `left_value`/`==` flows).

## Changes (instantiator only - every template benefits)
- **`gateIdentityActions()`**: gates every `aabenforms_mitid_validate` (verified) and `aabenforms_parent_cpr_verify` (match) action - reroutes its successors through a real `eca_scalar` `gate_*_ok` condition and adds a terminal `aabenforms_workflow_deny` on `gate_*_deny`, using the action's `result_token` + its runtime `<result_token>_status` companion. Instantiated flows now stop on a failed identity check.
- **Exclusive gateways** emit a real `eca_scalar` condition per labelled edge, comparing the gateway's token (declared via an `aabenforms:gateway token="..."` extension, or a default `[<id>_decision]`) to the edge label. The conditions block is populated; no successor carries a raw label. An unannotated gateway's default token stays false until an action writes it, so the draft emits every downstream action but **safely waits** at the decision rather than running all branches.

## Verified
- Instantiating `building_permit`: the MitID action routes to CPR-lookup via `gate_*_ok` and to a `deny_*` terminal via `gate_*_deny`; conditions populated; **no dangling/raw-label conditions**; the unannotated caseworker gateway emits all downstream actions and waits.
- Two new kernel tests (identity gate + annotated-gateway condition). Full instantiator kernel suite (13) green; 174 unit tests green; phpcs clean.

This only touches the creation/instantiation path; the already-hardened `config/sync` flows are unaffected. Decision gateways without a backing token stay safely pending until a kommune wires one (logged).