### PR TITLE
Accept workflow_id from submission payload at the MitID gate (fixes cross-origin demo deny)

### DIFF
--- a/web/modules/custom/aabenforms_core/src/Controller/WebformApiController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/WebformApiController.php
@@ -101,6 +101,19 @@ class WebformApiController extends ControllerBase {
 
     $submission_data = $data['data']['attributes']['data'] ?? $data['data'];
 
+    // The SPA POSTs from a different origin than the backend cookie domain, so
+    // the MitID session cookie is not shared. The unguessable workflow_id the
+    // SPA holds from login travels in the payload instead; stash it on the
+    // request so MitIdValidateAction can scope the identity gate to it when the
+    // ECA workflow fires synchronously inside save() below.
+    $workflow_id = $data['data']['attributes']['workflow_id']
+      ?? $data['data']['workflow_id']
+      ?? $data['workflow_id']
+      ?? NULL;
+    if (is_string($workflow_id) && $workflow_id !== '') {
+      $request->attributes->set('aabenforms_workflow_id', $workflow_id);
+    }
+
     $values = [
       'webform_id' => $id,
       'entity_type' => NULL,

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -67,22 +67,34 @@ class MitIdValidateAction extends AabenFormsActionBase {
   }
 
   /**
+   * Request attribute the webform controller stashes the submitted id under.
+   *
+   * @see \Drupal\aabenforms_core\Controller\WebformApiController::submitWebform()
+   */
+  protected const REQUEST_WORKFLOW_ATTR = 'aabenforms_workflow_id';
+
+  /**
    * Resolves the workflow id that scopes the MitID session to validate.
    *
-   * Resolution order:
-   * 1. The configured ECA token (`workflow_id_token`). A flow, or an upstream
-   *    action, may have populated it explicitly.
-   * 2. Fallback to the browser session's `mitid_workflow_id`, bound at login
-   *    by MitIdController. This is the real bridge between a citizen's MitID
-   *    authentication and the flow gate: the login mints an unguessable
-   *    `wf_<hex>` handle, stashes the session under it, and records it in the
-   *    browser session. A same-browser webform submission (the modeler test
-   *    harness, or the SPA submitting with credentials) carries that cookie,
-   *    so the gate can find the session the citizen just established.
+   * `workflow_id` is the bearer capability minted at MitID login (an
+   * unguessable `wf_<hex>` the session is stored under); whoever holds it can
+   * read that session for 15 minutes. The SPA that drove the login holds it,
+   * so the gate accepts it back from the submission. Resolution order:
    *
-   * The fallback is fail-safe: it only ever yields a handle that THIS browser
-   * established via a completed MitID callback. It cannot manufacture identity
-   * - an empty result still routes to the deny terminal.
+   * 1. The configured ECA token (`workflow_id_token`) - a flow or upstream
+   *    action may have populated it explicitly.
+   * 2. The id the submission carried, stashed on the request by the webform
+   *    controller (or passed as a `workflow_id` query param). This is the
+   *    cross-origin path: the SPA POSTs from a different host than the backend
+   *    cookie domain, so a shared session cookie is NOT available - the id
+   *    travels in the request payload instead.
+   * 3. The browser session's `mitid_workflow_id`, bound at login by
+   *    MitIdController. This is the same-origin path: the modeler test harness
+   *    (and any same-origin submission) carries the backend cookie.
+   *
+   * Fail-safe in every case: each source only yields a handle the caller
+   * already legitimately holds, and an empty result routes to the deny
+   * terminal. It can never manufacture identity.
    *
    * @return string
    *   The resolved workflow id, or '' when none is available.
@@ -94,14 +106,25 @@ class MitIdValidateAction extends AabenFormsActionBase {
       return $workflowId;
     }
 
-    $session = $this->requestStack->getCurrentRequest()?->getSession();
-    // Avoid forcing a session to start when none exists (e.g. CLI/cron),
-    // which would be a no-op anyway and can emit warnings.
-    if ($session && $session->isStarted()) {
-      $bound = $session->get(self::SESSION_WORKFLOW_KEY);
-      if (is_string($bound) && $bound !== '') {
-        $this->log('MitID validation: workflow id taken from browser session (login-bound)', [], 'info');
-        return $bound;
+    $request = $this->requestStack->getCurrentRequest();
+    if ($request) {
+      // Cross-origin SPA: the id rides in the request payload.
+      $fromRequest = $request->attributes->get(self::REQUEST_WORKFLOW_ATTR)
+        ?? $request->query->get('workflow_id');
+      if (is_string($fromRequest) && $fromRequest !== '') {
+        $this->log('MitID validation: workflow id taken from submission payload', [], 'info');
+        return $fromRequest;
+      }
+
+      // Same-origin: the login-bound browser session. Avoid forcing a session
+      // to start when none exists (e.g. CLI/cron), which would be a no-op.
+      $session = $request->getSession();
+      if ($session && $session->isStarted()) {
+        $bound = $session->get(self::SESSION_WORKFLOW_KEY);
+        if (is_string($bound) && $bound !== '') {
+          $this->log('MitID validation: workflow id taken from browser session (login-bound)', [], 'info');
+          return $bound;
+        }
       }
     }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
@@ -170,31 +170,54 @@ class MitIdValidateActionTest extends UnitTestCase {
   }
 
   /**
-   * Injects a request stack whose browser session may carry a workflow id.
+   * Injects a request stack with the given workflow-id sources populated.
    *
-   * Mirrors how MitIdController binds `mitid_workflow_id` to the browser
-   * session at login; the action's resolveWorkflowId() falls back to it when
-   * the configured token is empty.
+   * Mirrors the three request-side sources resolveWorkflowId() consults: the
+   * submission payload (stashed on the request as an attribute by the webform
+   * controller), a `workflow_id` query param, and the login-bound browser
+   * session `mitid_workflow_id`.
    *
-   * @param string|null $workflowId
-   *   The value to expose under `mitid_workflow_id`, or NULL for none.
-   * @param bool $started
-   *   Whether the session reports itself as started.
+   * @param array $sources
+   *   Any of: 'attribute', 'query', 'session' (string values), and
+   *   'session_started' (bool, default TRUE).
    */
-  protected function setBrowserWorkflowId(?string $workflowId, bool $started = TRUE): void {
+  protected function setRequestContext(array $sources = []): void {
     $session = $this->createMock(SessionInterface::class);
-    $session->method('isStarted')->willReturn($started);
+    $session->method('isStarted')->willReturn($sources['session_started'] ?? TRUE);
     $session->method('get')->willReturnCallback(
-      static fn ($key) => $key === 'mitid_workflow_id' ? $workflowId : NULL
+      static fn ($key) => $key === 'mitid_workflow_id' ? ($sources['session'] ?? NULL) : NULL
     );
-    $request = $this->createMock(Request::class);
-    $request->method('getSession')->willReturn($session);
+
+    $request = new Request();
+    $request->setSession($session);
+    if (isset($sources['attribute'])) {
+      $request->attributes->set('aabenforms_workflow_id', $sources['attribute']);
+    }
+    if (isset($sources['query'])) {
+      $request->query->set('workflow_id', $sources['query']);
+    }
+
     $requestStack = $this->createMock(RequestStack::class);
     $requestStack->method('getCurrentRequest')->willReturn($request);
 
     $property = (new \ReflectionClass($this->action))->getProperty('requestStack');
     $property->setAccessible(TRUE);
     $property->setValue($this->action, $requestStack);
+  }
+
+  /**
+   * Convenience: only the browser session carries the workflow id.
+   *
+   * @param string|null $workflowId
+   *   The value under `mitid_workflow_id`, or NULL for none.
+   * @param bool $started
+   *   Whether the session reports itself as started.
+   */
+  protected function setBrowserWorkflowId(?string $workflowId, bool $started = TRUE): void {
+    $this->setRequestContext([
+      'session' => $workflowId,
+      'session_started' => $started,
+    ]);
   }
 
   /**
@@ -445,6 +468,59 @@ class MitIdValidateActionTest extends UnitTestCase {
 
     $this->assertTrue($this->tokenStorage['mitid_valid'], 'Bridge should let a valid session validate.');
     $this->assertEquals($sessionData, $this->tokenStorage['mitid_session']);
+  }
+
+  /**
+   * Tests the cross-origin path: workflow id from the submission payload.
+   *
+   * The webform controller stashes the SPA-supplied workflow_id on the request
+   * as an attribute; the gate reads it when no cookie/token is present.
+   *
+   * @covers ::resolveWorkflowId
+   */
+  public function testWorkflowIdFromRequestPayload(): void {
+    $workflowId = 'wf_from_payload';
+    $sessionData = [
+      'cpr' => '2506924015',
+      'name' => 'Sofie Hansen',
+      'created_at' => time() - 60,
+      'expires_at' => time() + 600,
+    ];
+
+    // No token, no browser session - only the request attribute.
+    $this->setRequestContext(['attribute' => $workflowId, 'session_started' => FALSE]);
+
+    $this->sessionManager->expects($this->once())
+      ->method('getSession')
+      ->with($workflowId)
+      ->willReturn($sessionData);
+
+    $this->action->execute();
+
+    $this->assertTrue($this->tokenStorage['mitid_valid'], 'Payload-supplied id should validate.');
+  }
+
+  /**
+   * Tests the payload id is preferred over the browser session.
+   *
+   * @covers ::resolveWorkflowId
+   */
+  public function testPayloadPreferredOverBrowserSession(): void {
+    $this->setRequestContext([
+      'attribute' => 'wf_payload',
+      'session' => 'wf_browser',
+    ]);
+
+    $this->sessionManager->expects($this->once())
+      ->method('getSession')
+      ->with('wf_payload')
+      ->willReturn(NULL);
+
+    $this->logger->expects($this->once())->method('warning');
+
+    $this->action->execute();
+
+    $this->assertFalse($this->tokenStorage['mitid_valid']);
   }
 
   /**


### PR DESCRIPTION
## Why

Follow-up to #119. On prod the demo still denied every submission - the logs showed the session created at login, then immediately:

```
MitID session stored for workflow: …
MitID validation failed: no workflow id in context
Flow denied at gate: building_permit_denied
```

#119's browser-session bridge only works **same-origin**. The production SPA POSTs from a different host than the backend cookie domain, so the MitID session cookie isn't shared - the submit hits a fresh anonymous session, the gate resolves empty, deny. (Exactly the cross-origin trap the `MitIdSessionManager` docblock warns about.)

## Fix

`workflow_id` is the bearer capability minted at login (the unguessable `wf_<hex>` the session is stored under). The SPA already holds it - it's the same handle it uses for the Digital Post inbox (`?session=`). So it now travels in the submission payload:

- **Frontend** (separate PR on `aabenforms-frontend`): sends `data.attributes.workflow_id = sessionId`.
- **`WebformApiController`** stashes the payload `workflow_id` on the request.
- **`MitIdValidateAction::resolveWorkflowId()`** now resolves in order: configured token → request payload (attribute, then `?workflow_id=`) → login-bound browser session. The ECA workflow fires synchronously inside `save()` in the same request, so the gate sees it.

Fail-closed is unchanged - an absent/unknown id yields no session and routes to the deny terminal.

## Verified (local, no cookie - simulates cross-origin)

| Payload `workflow_id` | MitID gate | Flow |
|---|---|---|
| seeded session id | completed | CPR lookup → audit → Digital Post, all green |
| `wf_does_not_exist` | failed | deny terminal (fail-closed) |

- `phpunit --testsuite unit`: 367 passing (2 new payload-path tests).
- phpcs clean.

## Security note
Accepting `workflow_id` in the request is consistent with the existing model: it's a 128-bit unguessable bearer token already accepted by the inbox endpoint, only ever held by the SPA that performed the login. It cannot manufacture identity - an invalid id simply finds no session.

Needs the frontend PR deployed too for the live demo to pass end-to-end.