### PR TITLE
Fix dead caseworker_review_flow gate (verified audit critical)

### DIFF
--- a/config/sync/eca.eca.caseworker_review_flow.yml
+++ b/config/sync/eca.eca.caseworker_review_flow.yml
@@ -20,29 +20,18 @@ events:
       type: 'webform_submission parent_request_form'
     successors:
       -
-        id: check_both_complete
-        condition: ''
-conditions:
-  check_both_complete:
-    plugin: eca_scalar
-    configuration:
-      operator: '=='
-      left_value: '[webform_submission:data:parent1_status][webform_submission:data:parent2_status]'
-      right_value: completecomplete
-    successors:
-      -
-        id: check_caseworker_pending
-        condition: 'true'
-  check_caseworker_pending:
-    plugin: eca_scalar
-    configuration:
-      operator: '=='
-      left_value: '[webform_submission:data:caseworker_status]'
-      right_value: pending
-    successors:
-      -
         id: caseworker_audit
-        condition: 'true'
+        condition: gate_ready_for_caseworker
+conditions:
+  gate_ready_for_caseworker:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:parent1_status][webform_submission:values:parent2_status][webform_submission:values:caseworker_status]'
+      right: completecompletepending
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   caseworker_audit:


### PR DESCRIPTION
## What

`caseworker_review_flow` (flagged in the expert audit, PR #122) never evaluated. Three bugs, all in one flow:

1. **Wrong eca_scalar contract** - `operator: '=='` + `left_value`/`right_value` instead of `operator: equal` + `left`/`right` + `negate` (the contract documented in `reference_eca_scalar_gating`).
2. **`successors` on conditions** - a schema violation that silently creates dead code.
3. **Wrong token path** - `[webform_submission:data:...]` instead of the resolving `[webform_submission:values:...]`.

Net effect: both parents could approve and the caseworker assignment was **never recorded**.

## Fix

Collapse the two illegally-chained condition checks into a single valid gate on the event - one `eca_scalar` requiring `parent1_status` + `parent2_status` + `caseworker_status` = `complete`/`complete`/`pending` (the same concatenation idiom the original used) - routed to the existing audit + mark-assigned actions. No gateways, correct contract, no successors on conditions.

## Verified

Submitting a `parent_request_form` and marking both parents complete now fires the `caseworker_review` audit (before: nothing). Confirmed via a live submission on DDEV (audit count 44 -> 45).

## Known follow-up (not this PR)

`mark_caseworker_assigned` uses `eca_token_set_value`, which sets a transient token rather than persisting `caseworker_status`, so a later UPDATE while the field is still `pending` re-audits. The **happy path audits exactly once** (parent1 then parent2 approve). Persisting the field idempotently needs an entity set-field+save that must be tested for save-loops, so it's tracked separately rather than risked here.