### PR TITLE
Bridge MitID login to the flow gate + demo-citizen test harness

### DIFF
--- a/web/modules/custom/aabenforms_mitid/aabenforms_mitid.links.menu.yml
+++ b/web/modules/custom/aabenforms_mitid/aabenforms_mitid.links.menu.yml
@@ -3,3 +3,9 @@ aabenforms_mitid.settings:
   description: 'Configure MitID OIDC endpoints, client credentials, and assurance level.'
   route_name: aabenforms_mitid.settings
   parent: system.admin_config_services
+
+aabenforms_mitid.demo_session:
+  title: 'Test as demo citizen'
+  description: 'Activate a demo MitID identity so a gated flow can be run through its happy path in the modeler.'
+  route_name: aabenforms_mitid.demo_session
+  parent: system.admin_config_services

--- a/web/modules/custom/aabenforms_mitid/aabenforms_mitid.routing.yml
+++ b/web/modules/custom/aabenforms_mitid/aabenforms_mitid.routing.yml
@@ -6,6 +6,14 @@ aabenforms_mitid.settings:
   requirements:
     _permission: 'administer site configuration'
 
+aabenforms_mitid.demo_session:
+  path: '/admin/config/aabenforms/mitid/demo-session'
+  defaults:
+    _form: '\Drupal\aabenforms_mitid\Form\DemoSessionForm'
+    _title: 'Test as demo citizen'
+  requirements:
+    _permission: 'administer eca'
+
 aabenforms_mitid.login:
   path: '/mitid/login'
   defaults:

--- a/web/modules/custom/aabenforms_mitid/drush.services.yml
+++ b/web/modules/custom/aabenforms_mitid/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  aabenforms_mitid.drush_commands:
+    class: Drupal\aabenforms_mitid\Drush\AabenformsMitidCommands
+    arguments:
+      - '@aabenforms_mitid.session_manager'
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/aabenforms_mitid/src/DemoPersonas.php
+++ b/web/modules/custom/aabenforms_mitid/src/DemoPersonas.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\aabenforms_mitid;
+
+/**
+ * Canonical set of demo citizens for testing gated flows.
+ *
+ * These four personas mirror the users carrying a `cpr` attribute in the
+ * mock IdP realm (`.ddev/mocks/keycloak/realms/danish-gov-test.json`). They
+ * exist so a developer or kommune admin can drive a MitID-gated flow through
+ * its happy path without a live MitID/NemLog-in authentication - see the
+ * `aabenforms:seed-mitid-session` Drush command and the modeler's
+ * "Test as demo citizen" action.
+ *
+ * This is test/demo scaffolding only. Seeding a session here is gated by the
+ * `administer aabenforms workflows` permission (and the CLI), never exposed to
+ * anonymous citizens, and the resulting session carries the same shape a real
+ * MitID callback would produce so downstream actions behave identically.
+ */
+final class DemoPersonas {
+
+  /**
+   * The demo personas, keyed by a short stable slug.
+   *
+   * The CPRs are synthetic test numbers from the mock realm, not real people.
+   */
+  private const PERSONAS = [
+    'freja' => [
+      'cpr' => '0101904521',
+      'name' => 'Freja Nielsen',
+      'given_name' => 'Freja',
+      'family_name' => 'Nielsen',
+      'email' => 'freja.nielsen@example.dk',
+      'assurance_level' => 'substantial',
+    ],
+    'mikkel' => [
+      'cpr' => '1502856234',
+      'name' => 'Mikkel Jensen',
+      'given_name' => 'Mikkel',
+      'family_name' => 'Jensen',
+      'email' => 'mikkel.jensen@example.dk',
+      'assurance_level' => 'substantial',
+    ],
+    'sofie' => [
+      'cpr' => '2506924015',
+      'name' => 'Sofie Hansen',
+      'given_name' => 'Sofie',
+      'family_name' => 'Hansen',
+      'email' => 'sofie.hansen@example.dk',
+      'assurance_level' => 'high',
+    ],
+    'lars' => [
+      'cpr' => '0803755210',
+      'name' => 'Lars Andersen',
+      'given_name' => 'Lars',
+      'family_name' => 'Andersen',
+      'email' => 'lars.andersen@example.dk',
+      'assurance_level' => 'substantial',
+    ],
+  ];
+
+  /**
+   * Returns all demo personas keyed by slug.
+   *
+   * @return array[]
+   *   Persona definitions keyed by slug.
+   */
+  public static function all(): array {
+    return self::PERSONAS;
+  }
+
+  /**
+   * Returns the valid persona slugs.
+   *
+   * @return string[]
+   *   The persona keys (e.g. 'freja', 'mikkel').
+   */
+  public static function keys(): array {
+    return array_keys(self::PERSONAS);
+  }
+
+  /**
+   * Returns whether a slug names a known demo persona.
+   *
+   * @param string $key
+   *   The persona slug.
+   *
+   * @return bool
+   *   TRUE if the persona exists.
+   */
+  public static function exists(string $key): bool {
+    return isset(self::PERSONAS[$key]);
+  }
+
+  /**
+   * Returns one persona's MitID-session payload, or NULL if unknown.
+   *
+   * The returned array matches the shape a real MitID callback stores, so the
+   * CPR-lookup, audit and Digital Post actions downstream see no difference.
+   *
+   * @param string $key
+   *   The persona slug.
+   *
+   * @return array|null
+   *   The persona's session data, or NULL when the slug is unknown.
+   */
+  public static function get(string $key): ?array {
+    return self::PERSONAS[$key] ?? NULL;
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/src/Drush/AabenformsMitidCommands.php
+++ b/web/modules/custom/aabenforms_mitid/src/Drush/AabenformsMitidCommands.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_mitid\Drush;
+
+use Drupal\aabenforms_mitid\DemoPersonas;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for the ÅbenForms MitID demo harness.
+ *
+ * Provides af:seed, which seeds a demo-citizen MitID session so a gated flow
+ * can be tested through its happy path without a live authentication.
+ */
+final class AabenformsMitidCommands extends DrushCommands {
+
+  public function __construct(
+    private readonly MitIdSessionManager $sessionManager,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Seed a MitID session for a demo citizen so a gated flow can be tested.
+   *
+   * MitID-gated flows deny by default with no verified session (fail-closed).
+   * This mints a session for one of the demo personas, letting you exercise a
+   * flow's happy path without a live MitID/NemLog-in authentication. Pass the
+   * printed workflow id to the flow's workflow_id token, or use the modeler
+   * "Test as demo citizen" action which binds it to your browser session.
+   *
+   * @param string $persona
+   *   Persona slug: freja, mikkel, sofie or lars. Use 'list' to see them all.
+   * @param array $options
+   *   Command options.
+   *
+   * @command aabenforms:seed-mitid-session
+   * @aliases af:seed
+   * @option workflow-id Store the session under this exact workflow id instead
+   *   of a random one.
+   * @usage drush aabenforms:seed-mitid-session freja
+   *   Seed Freja Nielsen and print the workflow id.
+   * @usage drush aabenforms:seed-mitid-session list
+   *   List the available demo personas.
+   */
+  public function seedMitidSession(string $persona, array $options = ['workflow-id' => NULL]): int {
+    if ($persona === 'list') {
+      $rows = [];
+      foreach (DemoPersonas::all() as $slug => $p) {
+        $rows[] = [$slug, $p['name'], $p['cpr'], $p['assurance_level']];
+      }
+      $this->io()->table(['Slug', 'Name', 'CPR', 'Assurance'], $rows);
+      return self::EXIT_SUCCESS;
+    }
+
+    if (!DemoPersonas::exists($persona)) {
+      $this->logger()->error(dt('Unknown persona "@p". Known: @list.', [
+        '@p' => $persona,
+        '@list' => implode(', ', DemoPersonas::keys()),
+      ]));
+      return self::EXIT_FAILURE;
+    }
+
+    $workflowId = $this->sessionManager->seedDemoSession($persona, $options['workflow-id'] ?: NULL);
+    if ($workflowId === NULL) {
+      $this->logger()->error(dt('Failed to seed session for "@p".', ['@p' => $persona]));
+      return self::EXIT_FAILURE;
+    }
+
+    $data = DemoPersonas::get($persona);
+    $this->io()->success(dt('Seeded MitID session for @name (CPR @cpr).', [
+      '@name' => $data['name'],
+      '@cpr' => $data['cpr'],
+    ]));
+    $this->io()->writeln(dt('Workflow id: @id', ['@id' => $workflowId]));
+    $this->io()->writeln(dt('Valid for 15 minutes. Set the flow\'s workflow_id token to this value to pass the gate.'));
+    return self::EXIT_SUCCESS;
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/src/Form/DemoSessionForm.php
+++ b/web/modules/custom/aabenforms_mitid/src/Form/DemoSessionForm.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\aabenforms_mitid\Form;
+
+use Drupal\aabenforms_mitid\DemoPersonas;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Activates a demo MitID identity for testing gated flows in the modeler.
+ *
+ * MitID-gated flows fail closed: with no verified session the gate routes to
+ * the deny terminal, so the modeler's "Test this event" replay always denies
+ * for a gated flow until an identity is established. This form mints a session
+ * for one of the demo personas and binds it to the current browser session
+ * (the same `mitid_workflow_id` key a real login sets), so the very next
+ * "Test this event" - running in this browser - validates and follows the
+ * happy path.
+ */
+class DemoSessionForm extends FormBase {
+
+  /**
+   * Browser-session key bridging login (or this form) to the flow gate.
+   */
+  private const SESSION_WORKFLOW_KEY = 'mitid_workflow_id';
+
+  /**
+   * The MitID session manager.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager
+   */
+  protected MitIdSessionManager $sessionManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->sessionManager = $container->get('aabenforms_mitid.session_manager');
+    // FormBase already declares $requestStack (untyped); assign it here rather
+    // than redeclaring a typed property, which would clash with the parent.
+    $instance->requestStack = $container->get('request_stack');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'aabenforms_mitid_demo_session';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $session = $this->requestStack->getCurrentRequest()?->getSession();
+    $activeId = $session?->get(self::SESSION_WORKFLOW_KEY);
+    $activeData = is_string($activeId) ? $this->sessionManager->getSession($activeId) : NULL;
+
+    $form['intro'] = [
+      '#type' => 'item',
+      '#markup' => $this->t("<p>MitID-gated flows deny by default when no verified identity is present (fail-closed). To run a gated flow through its happy path in the modeler's <em>Test this event</em>, activate a demo citizen below. The identity is bound to your browser for 15 minutes and used by the MitID validation step exactly like a real login.</p>"),
+    ];
+
+    if ($activeData && !empty($activeData['demo_seeded'])) {
+      $form['active'] = [
+        '#type' => 'item',
+        '#markup' => $this->t('<p><strong>Active demo identity:</strong> @name (CPR @cpr). Gated flows tested in this browser will run as this citizen.</p>', [
+          '@name' => $activeData['name'] ?? $activeData['persona'] ?? 'unknown',
+          '@cpr' => $activeData['cpr'] ?? '?',
+        ]),
+      ];
+    }
+
+    $options = [];
+    foreach (DemoPersonas::all() as $slug => $p) {
+      $options[$slug] = $this->t('@name - CPR @cpr (@assurance)', [
+        '@name' => $p['name'],
+        '@cpr' => $p['cpr'],
+        '@assurance' => $p['assurance_level'],
+      ]);
+    }
+
+    $form['persona'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Demo citizen'),
+      '#options' => $options,
+      '#default_value' => DemoPersonas::keys()[0],
+      '#required' => TRUE,
+    ];
+
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Activate demo identity'),
+    ];
+    if ($activeData) {
+      $form['actions']['clear'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Clear demo identity'),
+        '#submit' => ['::clearIdentity'],
+        '#limit_validation_errors' => [],
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $persona = (string) $form_state->getValue('persona');
+    $workflowId = $this->sessionManager->seedDemoSession($persona);
+    if ($workflowId === NULL) {
+      $this->messenger()->addError($this->t('Could not activate demo identity "@p".', ['@p' => $persona]));
+      return;
+    }
+
+    $this->requestStack->getCurrentRequest()?->getSession()?->set(self::SESSION_WORKFLOW_KEY, $workflowId);
+    $data = DemoPersonas::get($persona);
+    $this->messenger()->addStatus($this->t('Demo identity active: @name (CPR @cpr). Run a gated flow Test this event now - it will validate as this citizen for 15 minutes.', [
+      '@name' => $data['name'],
+      '@cpr' => $data['cpr'],
+    ]));
+  }
+
+  /**
+   * Clears the active demo identity from this browser session.
+   *
+   * @param array $form
+   *   The form structure.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function clearIdentity(array &$form, FormStateInterface $form_state): void {
+    $session = $this->requestStack->getCurrentRequest()?->getSession();
+    $activeId = $session?->get(self::SESSION_WORKFLOW_KEY);
+    if (is_string($activeId) && $activeId !== '') {
+      $this->sessionManager->deleteSession($activeId);
+    }
+    $session?->remove(self::SESSION_WORKFLOW_KEY);
+    $this->messenger()->addStatus($this->t('Demo identity cleared. Gated flows will now fail closed again.'));
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
@@ -3,7 +3,9 @@
 namespace Drupal\aabenforms_mitid\Service;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_mitid\DemoPersonas;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Component\Utility\Crypt;
 use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Psr\Log\LoggerInterface;
@@ -141,6 +143,44 @@ class MitIdSessionManager {
       ]);
       return FALSE;
     }
+  }
+
+  /**
+   * Seeds a MitID session for a demo persona (test/demo harness only).
+   *
+   * Stores a session shaped exactly like a real MitID callback would, so a
+   * MitID-gated flow can be exercised through its happy path without a live
+   * authentication. The caller is responsible for access control: this is
+   * reached only from the `aabenforms:seed-mitid-session` Drush command and the
+   * permission-gated modeler "Test as demo citizen" action.
+   *
+   * @param string $persona
+   *   A demo persona slug (see \Drupal\aabenforms_mitid\DemoPersonas).
+   * @param string|null $workflow_id
+   *   The workflow id to key the session under. When NULL an unguessable
+   *   `wf_<hex>` handle is generated (matching MitIdController).
+   *
+   * @return string|null
+   *   The workflow id the session was stored under, or NULL when the persona
+   *   is unknown or storage failed.
+   */
+  public function seedDemoSession(string $persona, ?string $workflow_id = NULL): ?string {
+    $data = DemoPersonas::get($persona);
+    if ($data === NULL) {
+      $this->logger->warning('Refusing to seed unknown demo persona: {persona}', [
+        'persona' => $persona,
+      ]);
+      return NULL;
+    }
+
+    // Mark the session so the audit trail never confuses a seeded demo
+    // identity with a real MitID authentication.
+    $data['demo_seeded'] = TRUE;
+    $data['persona'] = $persona;
+
+    $workflow_id = $workflow_id ?: 'wf_' . substr(Crypt::randomBytesBase64(24), 0, 32);
+
+    return $this->storeSession($workflow_id, $data) ? $workflow_id : NULL;
   }
 
   /**

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdSessionManagerTest.php
@@ -680,4 +680,54 @@ class MitIdSessionManagerTest extends UnitTestCase {
     $this->assertEquals($expected, $result);
   }
 
+  /**
+   * Tests seeding a demo persona stores a real-shaped session.
+   *
+   * @covers ::seedDemoSession
+   */
+  public function testSeedDemoSessionStoresPersona(): void {
+    $captured = NULL;
+    $this->store->expects($this->once())
+      ->method('setWithExpire')
+      ->willReturnCallback(function ($key, $value, $ttl) use (&$captured): void {
+        $captured = ['key' => $key, 'value' => $value, 'ttl' => $ttl];
+      });
+
+    $workflowId = $this->sessionManager->seedDemoSession('freja');
+
+    $this->assertIsString($workflowId);
+    $this->assertStringStartsWith('wf_', $workflowId);
+    $this->assertSame($workflowId, $captured['key']);
+    $this->assertSame('0101904521', $captured['value']['cpr']);
+    $this->assertSame('Freja Nielsen', $captured['value']['name']);
+    $this->assertTrue($captured['value']['demo_seeded']);
+    $this->assertSame('freja', $captured['value']['persona']);
+    $this->assertSame($this->sessionTtl, $captured['ttl']);
+  }
+
+  /**
+   * Tests an explicit workflow id is honoured.
+   *
+   * @covers ::seedDemoSession
+   */
+  public function testSeedDemoSessionExplicitWorkflowId(): void {
+    $this->store->expects($this->once())->method('setWithExpire');
+
+    $result = $this->sessionManager->seedDemoSession('lars', 'wf_fixed');
+
+    $this->assertSame('wf_fixed', $result);
+  }
+
+  /**
+   * Tests an unknown persona is refused without touching storage.
+   *
+   * @covers ::seedDemoSession
+   */
+  public function testSeedDemoSessionUnknownPersona(): void {
+    $this->store->expects($this->never())->method('setWithExpire');
+    $this->logger->expects($this->once())->method('warning');
+
+    $this->assertNull($this->sessionManager->seedDemoSession('nobody'));
+  }
+
 }

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -8,6 +8,7 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
 
 /**
  * Wizard-created workflow configs are preserved across drush cim.
@@ -25,6 +26,17 @@ function aabenforms_workflows_help(string $route_name, RouteMatchInterface $rout
   switch ($route_name) {
     case 'help.page.aabenforms_workflows':
       return '<p>' . t('ECA workflow integration and templates for ÅbenForms.') . '</p>';
+
+    // On the ECA list - the entry point for "Test this event" - explain why a
+    // MitID-gated flow denies in a synthetic test, and how to run its happy
+    // path by activating a demo citizen.
+    case 'entity.eca.collection':
+      if (\Drupal::moduleHandler()->moduleExists('aabenforms_mitid')
+        && \Drupal::currentUser()->hasPermission('administer eca')) {
+        $link = Url::fromRoute('aabenforms_mitid.demo_session')->toString();
+        return '<p>' . t('MitID-gated flows fail closed: with no verified identity, <em>Test this event</em> stops at the deny step. To run a gated flow through its happy path, first <a href=":url">activate a demo citizen</a> - it binds an identity to your browser for 15 minutes.', [':url' => $link]) . '</p>';
+      }
+      return NULL;
   }
   return NULL;
 }

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\eca\Attribute\EcaAction;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * ECA Action: Validate MitID session.
@@ -39,13 +40,72 @@ class MitIdValidateAction extends AabenFormsActionBase {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * Browser-session key under which MitID login binds the workflow id.
+   *
+   * Set by MitIdController::callback() after a successful MitID/NemLog-in
+   * authentication. It is the per-browser, unguessable handle to the stored
+   * session and is the bridge between login and the flow gate.
+   */
+  protected const SESSION_WORKFLOW_KEY = 'mitid_workflow_id';
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->sessionManager = $container->get('aabenforms_mitid.session_manager');
     $instance->configFactory = $container->get('config.factory');
+    $instance->requestStack = $container->get('request_stack');
     return $instance;
+  }
+
+  /**
+   * Resolves the workflow id that scopes the MitID session to validate.
+   *
+   * Resolution order:
+   * 1. The configured ECA token (`workflow_id_token`). A flow, or an upstream
+   *    action, may have populated it explicitly.
+   * 2. Fallback to the browser session's `mitid_workflow_id`, bound at login
+   *    by MitIdController. This is the real bridge between a citizen's MitID
+   *    authentication and the flow gate: the login mints an unguessable
+   *    `wf_<hex>` handle, stashes the session under it, and records it in the
+   *    browser session. A same-browser webform submission (the modeler test
+   *    harness, or the SPA submitting with credentials) carries that cookie,
+   *    so the gate can find the session the citizen just established.
+   *
+   * The fallback is fail-safe: it only ever yields a handle that THIS browser
+   * established via a completed MitID callback. It cannot manufacture identity
+   * - an empty result still routes to the deny terminal.
+   *
+   * @return string
+   *   The resolved workflow id, or '' when none is available.
+   */
+  protected function resolveWorkflowId(): string {
+    $tokenName = $this->configuration['workflow_id_token'] ?? 'workflow_id';
+    $workflowId = $this->getTokenValue($tokenName, '');
+    if (!empty($workflowId)) {
+      return $workflowId;
+    }
+
+    $session = $this->requestStack->getCurrentRequest()?->getSession();
+    // Avoid forcing a session to start when none exists (e.g. CLI/cron),
+    // which would be a no-op anyway and can emit warnings.
+    if ($session && $session->isStarted()) {
+      $bound = $session->get(self::SESSION_WORKFLOW_KEY);
+      if (is_string($bound) && $bound !== '') {
+        $this->log('MitID validation: workflow id taken from browser session (login-bound)', [], 'info');
+        return $bound;
+      }
+    }
+
+    return '';
   }
 
   /**
@@ -152,7 +212,7 @@ class MitIdValidateAction extends AabenFormsActionBase {
    * {@inheritdoc}
    */
   public function execute(): void {
-    $workflowId = $this->getTokenValue($this->configuration['workflow_id_token'] ?? 'workflow_id', '');
+    $workflowId = $this->resolveWorkflowId();
 
     if (empty($workflowId)) {
       $this->recordNoSession('no workflow id in context');

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
@@ -14,6 +14,9 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\eca\EcaState;
 use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
 use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Tests the MitIdValidateAction ECA plugin.
@@ -159,6 +162,39 @@ class MitIdValidateActionTest extends UnitTestCase {
     $configFactoryProperty = $reflectionClass->getProperty('configFactory');
     $configFactoryProperty->setAccessible(TRUE);
     $configFactoryProperty->setValue($this->action, $configFactory);
+
+    // Default request stack: a request whose session is not started, so the
+    // browser-session bridge contributes nothing unless a test opts in via
+    // setBrowserWorkflowId(). This keeps the existing fail-closed tests valid.
+    $this->setBrowserWorkflowId(NULL, FALSE);
+  }
+
+  /**
+   * Injects a request stack whose browser session may carry a workflow id.
+   *
+   * Mirrors how MitIdController binds `mitid_workflow_id` to the browser
+   * session at login; the action's resolveWorkflowId() falls back to it when
+   * the configured token is empty.
+   *
+   * @param string|null $workflowId
+   *   The value to expose under `mitid_workflow_id`, or NULL for none.
+   * @param bool $started
+   *   Whether the session reports itself as started.
+   */
+  protected function setBrowserWorkflowId(?string $workflowId, bool $started = TRUE): void {
+    $session = $this->createMock(SessionInterface::class);
+    $session->method('isStarted')->willReturn($started);
+    $session->method('get')->willReturnCallback(
+      static fn ($key) => $key === 'mitid_workflow_id' ? $workflowId : NULL
+    );
+    $request = $this->createMock(Request::class);
+    $request->method('getSession')->willReturn($session);
+    $requestStack = $this->createMock(RequestStack::class);
+    $requestStack->method('getCurrentRequest')->willReturn($request);
+
+    $property = (new \ReflectionClass($this->action))->getProperty('requestStack');
+    $property->setAccessible(TRUE);
+    $property->setValue($this->action, $requestStack);
   }
 
   /**
@@ -373,6 +409,63 @@ class MitIdValidateActionTest extends UnitTestCase {
     $this->action->execute();
 
     // Verify result is FALSE (fail closed).
+    $this->assertFalse($this->tokenStorage['mitid_valid']);
+  }
+
+  /**
+   * Tests the browser-session bridge resolves the workflow id.
+   *
+   * When the configured token is empty (the usual case for a real submission,
+   * where nothing populates `workflow_id_<flow>`), the action falls back to
+   * the `mitid_workflow_id` the login bound to the browser session, so the
+   * gate finds the citizen's session and validates.
+   *
+   * @covers ::execute
+   * @covers ::resolveWorkflowId
+   */
+  public function testWorkflowIdFromBrowserSession(): void {
+    $workflowId = 'wf_browserbound';
+    $sessionData = [
+      'cpr' => '0101904521',
+      'name' => 'Freja Nielsen',
+      'assurance_level' => 'substantial',
+      'created_at' => time() - 60,
+      'expires_at' => time() + 600,
+    ];
+
+    // Token is NOT set; the only source is the browser session.
+    $this->setBrowserWorkflowId($workflowId);
+
+    $this->sessionManager->expects($this->once())
+      ->method('getSession')
+      ->with($workflowId)
+      ->willReturn($sessionData);
+
+    $this->action->execute();
+
+    $this->assertTrue($this->tokenStorage['mitid_valid'], 'Bridge should let a valid session validate.');
+    $this->assertEquals($sessionData, $this->tokenStorage['mitid_session']);
+  }
+
+  /**
+   * Tests the configured token wins over the browser session.
+   *
+   * @covers ::resolveWorkflowId
+   */
+  public function testTokenTakesPrecedenceOverBrowserSession(): void {
+    $this->tokenStorage['workflow_id'] = 'wf_from_token';
+    $this->setBrowserWorkflowId('wf_from_browser');
+
+    $this->sessionManager->expects($this->once())
+      ->method('getSession')
+      ->with('wf_from_token')
+      ->willReturn(NULL);
+
+    // No session for the token id -> fail closed, browser id never consulted.
+    $this->logger->expects($this->once())->method('warning');
+
+    $this->action->execute();
+
     $this->assertFalse($this->tokenStorage['mitid_valid']);
   }
 


### PR DESCRIPTION
## Why

The long-standing "why does a gated flow end up in deny?" puzzle, root-caused.

Every MitID-gated flow's `mitid_validate` reads its workflow id from a **bare ECA token** (`workflow_id_building_permit`, `workflow_id_med_nomination`, ...). Nothing populates that token on a real submission - not the webform submit controller, not a handler, not an upstream action. So `resolveWorkflowId()` got `''` and the gate denied **every** submission unless `allow_mitid_demo_mode` was on. The login *does* mint a per-browser `wf_<hex>` session and bind it to the browser as `mitid_workflow_id` (`MitIdController:174`), but that handle was never carried into the gate.

## What

**The bridge (security-relevant).** `MitIdValidateAction` now falls back to the browser session's `mitid_workflow_id` when its configured token is empty. A same-browser submission (the modeler "Test this event", or the SPA submitting with credentials) finds the session the citizen established at login.

- **Fail-closed is preserved:** with no login-bound session in the browser, the gate still routes to the deny terminal. The fallback only ever yields a handle this browser established via a completed MitID callback - it cannot manufacture identity, and sessions are per-browser so one citizen can't pick up another's.

**Demo-citizen harness** (the requested feature - test gated flows without a live login):
- `DemoPersonas` - the four demo citizens (freja/mikkel/sofie/lars), mirroring the `cpr`-bearing users in the mock IdP realm.
- `MitIdSessionManager::seedDemoSession()` - stores a real-shaped session, tagged `demo_seeded` for the audit trail.
- `drush aabenforms:seed-mitid-session` (`af:seed`) - seed a persona from the CLI; `af:seed list` lists them.
- Admin form **/admin/config/aabenforms/mitid/demo-session** ("Test as demo citizen", `administer eca`) - seeds a persona and binds it to the current browser, so the next "Test this event" runs the happy path; "Clear demo identity" removes it.
- `hook_help` on the ECA list explains why gated flows deny in a synthetic test and links to the tool.

## Verified end-to-end (live DDEV, demo mode OFF)

| State | MitID gate | Flow |
|---|---|---|
| Demo identity active (Freja) | completed | CPR lookup -> audit -> Digital Post, all green |
| Demo identity cleared | failed | deny terminal (fail-closed) |

- `phpunit --testsuite unit`: 365 passing (incl. 2 new bridge tests + 3 seed tests).
- MitID + multi-party kernel tests green.
- phpcs (Drupal, DrupalPractice) clean on changed files.

## Note on prod
This fixes a real gap: with the gate deployed and no bridge, legitimate citizen submissions could only pass via demo mode. The browser-session bridge is the intended login->gate linkage. No auto-deploy; merge gates the rollout.