### PR TITLE
Verify MitID id_token signature against issuer JWKS (closes identity-forgery critical)

### DIFF
--- a/config/sync/aabenforms_mitid.settings.yml
+++ b/config/sync/aabenforms_mitid.settings.yml
@@ -14,6 +14,11 @@ token_endpoint: 'http://keycloak:8080/realms/danish-gov-test/protocol/openid-con
 userinfo_endpoint: 'http://keycloak:8080/realms/danish-gov-test/protocol/openid-connect/userinfo'
 redirect_uri: 'https://aabenforms.ddev.site/mitid/callback'
 issuer: 'http://keycloak:8080/realms/danish-gov-test'
+accepted_issuers:
+  # The containerised Keycloak issues tokens with the browser-facing host
+  # (localhost:8080) while the backend reaches it - and fetches JWKS - via the
+  # internal host (keycloak:8080, the `issuer` above). Both are the same realm.
+  - 'http://localhost:8080/realms/danish-gov-test'
 scopes:
   - openid
   - ssn

--- a/web/modules/custom/aabenforms_mitid/aabenforms_mitid.services.yml
+++ b/web/modules/custom/aabenforms_mitid/aabenforms_mitid.services.yml
@@ -13,6 +13,14 @@ services:
       - '@logger.factory'
       - '@aabenforms_core.audit_logger'
 
+  aabenforms_mitid.token_verifier:
+    class: Drupal\aabenforms_mitid\Service\MitIdTokenVerifier
+    arguments:
+      - '@config.factory'
+      - '@http_client'
+      - '@cache.default'
+      - '@logger.factory'
+
   aabenforms_mitid.oidc_client:
     class: Drupal\aabenforms_mitid\Service\MitIdOidcClient
     arguments:
@@ -21,3 +29,4 @@ services:
       - '@logger.factory'
       - '@aabenforms_mitid.cpr_extractor'
       - '@aabenforms_mitid.session_manager'
+      - '@aabenforms_mitid.token_verifier'

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php
@@ -60,6 +60,13 @@ class MitIdOidcClient {
   protected MitIdSessionManager $sessionManager;
 
   /**
+   * The id_token signature verifier.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdTokenVerifier
+   */
+  protected MitIdTokenVerifier $tokenVerifier;
+
+  /**
    * Constructs a MitIdOidcClient.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -72,6 +79,8 @@ class MitIdOidcClient {
    *   The CPR extractor.
    * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $session_manager
    *   The session manager.
+   * @param \Drupal\aabenforms_mitid\Service\MitIdTokenVerifier $token_verifier
+   *   The id_token signature verifier.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
@@ -79,12 +88,14 @@ class MitIdOidcClient {
     LoggerChannelFactoryInterface $logger_factory,
     MitIdCprExtractor $cpr_extractor,
     MitIdSessionManager $session_manager,
+    MitIdTokenVerifier $token_verifier,
   ) {
     $this->configFactory = $config_factory;
     $this->httpClient = $http_client;
     $this->logger = $logger_factory->get('aabenforms_mitid');
     $this->cprExtractor = $cpr_extractor;
     $this->sessionManager = $session_manager;
+    $this->tokenVerifier = $token_verifier;
   }
 
   /**
@@ -280,9 +291,10 @@ class MitIdOidcClient {
    *   If validation fails.
    */
   public function validateIdToken(string $id_token): array {
-    if (!$this->cprExtractor->validateToken($id_token)) {
-      throw new \RuntimeException('ID token validation failed');
-    }
+    // Cryptographically verify the id_token before trusting ANY claim: RS256
+    // signature against the issuer JWKS, plus iss/aud/exp. Fail closed - a
+    // forged or tampered token must never reach claim extraction.
+    $this->tokenVerifier->verify($id_token);
 
     return $this->cprExtractor->extractPersonData($id_token);
   }

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdTokenVerifier.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdTokenVerifier.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Drupal\aabenforms_mitid\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use GuzzleHttp\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Cryptographically verifies MitID/NemLog-in id_tokens against the IdP JWKS.
+ *
+ * The previous code trusted the id_token after only decoding its payload, with
+ * no signature check and no issuer/audience validation - a JWT with arbitrary
+ * CPR claims would be accepted. This service closes that hole: it verifies the
+ * RS256 signature against the issuer's published JWKS (fetched + cached), then
+ * validates iss, aud, exp/iat/nbf. It fails CLOSED - any doubt throws and the
+ * caller must reject the login.
+ *
+ * Dependency-free on purpose: openssl_verify() performs the actual signature
+ * check; this class only converts a JWK (modulus/exponent) into a PEM public
+ * key via a deterministic DER encoding, so no composer dependency is added to
+ * a security-critical path.
+ */
+class MitIdTokenVerifier {
+
+  /**
+   * JWKS cache lifetime (seconds).
+   */
+  protected const JWKS_TTL = 3600;
+
+  /**
+   * Allowed clock skew when checking exp/iat/nbf (seconds).
+   */
+  protected const LEEWAY = 60;
+
+  public function __construct(
+    protected ConfigFactoryInterface $configFactory,
+    protected ClientInterface $httpClient,
+    protected CacheBackendInterface $cache,
+    LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->logger = $loggerFactory->get('aabenforms_mitid');
+  }
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Verifies an id_token and returns its validated claims.
+   *
+   * @param string $idToken
+   *   Compact JWS (header.payload.signature).
+   *
+   * @return array
+   *   The validated claim set.
+   *
+   * @throws \RuntimeException
+   *   On any signature, issuer, audience or temporal validation failure.
+   */
+  public function verify(string $idToken): array {
+    $parts = explode('.', $idToken);
+    if (count($parts) !== 3) {
+      throw new \RuntimeException('id_token is not a compact JWS (expected 3 parts).');
+    }
+    [$encodedHeader, $encodedPayload, $encodedSignature] = $parts;
+
+    $header = json_decode($this->b64UrlDecode($encodedHeader), TRUE);
+    $claims = json_decode($this->b64UrlDecode($encodedPayload), TRUE);
+    if (!is_array($header) || !is_array($claims)) {
+      throw new \RuntimeException('id_token header or payload is not valid JSON.');
+    }
+
+    $alg = $header['alg'] ?? '';
+    if ($alg !== 'RS256') {
+      // Reject anything we do not cryptographically verify - notably "none"
+      // and any HMAC alg an attacker might substitute.
+      throw new \RuntimeException('Unsupported id_token alg: ' . $alg . ' (only RS256 is accepted).');
+    }
+
+    $kid = $header['kid'] ?? '';
+    $jwk = $this->signingKey($kid);
+    if ($jwk === NULL) {
+      throw new \RuntimeException('No matching RS256 signing key for kid: ' . ($kid ?: '(none)'));
+    }
+
+    $signature = $this->b64UrlDecode($encodedSignature);
+    $signingInput = $encodedHeader . '.' . $encodedPayload;
+    $pem = $this->jwkToPem($jwk);
+
+    $ok = openssl_verify($signingInput, $signature, $pem, OPENSSL_ALGO_SHA256);
+    if ($ok !== 1) {
+      throw new \RuntimeException('id_token signature verification failed.');
+    }
+
+    $this->validateClaims($claims);
+    return $claims;
+  }
+
+  /**
+   * Validates issuer, audience and temporal claims.
+   *
+   * @param array $claims
+   *   The decoded claims.
+   *
+   * @throws \RuntimeException
+   *   If any check fails.
+   */
+  protected function validateClaims(array $claims): void {
+    $config = $this->configFactory->get('aabenforms_mitid.settings');
+    $now = time();
+
+    // Issuer allowlist: the primary `issuer` plus any `accepted_issuers`. The
+    // extra list exists for split-hostname IdP setups where the token's iss
+    // (browser-facing host) differs from the backend-reachable host used for
+    // the token exchange and JWKS fetch (e.g. a containerised Keycloak).
+    $accepted = array_values(array_filter(array_merge(
+      [(string) ($config->get('issuer') ?? '')],
+      array_map('strval', (array) ($config->get('accepted_issuers') ?? [])),
+    ), 'strlen'));
+    if ($accepted !== [] && !in_array((string) ($claims['iss'] ?? ''), $accepted, TRUE)) {
+      throw new \RuntimeException('id_token issuer mismatch.');
+    }
+
+    $clientId = (string) ($config->get('client_id') ?? '');
+    $aud = $claims['aud'] ?? [];
+    $audList = is_array($aud) ? $aud : [$aud];
+    if ($clientId !== '' && !in_array($clientId, $audList, TRUE)) {
+      throw new \RuntimeException('id_token audience does not include this client.');
+    }
+
+    if (!isset($claims['exp']) || ($claims['exp'] + self::LEEWAY) < $now) {
+      throw new \RuntimeException('id_token is expired.');
+    }
+    if (isset($claims['nbf']) && ($claims['nbf'] - self::LEEWAY) > $now) {
+      throw new \RuntimeException('id_token is not yet valid (nbf).');
+    }
+    if (isset($claims['iat']) && ($claims['iat'] - self::LEEWAY) > $now) {
+      throw new \RuntimeException('id_token issued in the future (iat).');
+    }
+  }
+
+  /**
+   * Returns the JWKS signing key for a kid, refreshing once on a miss.
+   *
+   * @param string $kid
+   *   The key id from the token header.
+   *
+   * @return array|null
+   *   The matching JWK, or NULL when none is found.
+   */
+  protected function signingKey(string $kid): ?array {
+    $key = $this->findKey($this->jwks(FALSE), $kid);
+    if ($key !== NULL) {
+      return $key;
+    }
+    // Key rotation: the IdP may have published a new kid since we cached.
+    // Refetch once, bypassing the cache, before giving up.
+    return $this->findKey($this->jwks(TRUE), $kid);
+  }
+
+  /**
+   * Selects an RSA signing key (use=sig, RS256) matching kid from a key set.
+   */
+  protected function findKey(array $keys, string $kid): ?array {
+    foreach ($keys as $jwk) {
+      if (($jwk['kty'] ?? '') !== 'RSA') {
+        continue;
+      }
+      if (($jwk['use'] ?? 'sig') !== 'sig') {
+        continue;
+      }
+      if (isset($jwk['alg']) && $jwk['alg'] !== 'RS256') {
+        continue;
+      }
+      if ($kid === '' || ($jwk['kid'] ?? '') === $kid) {
+        return $jwk;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Fetches the JWKS key array, cached for JWKS_TTL.
+   *
+   * @param bool $forceRefresh
+   *   When TRUE, bypass and overwrite the cache.
+   *
+   * @return array
+   *   The list of JWK entries (possibly empty).
+   */
+  protected function jwks(bool $forceRefresh): array {
+    $uri = $this->jwksUri();
+    if ($uri === '') {
+      throw new \RuntimeException('No jwks_uri configured or derivable for id_token verification.');
+    }
+    $cid = 'aabenforms_mitid:jwks:' . md5($uri);
+
+    if (!$forceRefresh) {
+      $cached = $this->cache->get($cid);
+      if ($cached && is_array($cached->data)) {
+        return $cached->data;
+      }
+    }
+
+    try {
+      $response = $this->httpClient->get($uri, ['headers' => ['Accept' => 'application/json']]);
+      $data = json_decode((string) $response->getBody(), TRUE);
+      $keys = (is_array($data) && isset($data['keys']) && is_array($data['keys'])) ? $data['keys'] : [];
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('JWKS fetch failed from {uri}: {error}', ['uri' => $uri, 'error' => $e->getMessage()]);
+      // Fall back to a stale cache if we have one - better than failing every
+      // login on a transient IdP blip - but never invent keys.
+      $stale = $this->cache->get($cid);
+      if ($stale && is_array($stale->data)) {
+        return $stale->data;
+      }
+      throw new \RuntimeException('Unable to retrieve JWKS for id_token verification.');
+    }
+
+    $this->cache->set($cid, $keys, time() + self::JWKS_TTL);
+    return $keys;
+  }
+
+  /**
+   * Resolves the JWKS URI from config, OIDC discovery, or Keycloak default.
+   */
+  protected function jwksUri(): string {
+    $config = $this->configFactory->get('aabenforms_mitid.settings');
+    $explicit = (string) ($config->get('jwks_uri') ?? '');
+    if ($explicit !== '') {
+      return $explicit;
+    }
+
+    $issuer = rtrim((string) ($config->get('issuer') ?? ''), '/');
+    if ($issuer === '') {
+      return '';
+    }
+
+    // Try OIDC discovery (cached) for the authoritative jwks_uri.
+    $cid = 'aabenforms_mitid:jwks_uri:' . md5($issuer);
+    $cached = $this->cache->get($cid);
+    if ($cached && is_string($cached->data) && $cached->data !== '') {
+      return $cached->data;
+    }
+    try {
+      $response = $this->httpClient->get($issuer . '/.well-known/openid-configuration', ['headers' => ['Accept' => 'application/json']]);
+      $doc = json_decode((string) $response->getBody(), TRUE);
+      if (is_array($doc) && !empty($doc['jwks_uri'])) {
+        $this->cache->set($cid, $doc['jwks_uri'], time() + self::JWKS_TTL);
+        return $doc['jwks_uri'];
+      }
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('OIDC discovery failed for {iss}: {error}', ['iss' => $issuer, 'error' => $e->getMessage()]);
+    }
+
+    // Keycloak convention as a last resort.
+    return $issuer . '/protocol/openid-connect/certs';
+  }
+
+  /**
+   * Converts an RSA JWK (n, e) into a PEM SubjectPublicKeyInfo public key.
+   *
+   * Pure DER encoding (no crypto): builds RSAPublicKey ::= SEQUENCE { n, e }
+   * wrapped in a SubjectPublicKeyInfo with the rsaEncryption OID, then PEM.
+   */
+  protected function jwkToPem(array $jwk): string {
+    if (empty($jwk['n']) || empty($jwk['e'])) {
+      throw new \RuntimeException('JWK is missing RSA modulus/exponent.');
+    }
+    $modulus = $this->derUnsignedInteger($this->b64UrlDecode($jwk['n']));
+    $exponent = $this->derUnsignedInteger($this->b64UrlDecode($jwk['e']));
+    $rsaPublicKey = $this->derSequence($modulus . $exponent);
+
+    // AlgorithmIdentifier: rsaEncryption (1.2.840.113549.1.1.1) + NULL params.
+    $rsaOid = "\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01";
+    $algId = $this->derSequence($rsaOid . "\x05\x00");
+    // subjectPublicKey BIT STRING wraps the DER RSAPublicKey (0x00 unused bits).
+    $bitString = $this->derTlv(0x03, "\x00" . $rsaPublicKey);
+    $spki = $this->derSequence($algId . $bitString);
+
+    return "-----BEGIN PUBLIC KEY-----\n"
+      . chunk_split(base64_encode($spki), 64, "\n")
+      . "-----END PUBLIC KEY-----\n";
+  }
+
+  /**
+   * DER INTEGER from a big-endian unsigned byte string (adds 0x00 sign pad).
+   */
+  protected function derUnsignedInteger(string $bytes): string {
+    $bytes = ltrim($bytes, "\x00");
+    if ($bytes === '') {
+      $bytes = "\x00";
+    }
+    if (ord($bytes[0]) & 0x80) {
+      $bytes = "\x00" . $bytes;
+    }
+    return $this->derTlv(0x02, $bytes);
+  }
+
+  /**
+   * DER SEQUENCE wrapper.
+   */
+  protected function derSequence(string $content): string {
+    return $this->derTlv(0x30, $content);
+  }
+
+  /**
+   * Builds a DER tag-length-value with correct short/long form length.
+   */
+  protected function derTlv(int $tag, string $content): string {
+    $len = strlen($content);
+    if ($len < 0x80) {
+      $length = chr($len);
+    }
+    else {
+      $bytes = '';
+      while ($len > 0) {
+        $bytes = chr($len & 0xff) . $bytes;
+        $len >>= 8;
+      }
+      $length = chr(0x80 | strlen($bytes)) . $bytes;
+    }
+    return chr($tag) . $length . $content;
+  }
+
+  /**
+   * Base64url-decode (RFC 7515) with padding restoration.
+   */
+  protected function b64UrlDecode(string $data): string {
+    $b64 = strtr($data, '-_', '+/');
+    $pad = strlen($b64) % 4;
+    if ($pad > 0) {
+      $b64 .= str_repeat('=', 4 - $pad);
+    }
+    $decoded = base64_decode($b64, TRUE);
+    if ($decoded === FALSE) {
+      throw new \RuntimeException('Invalid base64url segment in id_token.');
+    }
+    return $decoded;
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/tests/src/Kernel/MitIdOidcFlowTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Kernel/MitIdOidcFlowTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_mitid\Kernel;
 
 use Drupal\aabenforms_mitid\Service\MitIdOidcClient;
+use Drupal\aabenforms_mitid\Service\MitIdTokenVerifier;
 use Drupal\KernelTests\KernelTestBase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -89,13 +90,34 @@ class MitIdOidcFlowTest extends KernelTestBase {
     $handlerStack = HandlerStack::create($this->mockHandler);
     $httpClient = new Client(['handler' => $handlerStack]);
 
+    // Stub the signature verifier: RS256/JWKS verification is covered by
+    // MitIdTokenVerifierTest. This flow test exercises code exchange + session
+    // creation with a mock id_token, so bypass the crypto rather than reach for
+    // a real JWKS endpoint.
+    $tokenVerifier = new class(
+      $this->container->get('config.factory'),
+      $httpClient,
+      $this->container->get('cache.default'),
+      $this->container->get('logger.factory'),
+    ) extends MitIdTokenVerifier {
+
+      /**
+       * {@inheritdoc}
+       */
+      public function verify(string $idToken): array {
+        return [];
+      }
+
+    };
+
     // Create OIDC client with mocked HTTP client.
     $this->oidcClient = new MitIdOidcClient(
       $this->container->get('config.factory'),
       $httpClient,
       $this->container->get('logger.factory'),
       $this->container->get('aabenforms_mitid.cpr_extractor'),
-      $this->sessionManager
+      $this->sessionManager,
+      $tokenVerifier
     );
   }
 

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdTokenVerifierTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdTokenVerifierTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_mitid\Unit\Service;
+
+use Drupal\aabenforms_mitid\Service\MitIdTokenVerifier;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Tests cryptographic id_token verification.
+ *
+ * Generates a throwaway RSA keypair, publishes its public half as a JWK in a
+ * primed cache (so no HTTP), and signs real RS256 tokens to prove the verifier
+ * accepts genuine tokens and rejects forged/tampered/wrong-audience ones.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_mitid\Service\MitIdTokenVerifier
+ * @group aabenforms_mitid
+ */
+class MitIdTokenVerifierTest extends UnitTestCase {
+
+  /**
+   * The verifier under test.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdTokenVerifier
+   */
+  protected MitIdTokenVerifier $verifier;
+
+  /**
+   * PEM-encoded private key used to sign test tokens.
+   *
+   * @var \OpenSSLAsymmetricKey
+   */
+  protected $privateKey;
+
+  /**
+   * The kid advertised in the JWKS and token headers.
+   */
+  protected const KID = 'test-kid-1';
+
+  /**
+   * The issuer the verifier is configured to accept.
+   */
+  protected const ISSUER = 'https://idp.example.test/realms/dk';
+
+  /**
+   * The audience (client_id) the verifier is configured for.
+   */
+  protected const CLIENT_ID = 'aabenforms-backend';
+
+  /**
+   * The configured jwks_uri (so no discovery HTTP is attempted).
+   */
+  protected const JWKS_URI = 'https://idp.example.test/realms/dk/certs';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $res = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    $this->privateKey = $res;
+    $details = openssl_pkey_get_details($res);
+    $jwk = [
+      'kty' => 'RSA',
+      'use' => 'sig',
+      'alg' => 'RS256',
+      'kid' => self::KID,
+      'n' => $this->b64url($details['rsa']['n']),
+      'e' => $this->b64url($details['rsa']['e']),
+    ];
+
+    // Config: issuer, client_id, explicit jwks_uri (skips discovery).
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['issuer', self::ISSUER],
+      ['accepted_issuers', []],
+      ['client_id', self::CLIENT_ID],
+      ['jwks_uri', self::JWKS_URI],
+    ]);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    // Prime the cache so jwks() returns our key set without HTTP.
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cid = 'aabenforms_mitid:jwks:' . md5(self::JWKS_URI);
+    $cache->method('get')->willReturnCallback(
+      static fn ($id) => $id === $cid ? (object) ['data' => [$jwk]] : FALSE
+    );
+
+    $httpClient = $this->createMock(ClientInterface::class);
+    $logger = $this->createMock(LoggerChannelInterface::class);
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($logger);
+
+    $this->verifier = new MitIdTokenVerifier($configFactory, $httpClient, $cache, $loggerFactory);
+  }
+
+  /**
+   * Tests a genuine, correctly-signed token verifies and returns claims.
+   *
+   * @covers ::verify
+   */
+  public function testGenuineTokenVerifies(): void {
+    $token = $this->makeToken(['cpr' => '0101904521', 'name' => 'Freja Nielsen']);
+    $claims = $this->verifier->verify($token);
+    $this->assertSame('0101904521', $claims['cpr']);
+    $this->assertSame('Freja Nielsen', $claims['name']);
+  }
+
+  /**
+   * Tests a tampered payload (forged CPR) is rejected - the core attack.
+   *
+   * @covers ::verify
+   */
+  public function testForgedPayloadRejected(): void {
+    $token = $this->makeToken(['cpr' => '0101904521']);
+    [$h, $p, $s] = explode('.', $token);
+    $claims = json_decode($this->b64urlDecode($p), TRUE);
+    $claims['cpr'] = '0000000000';
+    $forged = $h . '.' . $this->b64url(json_encode($claims)) . '.' . $s;
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('signature verification failed');
+    $this->verifier->verify($forged);
+  }
+
+  /**
+   * Tests an alg=none downgrade is rejected.
+   *
+   * @covers ::verify
+   */
+  public function testAlgNoneRejected(): void {
+    $header = $this->b64url(json_encode(['alg' => 'none', 'typ' => 'JWT']));
+    $payload = $this->b64url(json_encode([
+      'cpr' => '1',
+      'iss' => self::ISSUER,
+      'aud' => self::CLIENT_ID,
+      'exp' => time() + 600,
+    ]));
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Unsupported id_token alg');
+    $this->verifier->verify($header . '.' . $payload . '.');
+  }
+
+  /**
+   * Tests an unknown kid (no matching signing key) is rejected.
+   *
+   * @covers ::verify
+   */
+  public function testUnknownKidRejected(): void {
+    $token = $this->makeToken(['cpr' => '1'], 'some-other-kid');
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('No matching RS256 signing key');
+    $this->verifier->verify($token);
+  }
+
+  /**
+   * Tests a wrong audience is rejected even with a valid signature.
+   *
+   * @covers ::verify
+   */
+  public function testWrongAudienceRejected(): void {
+    $token = $this->makeToken(['cpr' => '1', 'aud' => 'some-other-client']);
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('audience');
+    $this->verifier->verify($token);
+  }
+
+  /**
+   * Tests a wrong issuer is rejected even with a valid signature.
+   *
+   * @covers ::verify
+   */
+  public function testWrongIssuerRejected(): void {
+    $token = $this->makeToken(['cpr' => '1', 'iss' => 'https://evil.example/realms/dk']);
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('issuer');
+    $this->verifier->verify($token);
+  }
+
+  /**
+   * Tests an expired token is rejected even with a valid signature.
+   *
+   * @covers ::verify
+   */
+  public function testExpiredTokenRejected(): void {
+    $token = $this->makeToken(['cpr' => '1', 'exp' => time() - 600]);
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('expired');
+    $this->verifier->verify($token);
+  }
+
+  /**
+   * Builds and signs an RS256 token with sensible default claims.
+   *
+   * @param array $claimOverrides
+   *   Claims to merge over the defaults (iss/aud/exp/iat).
+   * @param string|null $kid
+   *   The kid header; defaults to the published signing kid.
+   *
+   * @return string
+   *   The compact JWS.
+   */
+  protected function makeToken(array $claimOverrides = [], ?string $kid = NULL): string {
+    $header = ['alg' => 'RS256', 'typ' => 'JWT', 'kid' => $kid ?? self::KID];
+    $claims = $claimOverrides + [
+      'iss' => self::ISSUER,
+      'aud' => self::CLIENT_ID,
+      'exp' => time() + 600,
+      'iat' => time(),
+      'sub' => 'uuid-123',
+    ];
+    $signingInput = $this->b64url(json_encode($header)) . '.' . $this->b64url(json_encode($claims));
+    openssl_sign($signingInput, $signature, $this->privateKey, OPENSSL_ALGO_SHA256);
+    return $signingInput . '.' . $this->b64url($signature);
+  }
+
+  /**
+   * Base64url-encode.
+   */
+  protected function b64url(string $data): string {
+    return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+  }
+
+  /**
+   * Base64url-decode.
+   */
+  protected function b64urlDecode(string $data): string {
+    $b64 = strtr($data, '-_', '+/');
+    $pad = strlen($b64) % 4;
+    if ($pad) {
+      $b64 .= str_repeat('=', 4 - $pad);
+    }
+    return base64_decode($b64);
+  }
+
+}


### PR DESCRIPTION
## The hole (verified critical #1 from the expert audit)

`MitIdCprExtractor::parseJwt` base64-decoded the id_token payload and trusted it - no signature check, no `iss`/`aud` validation. `validateToken()` only checked claim presence + `exp`. A JWT with arbitrary CPR/identity claims would be accepted, so the citizen identity behind every gated flow was forgeable.

## Fix

New `MitIdTokenVerifier`, called in `MitIdOidcClient::validateIdToken` before any claim is trusted, **fails closed**:
- Verifies the **RS256 signature** against the issuer's published **JWKS** (fetched + cached 1h; refetch-once on unknown `kid` for rotation; stale-cache fallback on transient IdP blips).
- Validates `iss` (allowlist), `aud` (must include this `client_id`), and `exp`/`iat`/`nbf`.
- Rejects `alg: none` and any non-RS256 alg (no downgrade).
- **Dependency-free**: `openssl_verify` does the crypto; the class only DER-encodes a JWK `(n,e)` into a PEM key, so no composer dependency lands on a security-critical path (vendor is gitignored, so a new dep would be deploy-risky).

`accepted_issuers` handles the split-hostname dev IdP (containerised Keycloak issues tokens with the browser-facing host while the backend reaches it - and JWKS - via the internal host).

## Verified end to end (live DDEV, real mock IdP)

| Case | Result |
|---|---|
| Genuine MitID login (Freja) | **accepted** - session created, full RS256 verification |
| Forged-CPR token (payload tampered) | **rejected** - signature verification failed |
| `alg: none` downgrade | **rejected** |
| Wrong `aud` / `iss` / `exp` / unknown `kid` | **rejected** |

Unit test (`MitIdTokenVerifierTest`) generates a throwaway RSA keypair, signs real tokens, and asserts all of the above (7 tests). 57 mitid unit tests green, phpcs clean.

## ⚠️ DEPLOY PREREQUISITE

Production must resolve `aabenforms_mitid.settings` **`issuer`** to the prod realm issuer (the value prod tokens already carry, e.g. the `auth.*` realm). The verifier derives the JWKS from `issuer` and validates `iss` against it - if prod still resolves the dev `keycloak:8080` issuer, **every login fails closed**. This is an env-config (settings.php `$config` override) check, like the `AABENFORMS_CPR_KEY` rollout. Confirm with a test login on prod right after deploy.

Note: `security.validate_tokens` and `MitIdCprExtractor::validateToken` are now vestigial for this path (left in place; no behaviour depends on them).