### PR TITLE
af:modeler-adopt - repair ECA flows that fell back to BPMN.iO

### DIFF
--- a/web/modules/custom/aabenforms_workflows/drush.services.yml
+++ b/web/modules/custom/aabenforms_workflows/drush.services.yml
@@ -5,3 +5,9 @@ services:
       - '@aabenforms_workflows.approval_token'
     tags:
       - { name: drush.command }
+  aabenforms_workflows.drush_modeler:
+    class: Drupal\aabenforms_workflows\Drush\ModelerCommands
+    arguments:
+      - '@entity_type.manager'
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/aabenforms_workflows/src/Drush/ModelerCommands.php
+++ b/web/modules/custom/aabenforms_workflows/src/Drush/ModelerCommands.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Drush;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for keeping ECA flows owned by the workflow modeler.
+ *
+ * An ECA flow renders in the React workflow modeler only while its config
+ * carries the `modeler_api.modeler_id` third-party setting. ModelOwnerBase
+ * defaults a missing setting to "fallback", which drops the flow to the
+ * BPMN.iO editor. Some ECA save paths (and editing a flow in BPMN.iO) strip
+ * that setting, so flows silently regress to fallback even though config/sync
+ * declares the modeler. `af:modeler-adopt` re-asserts it across every flow;
+ * it is idempotent and safe to run as a post-deploy step.
+ */
+final class ModelerCommands extends DrushCommands {
+
+  /**
+   * The modeler id every ÅbenForms flow should be owned by.
+   */
+  private const MODELER_ID = 'workflow_modeler';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Ensure every ECA flow is owned by the React workflow modeler.
+   *
+   * Sets the `modeler_api.modeler_id` third-party setting to workflow_modeler
+   * on any flow that is missing it (i.e. showing as "Fallback" / editable only
+   * via BPMN.iO). Idempotent: flows already owned by the modeler are left
+   * untouched.
+   *
+   * @command aabenforms:modeler:adopt
+   * @aliases af:modeler-adopt
+   * @usage drush aabenforms:modeler:adopt
+   *   Repair every flow that has fallen back to the BPMN.iO editor.
+   */
+  public function adopt(): int {
+    $storage = $this->entityTypeManager->getStorage('eca');
+    /** @var \Drupal\Core\Config\Entity\ThirdPartySettingsInterface[] $flows */
+    $flows = $storage->loadMultiple();
+
+    $fixed = [];
+    foreach ($flows as $id => $flow) {
+      if ($flow->getThirdPartySetting('modeler_api', 'modeler_id', 'fallback') === self::MODELER_ID) {
+        continue;
+      }
+      $flow->setThirdPartySetting('modeler_api', 'modeler_id', self::MODELER_ID);
+      // ModelerApi shows this label in the list; default it to the flow id when
+      // none is present so the row stays readable.
+      if ($flow->getThirdPartySetting('modeler_api', 'label', '') === '') {
+        $flow->setThirdPartySetting('modeler_api', 'label', $id);
+      }
+      $flow->save();
+      $fixed[] = $id;
+    }
+
+    if ($fixed === []) {
+      $this->io()->success(dt('All @count flows already use the workflow modeler.', [
+        '@count' => count($flows),
+      ]));
+      return self::EXIT_SUCCESS;
+    }
+
+    $this->io()->success(dt('Adopted the workflow modeler on @n flow(s):', ['@n' => count($fixed)]));
+    $this->io()->listing($fixed);
+    return self::EXIT_SUCCESS;
+  }
+
+}


### PR DESCRIPTION
## Problem

Several flows (association_booking, contact_form, company_verification, phone_declaration, ...) render as **"Fallback"** with only an "Edit with BPMN.iO" link instead of the React workflow modeler.

Root cause, confirmed in contrib: `ModelOwnerBase::getModelerId()` returns `getThirdPartySetting('modeler_api', 'modeler_id', 'fallback')` - a flow shows as Fallback **exactly when that third-party setting is absent**. `config/sync` declares `workflow_modeler` for all flows, but some ECA save paths (and editing a flow in BPMN.iO) strip it, and `drush cim` does not reconcile the third-party setting back. So flows silently regress.

Reproduced locally: stripping the setting → "fallback"; re-setting it via the entity API → "workflow_modeler", and it sticks.

## Fix

`drush aabenforms:modeler:adopt` (alias `af:modeler-adopt`) re-asserts `modeler_id=workflow_modeler` (plus a readable label) on every flow that lost it, using the same entity-API write the modeler save performs. Idempotent - flows already owned by the modeler are untouched.

Paired with a deploy.yml post-deploy step (infra repo) so flows self-heal on every release.

## Verified

```
# break 2 flows, then:
$ drush af:modeler-adopt
[OK] Adopted the workflow modeler on 2 flow(s): company_verification_flow, contact_form_flow
$ drush af:modeler-adopt
[OK] All 19 flows already use the workflow modeler.
```

phpcs clean.