### PR TITLE
Unified flow visualisation: shared ECA graph + node-graph on template browser & per-flow

### DIFF
--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -211,6 +211,7 @@ function aabenforms_workflows_theme(array $existing, string $type, string $theme
         'category_badge' => NULL,
         'description' => NULL,
         'preview_url' => NULL,
+        'graph_svg' => NULL,
         'use_link' => NULL,
       ],
       'template' => 'workflow-template-card',

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -7,8 +7,31 @@
  * Provides ECA workflow integration and pre-built templates.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+
+/**
+ * Implements hook_entity_operation().
+ *
+ * Adds a "Flow diagram" link to every ECA flow on the collection page, so the
+ * read-only node-graph is reachable from where admins already manage flows.
+ */
+function aabenforms_workflows_entity_operation(EntityInterface $entity): array {
+  if ($entity->getEntityTypeId() !== 'eca') {
+    return [];
+  }
+  if (!\Drupal::currentUser()->hasPermission('administer workflows')) {
+    return [];
+  }
+  return [
+    'flow_diagram' => [
+      'title' => t('Flow diagram'),
+      'weight' => 50,
+      'url' => Url::fromRoute('aabenforms_workflows.flow_graph', ['eca' => $entity->id()]),
+    ],
+  ];
+}
 
 /**
  * Wizard-created workflow configs are preserved across drush cim.

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
@@ -18,6 +18,21 @@ aabenforms_workflows.election_results:
       id:
         type: string
 
+aabenforms_workflows.flow_graph:
+  path: '/admin/aabenforms/flow/{eca}/graph'
+  defaults:
+    _controller: '\Drupal\aabenforms_workflows\Controller\FlowGraphController::view'
+    _title: 'Flow diagram'
+  requirements:
+    _permission: 'administer workflows'
+
+aabenforms_workflows.flow_graph_json:
+  path: '/admin/aabenforms/flow/{eca}/graph.json'
+  defaults:
+    _controller: '\Drupal\aabenforms_workflows\Controller\FlowGraphController::json'
+  requirements:
+    _permission: 'administer workflows'
+
 aabenforms_workflows.template_browser:
   path: '/admin/aabenforms/workflow-templates'
   defaults:

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -107,3 +107,7 @@ services:
       - '@config.storage'
     tags:
       - { name: event_subscriber }
+  aabenforms_workflows.eca_graph_builder:
+    class: Drupal\aabenforms_workflows\Service\EcaGraphBuilder
+    arguments:
+      - '@entity_type.manager'

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -111,3 +111,7 @@ services:
     class: Drupal\aabenforms_workflows\Service\EcaGraphBuilder
     arguments:
       - '@entity_type.manager'
+  aabenforms_workflows.flow_graph_renderer:
+    class: Drupal\aabenforms_workflows\Service\FlowGraphRenderer
+    arguments:
+      - '@aabenforms_workflows.eca_graph_builder'

--- a/web/modules/custom/aabenforms_workflows/css/template-browser.css
+++ b/web/modules/custom/aabenforms_workflows/css/template-browser.css
@@ -53,6 +53,25 @@
   border-bottom: 1px solid #e0e0e0;
 }
 
+/* Inline node-graph preview rendered from the ECA flow. */
+.template-card__graph {
+  display: block;
+  height: 200px;
+  padding: 12px;
+  overflow: auto;
+  background-image: radial-gradient(#e3e6ea 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+
+/* Size the diagram to the thumbnail height; wider flows scroll horizontally
+   at a readable node size rather than shrinking to dots. */
+.template-card__graph svg {
+  display: block;
+  width: auto;
+  height: 168px;
+  max-width: none;
+}
+
 .bpmn-preview-thumbnail {
   position: relative;
   height: 200px;

--- a/web/modules/custom/aabenforms_workflows/css/workflow-wizard.css
+++ b/web/modules/custom/aabenforms_workflows/css/workflow-wizard.css
@@ -138,3 +138,23 @@
     flex-shrink: 0;
   }
 }
+
+/* Read-only node-graph preview inside the wizard (matches the template cards). */
+.aabenforms-wizard-graph {
+  margin: 12px 0;
+  padding: 12px;
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background-color: #fff;
+  background-image: radial-gradient(#e3e6ea 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+
+.aabenforms-wizard-graph svg {
+  display: block;
+  width: auto;
+  height: 240px;
+  max-width: none;
+}

--- a/web/modules/custom/aabenforms_workflows/src/Controller/FlowGraphController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/FlowGraphController.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Controller;
+
+use Drupal\aabenforms_workflows\Service\EcaGraphBuilder;
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Renders an ECA flow as a node-graph.
+ *
+ * Read-only inline-SVG view (no build step) plus a JSON endpoint serving the
+ * same {nodes, edges} model the editable React Flow surfaces will consume - one
+ * shared graph for the dashboard, the wizard and the modeler.
+ */
+class FlowGraphController extends ControllerBase {
+
+  /**
+   * Node-box width, in SVG user units.
+   */
+  protected const NODE_W = 190;
+
+  /**
+   * Node-box height, in SVG user units.
+   */
+  protected const NODE_H = 54;
+
+  public function __construct(
+    protected EcaGraphBuilder $graphBuilder,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static($container->get('aabenforms_workflows.eca_graph_builder'));
+  }
+
+  /**
+   * Page: the flow rendered as a read-only SVG node-graph.
+   *
+   * @param string $eca
+   *   The eca config entity id.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function view(string $eca): array {
+    $graph = $this->graphBuilder->build($eca);
+    if ($graph === NULL) {
+      throw new NotFoundHttpException();
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['aabenforms-flow-graph']],
+      'legend' => [
+        '#markup' => '<p>' . $this->t('Read-only diagram generated from the live ECA flow. Branch labels show the gating condition.') . '</p>',
+      ],
+      'svg' => [
+        '#markup' => $this->renderSvg($graph),
+        '#allowed_tags' => ['svg', 'g', 'rect', 'path', 'text', 'title', 'defs', 'marker', 'polygon', 'tspan'],
+      ],
+    ];
+  }
+
+  /**
+   * JSON endpoint: the {label, nodes, edges} graph for programmatic renderers.
+   *
+   * @param string $eca
+   *   The eca config entity id.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The graph, or 404 when the flow does not exist.
+   */
+  public function json(string $eca): JsonResponse {
+    $graph = $this->graphBuilder->build($eca);
+    if ($graph === NULL) {
+      return new JsonResponse(['error' => 'Flow not found'], 404);
+    }
+    return new JsonResponse($graph);
+  }
+
+  /**
+   * Renders a {nodes, edges} graph to a standalone inline SVG string.
+   *
+   * @param array $graph
+   *   The graph from EcaGraphBuilder.
+   *
+   * @return string
+   *   SVG markup.
+   */
+  protected function renderSvg(array $graph): string {
+    $styles = [
+      'event' => ['fill' => '#e6f4ea', 'stroke' => '#137333', 'text' => '#0d652d'],
+      'action' => ['fill' => '#e8f0fe', 'stroke' => '#1a73e8', 'text' => '#174ea6'],
+      'deny' => ['fill' => '#fce8e6', 'stroke' => '#c5221f', 'text' => '#a50e0e'],
+    ];
+
+    $maxX = 0;
+    $maxY = 0;
+    $pos = [];
+    foreach ($graph['nodes'] as $node) {
+      $x = $node['position']['x'];
+      $y = $node['position']['y'];
+      $pos[$node['id']] = ['x' => $x, 'y' => $y];
+      $maxX = max($maxX, $x + self::NODE_W);
+      $maxY = max($maxY, $y + self::NODE_H);
+    }
+    $width = $maxX + 40;
+    $height = $maxY + 40;
+
+    $edgesSvg = '';
+    foreach ($graph['edges'] as $edge) {
+      if (!isset($pos[$edge['source']], $pos[$edge['target']])) {
+        continue;
+      }
+      $s = $pos[$edge['source']];
+      $t = $pos[$edge['target']];
+      $x1 = $s['x'] + self::NODE_W;
+      $y1 = $s['y'] + self::NODE_H / 2;
+      $x2 = $t['x'];
+      $y2 = $t['y'] + self::NODE_H / 2;
+      $mx = ($x1 + $x2) / 2;
+      $path = new FormattableMarkup(
+        '<path d="M@x1,@y1 C@cx1,@y1 @cx2,@y2 @x2e,@y2" fill="none" stroke="#9aa0a6" stroke-width="1.5" marker-end="url(#af-arrow)" />',
+        [
+          '@x1' => $x1, '@y1' => $y1, '@cx1' => $mx, '@cx2' => $mx,
+          '@y2' => $y2, '@x2e' => $x2 - 6,
+        ],
+      );
+      $edgesSvg .= $path;
+      if (($edge['label'] ?? '') !== '') {
+        $edgesSvg .= new FormattableMarkup(
+          '<text x="@x" y="@y" text-anchor="middle" font-size="11" fill="#5f6368" font-family="sans-serif"><tspan dy="-3">@label</tspan></text>',
+          ['@x' => $mx, '@y' => ($y1 + $y2) / 2, '@label' => $edge['label']],
+        );
+      }
+    }
+
+    $nodesSvg = '';
+    foreach ($graph['nodes'] as $node) {
+      $style = $styles[$node['type']] ?? $styles['action'];
+      $x = $pos[$node['id']]['x'];
+      $y = $pos[$node['id']]['y'];
+      $label = $this->truncate($node['label'], 26);
+      $nodesSvg .= new FormattableMarkup(
+        '<g><title>@full</title>'
+        . '<rect x="@x" y="@y" rx="8" ry="8" width="@w" height="@h" fill="@fill" stroke="@stroke" stroke-width="1.5" />'
+        . '<text x="@tx" y="@ty" text-anchor="middle" font-size="12" font-family="sans-serif" fill="@text">@label</text>'
+        . '</g>',
+        [
+          '@full' => $node['label'] . ' (' . $node['type'] . ')',
+          '@x' => $x, '@y' => $y, '@w' => self::NODE_W, '@h' => self::NODE_H,
+          '@fill' => $style['fill'], '@stroke' => $style['stroke'], '@text' => $style['text'],
+          '@tx' => $x + self::NODE_W / 2, '@ty' => $y + self::NODE_H / 2 + 4,
+          '@label' => $label,
+        ],
+      );
+    }
+
+    $title = Html::escape($graph['label'] ?? 'flow');
+    return '<svg viewBox="0 0 ' . $width . ' ' . $height . '" width="100%" '
+      . 'style="max-width:' . $width . 'px" role="img" aria-label="' . $title . ' flow diagram" '
+      . 'xmlns="http://www.w3.org/2000/svg">'
+      . '<defs><marker id="af-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+      . '<path d="M0,0 L10,5 L0,10 z" fill="#9aa0a6" /></marker></defs>'
+      . $edgesSvg . $nodesSvg
+      . '</svg>';
+  }
+
+  /**
+   * Truncates a label for display inside a fixed-width node box.
+   */
+  protected function truncate(string $text, int $max): string {
+    $text = Html::escape($text);
+    if (mb_strlen($text) <= $max) {
+      return $text;
+    }
+    return mb_substr($text, 0, $max - 1) . '…';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Controller/FlowGraphController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/FlowGraphController.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Drupal\aabenforms_workflows\Controller;
 
 use Drupal\aabenforms_workflows\Service\EcaGraphBuilder;
-use Drupal\Component\Render\FormattableMarkup;
-use Drupal\Component\Utility\Html;
+use Drupal\aabenforms_workflows\Service\FlowGraphRenderer;
 use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,29 +16,23 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * Read-only inline-SVG view (no build step) plus a JSON endpoint serving the
  * same {nodes, edges} model the editable React Flow surfaces will consume - one
- * shared graph for the dashboard, the wizard and the modeler.
+ * shared graph for the dashboard, the template browser, and the modeler.
  */
 class FlowGraphController extends ControllerBase {
 
-  /**
-   * Node-box width, in SVG user units.
-   */
-  protected const NODE_W = 190;
-
-  /**
-   * Node-box height, in SVG user units.
-   */
-  protected const NODE_H = 54;
-
   public function __construct(
     protected EcaGraphBuilder $graphBuilder,
+    protected FlowGraphRenderer $renderer,
   ) {}
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static($container->get('aabenforms_workflows.eca_graph_builder'));
+    return new static(
+      $container->get('aabenforms_workflows.eca_graph_builder'),
+      $container->get('aabenforms_workflows.flow_graph_renderer'),
+    );
   }
 
   /**
@@ -52,8 +45,8 @@ class FlowGraphController extends ControllerBase {
    *   A render array.
    */
   public function view(string $eca): array {
-    $graph = $this->graphBuilder->build($eca);
-    if ($graph === NULL) {
+    $svg = $this->renderer->renderForFlow($eca);
+    if ($svg === NULL) {
       throw new NotFoundHttpException();
     }
 
@@ -64,8 +57,8 @@ class FlowGraphController extends ControllerBase {
         '#markup' => '<p>' . $this->t('Read-only diagram generated from the live ECA flow. Branch labels show the gating condition.') . '</p>',
       ],
       'svg' => [
-        '#markup' => $this->renderSvg($graph),
-        '#allowed_tags' => ['svg', 'g', 'rect', 'path', 'text', 'title', 'defs', 'marker', 'polygon', 'tspan'],
+        '#markup' => $svg,
+        '#allowed_tags' => FlowGraphRenderer::allowedTags(),
       ],
     ];
   }
@@ -85,105 +78,6 @@ class FlowGraphController extends ControllerBase {
       return new JsonResponse(['error' => 'Flow not found'], 404);
     }
     return new JsonResponse($graph);
-  }
-
-  /**
-   * Renders a {nodes, edges} graph to a standalone inline SVG string.
-   *
-   * @param array $graph
-   *   The graph from EcaGraphBuilder.
-   *
-   * @return string
-   *   SVG markup.
-   */
-  protected function renderSvg(array $graph): string {
-    $styles = [
-      'event' => ['fill' => '#e6f4ea', 'stroke' => '#137333', 'text' => '#0d652d'],
-      'action' => ['fill' => '#e8f0fe', 'stroke' => '#1a73e8', 'text' => '#174ea6'],
-      'deny' => ['fill' => '#fce8e6', 'stroke' => '#c5221f', 'text' => '#a50e0e'],
-    ];
-
-    $maxX = 0;
-    $maxY = 0;
-    $pos = [];
-    foreach ($graph['nodes'] as $node) {
-      $x = $node['position']['x'];
-      $y = $node['position']['y'];
-      $pos[$node['id']] = ['x' => $x, 'y' => $y];
-      $maxX = max($maxX, $x + self::NODE_W);
-      $maxY = max($maxY, $y + self::NODE_H);
-    }
-    $width = $maxX + 40;
-    $height = $maxY + 40;
-
-    $edgesSvg = '';
-    foreach ($graph['edges'] as $edge) {
-      if (!isset($pos[$edge['source']], $pos[$edge['target']])) {
-        continue;
-      }
-      $s = $pos[$edge['source']];
-      $t = $pos[$edge['target']];
-      $x1 = $s['x'] + self::NODE_W;
-      $y1 = $s['y'] + self::NODE_H / 2;
-      $x2 = $t['x'];
-      $y2 = $t['y'] + self::NODE_H / 2;
-      $mx = ($x1 + $x2) / 2;
-      $path = new FormattableMarkup(
-        '<path d="M@x1,@y1 C@cx1,@y1 @cx2,@y2 @x2e,@y2" fill="none" stroke="#9aa0a6" stroke-width="1.5" marker-end="url(#af-arrow)" />',
-        [
-          '@x1' => $x1, '@y1' => $y1, '@cx1' => $mx, '@cx2' => $mx,
-          '@y2' => $y2, '@x2e' => $x2 - 6,
-        ],
-      );
-      $edgesSvg .= $path;
-      if (($edge['label'] ?? '') !== '') {
-        $edgesSvg .= new FormattableMarkup(
-          '<text x="@x" y="@y" text-anchor="middle" font-size="11" fill="#5f6368" font-family="sans-serif"><tspan dy="-3">@label</tspan></text>',
-          ['@x' => $mx, '@y' => ($y1 + $y2) / 2, '@label' => $edge['label']],
-        );
-      }
-    }
-
-    $nodesSvg = '';
-    foreach ($graph['nodes'] as $node) {
-      $style = $styles[$node['type']] ?? $styles['action'];
-      $x = $pos[$node['id']]['x'];
-      $y = $pos[$node['id']]['y'];
-      $label = $this->truncate($node['label'], 26);
-      $nodesSvg .= new FormattableMarkup(
-        '<g><title>@full</title>'
-        . '<rect x="@x" y="@y" rx="8" ry="8" width="@w" height="@h" fill="@fill" stroke="@stroke" stroke-width="1.5" />'
-        . '<text x="@tx" y="@ty" text-anchor="middle" font-size="12" font-family="sans-serif" fill="@text">@label</text>'
-        . '</g>',
-        [
-          '@full' => $node['label'] . ' (' . $node['type'] . ')',
-          '@x' => $x, '@y' => $y, '@w' => self::NODE_W, '@h' => self::NODE_H,
-          '@fill' => $style['fill'], '@stroke' => $style['stroke'], '@text' => $style['text'],
-          '@tx' => $x + self::NODE_W / 2, '@ty' => $y + self::NODE_H / 2 + 4,
-          '@label' => $label,
-        ],
-      );
-    }
-
-    $title = Html::escape($graph['label'] ?? 'flow');
-    return '<svg viewBox="0 0 ' . $width . ' ' . $height . '" width="100%" '
-      . 'style="max-width:' . $width . 'px" role="img" aria-label="' . $title . ' flow diagram" '
-      . 'xmlns="http://www.w3.org/2000/svg">'
-      . '<defs><marker id="af-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
-      . '<path d="M0,0 L10,5 L0,10 z" fill="#9aa0a6" /></marker></defs>'
-      . $edgesSvg . $nodesSvg
-      . '</svg>';
-  }
-
-  /**
-   * Truncates a label for display inside a fixed-width node box.
-   */
-  protected function truncate(string $text, int $max): string {
-    $text = Html::escape($text);
-    if (mb_strlen($text) <= $max) {
-      return $text;
-    }
-    return mb_substr($text, 0, $max - 1) . '…';
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/src/Controller/TemplateBrowserController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/TemplateBrowserController.php
@@ -6,6 +6,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\aabenforms_workflows\Service\BpmnTemplateManager;
+use Drupal\aabenforms_workflows\Service\FlowGraphRenderer;
 use Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -32,19 +33,30 @@ class TemplateBrowserController extends ControllerBase {
   protected WorkflowTemplateInstantiator $instantiator;
 
   /**
+   * The flow graph renderer.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\FlowGraphRenderer
+   */
+  protected FlowGraphRenderer $graphRenderer;
+
+  /**
    * Constructs a TemplateBrowserController object.
    *
    * @param \Drupal\aabenforms_workflows\Service\BpmnTemplateManager $template_manager
    *   The BPMN template manager service.
    * @param \Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator $instantiator
    *   The template instantiator service.
+   * @param \Drupal\aabenforms_workflows\Service\FlowGraphRenderer $graph_renderer
+   *   The flow graph renderer.
    */
   public function __construct(
     BpmnTemplateManager $template_manager,
     WorkflowTemplateInstantiator $instantiator,
+    FlowGraphRenderer $graph_renderer,
   ) {
     $this->templateManager = $template_manager;
     $this->instantiator = $instantiator;
+    $this->graphRenderer = $graph_renderer;
   }
 
   /**
@@ -53,7 +65,8 @@ class TemplateBrowserController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('aabenforms_workflows.bpmn_template_manager'),
-      $container->get('aabenforms_workflows.template_instantiator')
+      $container->get('aabenforms_workflows.template_instantiator'),
+      $container->get('aabenforms_workflows.flow_graph_renderer')
     );
   }
 
@@ -157,10 +170,20 @@ class TemplateBrowserController extends ControllerBase {
         ucfirst(str_replace('_', ' ', $template['category'])) .
         '</span>';
 
-      // Generate BPMN preview placeholder.
-      $preview_url = Url::fromRoute('aabenforms_workflows.template_preview', [
-        'template_id' => $template_id,
-      ])->toString();
+      // Render the node-graph straight from the template's ECA flow (every
+      // template X has a flow X_flow). Falls back to the legacy BPMN preview
+      // when no flow exists yet.
+      $graph_svg = $this->graphRenderer->renderForFlow($template_id . '_flow');
+      if ($graph_svg !== NULL) {
+        $preview_url = Url::fromRoute('aabenforms_workflows.flow_graph', [
+          'eca' => $template_id . '_flow',
+        ])->toString();
+      }
+      else {
+        $preview_url = Url::fromRoute('aabenforms_workflows.template_preview', [
+          'template_id' => $template_id,
+        ])->toString();
+      }
 
       $item = [
         '#theme' => 'workflow_template_card',
@@ -170,6 +193,7 @@ class TemplateBrowserController extends ControllerBase {
         '#category_badge' => $category_badge,
         '#description' => $description,
         '#preview_url' => $preview_url,
+        '#graph_svg' => $graph_svg,
         '#use_link' => $use_link,
       ];
 

--- a/web/modules/custom/aabenforms_workflows/src/Form/WorkflowTemplateWizardForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/WorkflowTemplateWizardForm.php
@@ -287,13 +287,13 @@ class WorkflowTemplateWizardForm extends FormBase {
   }
 
   /**
-   * Builds Step 2: Visual Workflow Editor.
+   * Builds Step 2: Flow Preview (read-only node-graph of the template's flow).
    */
   protected function buildStepVisualEditor(array &$form, FormStateInterface $form_state): void {
     $template_id = $form_state->getValue('template_id');
 
     $form['step_title'] = [
-      '#markup' => '<h2>' . $this->t('Step 2: Visual Workflow Editor') . '</h2>',
+      '#markup' => '<h2>' . $this->t('Step 2: Flow Preview') . '</h2>',
     ];
 
     $form['help'] = [
@@ -650,7 +650,7 @@ class WorkflowTemplateWizardForm extends FormBase {
   protected function getProgressSteps(int $current_step): array {
     $steps = [
       1 => $this->t('Select Template'),
-      2 => $this->t('Visual Editor'),
+      2 => $this->t('Flow Preview'),
       3 => $this->t('Configure Webform'),
       4 => $this->t('Configure Actions'),
       5 => $this->t('Data Visibility'),

--- a/web/modules/custom/aabenforms_workflows/src/Form/WorkflowTemplateWizardForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/WorkflowTemplateWizardForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Url;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\aabenforms_workflows\Service\BpmnTemplateManager;
+use Drupal\aabenforms_workflows\Service\FlowGraphRenderer;
 use Drupal\aabenforms_workflows\Service\WorkflowTemplateMetadata;
 use Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator;
 use Drupal\webform\Entity\Webform;
@@ -54,6 +55,13 @@ class WorkflowTemplateWizardForm extends FormBase {
   protected ModelerApi $modelerApi;
 
   /**
+   * The flow graph renderer.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\FlowGraphRenderer
+   */
+  protected FlowGraphRenderer $graphRenderer;
+
+  /**
    * Constructs a WorkflowTemplateWizardForm object.
    *
    * @param \Drupal\aabenforms_workflows\Service\BpmnTemplateManager $template_manager
@@ -64,17 +72,21 @@ class WorkflowTemplateWizardForm extends FormBase {
    *   The template instantiator service.
    * @param \Drupal\modeler_api\Api $modeler_api
    *   The Modeler API service.
+   * @param \Drupal\aabenforms_workflows\Service\FlowGraphRenderer $graph_renderer
+   *   The flow graph renderer.
    */
   public function __construct(
     BpmnTemplateManager $template_manager,
     WorkflowTemplateMetadata $template_metadata,
     WorkflowTemplateInstantiator $instantiator,
     ModelerApi $modeler_api,
+    FlowGraphRenderer $graph_renderer,
   ) {
     $this->templateManager = $template_manager;
     $this->templateMetadata = $template_metadata;
     $this->instantiator = $instantiator;
     $this->modelerApi = $modeler_api;
+    $this->graphRenderer = $graph_renderer;
   }
 
   /**
@@ -85,8 +97,36 @@ class WorkflowTemplateWizardForm extends FormBase {
       $container->get('aabenforms_workflows.bpmn_template_manager'),
       $container->get('aabenforms_workflows.template_metadata'),
       $container->get('aabenforms_workflows.template_instantiator'),
-      $container->get('modeler_api.service')
+      $container->get('modeler_api.service'),
+      $container->get('aabenforms_workflows.flow_graph_renderer')
     );
+  }
+
+  /**
+   * Builds a read-only node-graph render element for a template's ECA flow.
+   *
+   * @param string|null $template_id
+   *   The template id; its flow is "<template_id>_flow".
+   *
+   * @return array|null
+   *   A render element, or NULL when no flow/graph is available.
+   */
+  protected function graphPreview(?string $template_id): ?array {
+    if (!is_string($template_id) || $template_id === '') {
+      return NULL;
+    }
+    $svg = $this->graphRenderer->renderForFlow($template_id . '_flow');
+    if ($svg === NULL) {
+      return NULL;
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['aabenforms-flow-graph', 'aabenforms-wizard-graph']],
+      'svg' => [
+        '#markup' => $svg,
+        '#allowed_tags' => FlowGraphRenderer::allowedTags(),
+      ],
+    ];
   }
 
   /**
@@ -223,6 +263,11 @@ class WorkflowTemplateWizardForm extends FormBase {
         '#markup' => '<p>' . $preview['description'] . '</p>',
       ];
 
+      // Visual node-graph of the template's flow (start -> gated steps -> deny).
+      if ($graph = $this->graphPreview($selected_template)) {
+        $form['preview']['graph'] = $graph;
+      }
+
       if (!empty($preview['steps'])) {
         $steps_list = [];
         foreach ($preview['steps'] as $step) {
@@ -252,8 +297,14 @@ class WorkflowTemplateWizardForm extends FormBase {
     ];
 
     $form['help'] = [
-      '#markup' => '<p>' . $this->t('Customize your workflow visually using the BPMN editor. Add, remove, or modify workflow steps to match your exact needs.') . '</p>',
+      '#markup' => '<p>' . $this->t('This is your workflow as it will run - generated from the live ECA flow. Branch labels show the gating condition (for example MitID = verified).') . '</p>',
     ];
+
+    // Read-only node-graph preview of the flow - the same diagram shown on the
+    // template browser and the dashboard.
+    if ($graph = $this->graphPreview($template_id)) {
+      $form['flow_graph'] = $graph;
+    }
 
     // Load template BPMN XML.
     $bpmn_xml = $form_state->get('bpmn_xml');
@@ -262,59 +313,14 @@ class WorkflowTemplateWizardForm extends FormBase {
       $form_state->set('bpmn_xml', $bpmn_xml);
     }
 
-    // bpmn_io contrib's bpmn-modeler.js auto-instantiates
-    // window.modeler = new BpmnJS({container: '#bpmn-io .canvas'}) at
-    // script load. If that DOM is absent, every page using the library
-    // crashes with `Cannot read properties of null (reading 'appendChild')`.
-    // This hidden shim satisfies the auto-init; our own editor JS
-    // instantiates a separate BpmnJS against #bpmn-canvas below.
-    $form['bpmn_io_shim'] = [
-      '#markup' => '<div id="bpmn-io" hidden aria-hidden="true"><div class="canvas"></div></div>',
-    ];
-
-    // BPMN.io editor container.
-    $form['bpmn_editor'] = [
-      '#type' => 'container',
-      '#attributes' => [
-        'id' => 'bpmn-io-container',
-        'class' => ['bpmn-editor-wrapper'],
-      ],
-    ];
-
-    // Canvas for BPMN.io.
-    $form['bpmn_editor']['canvas'] = [
-      '#markup' => '<div id="bpmn-canvas" class="bpmn-canvas"></div>',
-    ];
-
-    // Hidden field to store BPMN XML.
+    // Carry the template BPMN through for instantiation. The accurate flow
+    // preview is the read-only node-graph above; in-place visual EDITING is
+    // handled by the React Flow editor (separate increment). The old bpmn-js
+    // canvas was removed - it rendered an empty, broken editor below the graph.
     $form['bpmn_xml'] = [
       '#type' => 'hidden',
       '#default_value' => $bpmn_xml,
-      '#attributes' => [
-        'id' => 'bpmn-xml-data',
-      ],
-    ];
-
-    // Validation status.
-    $form['validation_status'] = [
-      '#type' => 'container',
-      '#attributes' => [
-        'id' => 'bpmn-validation-status',
-        'class' => ['bpmn-validation-status'],
-      ],
-      '#markup' => '<div class="validation-message"></div>',
-    ];
-
-    // Attach BPMN.io libraries and custom palette.
-    // bpmn_io/core gives us BpmnJS without the modeler_api-coupled wrapper
-    // (bpmn_io/ui) which crashes on standalone pages.
-    $form['#attached']['library'][] = 'bpmn_io/core';
-    $form['#attached']['library'][] = 'aabenforms_workflows/bpmn_editor';
-    $form['#attached']['drupalSettings']['aabenforms_workflows']['bpmn'] = [
-      'xml' => $bpmn_xml,
-      'template_id' => $template_id,
-      'auto_save_url' => Url::fromRoute('aabenforms_workflows.wizard_autosave')->toString(),
-      'validate_url' => Url::fromRoute('aabenforms_workflows.wizard_validate')->toString(),
+      '#attributes' => ['id' => 'bpmn-xml-data'],
     ];
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Service/EcaGraphBuilder.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/EcaGraphBuilder.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Converts an ECA flow into a renderable {nodes, edges} graph.
+ *
+ * One shared data source for every surface that visualises a flow - the
+ * dashboard, the creation wizard, and the modeler - so they all draw the same
+ * picture straight from the ECA event/condition/action/successor graph rather
+ * than from three different representations (bpmn-js, React Flow, server text).
+ *
+ * Conditions are NOT nodes - in ECA they are predicates that gate an action's
+ * successor edge - so they surface as edge labels. Actions whose plugin is the
+ * deny terminal render as a distinct "deny" node type.
+ */
+class EcaGraphBuilder {
+
+  /**
+   * Horizontal distance between layers, in layout units.
+   */
+  protected const COL_WIDTH = 240;
+
+  /**
+   * Vertical distance between sibling nodes, in layout units.
+   */
+  protected const ROW_HEIGHT = 96;
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Builds the graph for a stored ECA flow by id.
+   *
+   * @param string $ecaId
+   *   The eca config entity id.
+   *
+   * @return array|null
+   *   {label, nodes, edges}, or NULL when the flow does not exist.
+   */
+  public function build(string $ecaId): ?array {
+    $eca = $this->entityTypeManager->getStorage('eca')->load($ecaId);
+    if ($eca === NULL) {
+      return NULL;
+    }
+    return $this->fromConfig([
+      'label' => (string) ($eca->label() ?? $ecaId),
+      'events' => $eca->get('events') ?? [],
+      'conditions' => $eca->get('conditions') ?? [],
+      'actions' => $eca->get('actions') ?? [],
+    ]);
+  }
+
+  /**
+   * Pure transform from raw ECA config arrays to a graph.
+   *
+   * Kept separate from entity loading so it is unit-testable without a
+   * database.
+   *
+   * @param array $config
+   *   Keys: label, events, conditions, actions (the ECA config arrays).
+   *
+   * @return array
+   *   {label, nodes, edges}.
+   */
+  public function fromConfig(array $config): array {
+    $events = $config['events'] ?? [];
+    $conditions = $config['conditions'] ?? [];
+    $actions = $config['actions'] ?? [];
+
+    $nodes = [];
+    foreach ($events as $id => $event) {
+      $nodes[$id] = [
+        'id' => $id,
+        'type' => 'event',
+        'label' => (string) ($event['label'] ?? $this->humanizeEvent($event)),
+        'plugin' => (string) ($event['plugin'] ?? ''),
+      ];
+    }
+    foreach ($actions as $id => $action) {
+      $plugin = (string) ($action['plugin'] ?? '');
+      $nodes[$id] = [
+        'id' => $id,
+        'type' => $plugin === 'aabenforms_workflow_deny' ? 'deny' : 'action',
+        'label' => (string) ($action['label'] ?? $id),
+        'plugin' => $plugin,
+      ];
+    }
+
+    $edges = [];
+    foreach ([$events, $actions] as $set) {
+      foreach ($set as $sourceId => $component) {
+        foreach (($component['successors'] ?? []) as $successor) {
+          $targetId = $successor['id'] ?? NULL;
+          if ($targetId === NULL || !isset($nodes[$targetId])) {
+            continue;
+          }
+          $conditionId = (string) ($successor['condition'] ?? '');
+          $edges[] = [
+            'id' => $sourceId . '->' . $targetId,
+            'source' => $sourceId,
+            'target' => $targetId,
+            'condition' => $conditionId,
+            'label' => $this->conditionLabel($conditionId, $conditions),
+          ];
+        }
+      }
+    }
+
+    $this->assignLayout($nodes, $edges);
+
+    return [
+      'label' => (string) ($config['label'] ?? ''),
+      'nodes' => array_values($nodes),
+      'edges' => $edges,
+    ];
+  }
+
+  /**
+   * Assigns each node an (x, y) position from a longest-path layering.
+   *
+   * Roots (no incoming edge - the events) sit in column 0; each node's column
+   * is the longest path from any root, so a node always sits to the right of
+   * everything that can reach it. Within a column, nodes stack vertically.
+   *
+   * @param array $nodes
+   *   Node map keyed by id; mutated in place to add 'position'.
+   * @param array $edges
+   *   Edge list.
+   */
+  protected function assignLayout(array &$nodes, array $edges): void {
+    $depth = [];
+    foreach ($nodes as $id => $node) {
+      $depth[$id] = 0;
+    }
+
+    // Relax longest-path depths. Bounded iteration count guards against cycles
+    // (ECA flows are acyclic, but a malformed flow must never loop forever).
+    $maxPasses = count($nodes) + 1;
+    for ($pass = 0; $pass < $maxPasses; $pass++) {
+      $changed = FALSE;
+      foreach ($edges as $edge) {
+        $s = $edge['source'];
+        $t = $edge['target'];
+        if (!isset($depth[$s]) || !isset($depth[$t])) {
+          continue;
+        }
+        if ($depth[$t] < $depth[$s] + 1) {
+          $depth[$t] = $depth[$s] + 1;
+          $changed = TRUE;
+        }
+      }
+      if (!$changed) {
+        break;
+      }
+    }
+
+    $rowInColumn = [];
+    foreach ($nodes as $id => &$node) {
+      $col = $depth[$id];
+      $row = $rowInColumn[$col] ?? 0;
+      $rowInColumn[$col] = $row + 1;
+      $node['position'] = [
+        'x' => $col * self::COL_WIDTH + 40,
+        'y' => $row * self::ROW_HEIGHT + 40,
+      ];
+    }
+  }
+
+  /**
+   * Produces a short human label for a gating condition id.
+   *
+   * @param string $conditionId
+   *   The condition id referenced by a successor (empty = unconditional).
+   * @param array $conditions
+   *   The flow's conditions config.
+   *
+   * @return string
+   *   A short edge label ('' for an unconditional edge).
+   */
+  protected function conditionLabel(string $conditionId, array $conditions): string {
+    if ($conditionId === '') {
+      return '';
+    }
+    // Prefer a meaningful comparison when the condition is an eca_scalar gate.
+    $config = $conditions[$conditionId]['configuration'] ?? [];
+    if (isset($config['right'])) {
+      $negate = !empty($config['negate']);
+      return ($negate ? '≠ ' : '= ') . (string) $config['right'];
+    }
+    // Otherwise humanise the id (gate_building_mitid_ok -> "building mitid ok").
+    $text = preg_replace('/^gate_/', '', $conditionId);
+    return trim(str_replace('_', ' ', (string) $text));
+  }
+
+  /**
+   * Humanises an event whose plugin has no explicit label.
+   */
+  protected function humanizeEvent(array $event): string {
+    $plugin = (string) ($event['plugin'] ?? '');
+    $type = (string) ($event['configuration']['type'] ?? '');
+    if (str_contains($plugin, 'insert')) {
+      return $type !== '' ? 'Submission created' : 'Created';
+    }
+    if (str_contains($plugin, 'update')) {
+      return 'Submission updated';
+    }
+    if (str_contains($plugin, 'custom')) {
+      return 'Custom event';
+    }
+    return $plugin !== '' ? $plugin : 'Event';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/FlowGraphRenderer.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/FlowGraphRenderer.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Component\Utility\Html;
+
+/**
+ * Renders an EcaGraphBuilder {nodes, edges} graph to a standalone inline SVG.
+ *
+ * Shared by every read-only surface (the per-flow page and the template-browser
+ * cards) so they draw flows identically, with no JS build step.
+ */
+class FlowGraphRenderer {
+
+  /**
+   * Node-box width, in SVG user units.
+   */
+  protected const NODE_W = 190;
+
+  /**
+   * Node-box height, in SVG user units.
+   */
+  protected const NODE_H = 54;
+
+  public function __construct(
+    protected EcaGraphBuilder $graphBuilder,
+  ) {}
+
+  /**
+   * Builds and renders the graph for a stored ECA flow.
+   *
+   * @param string $ecaId
+   *   The eca config entity id.
+   *
+   * @return string|null
+   *   SVG markup, or NULL when the flow does not exist.
+   */
+  public function renderForFlow(string $ecaId): ?string {
+    $graph = $this->graphBuilder->build($ecaId);
+    return $graph === NULL ? NULL : $this->render($graph);
+  }
+
+  /**
+   * Renders a {nodes, edges} graph to an inline SVG string.
+   *
+   * @param array $graph
+   *   The graph from EcaGraphBuilder.
+   *
+   * @return string
+   *   SVG markup.
+   */
+  public function render(array $graph): string {
+    $styles = [
+      'event' => ['fill' => '#e6f4ea', 'stroke' => '#137333', 'text' => '#0d652d'],
+      'action' => ['fill' => '#e8f0fe', 'stroke' => '#1a73e8', 'text' => '#174ea6'],
+      'deny' => ['fill' => '#fce8e6', 'stroke' => '#c5221f', 'text' => '#a50e0e'],
+    ];
+
+    $maxX = 0;
+    $maxY = 0;
+    $pos = [];
+    foreach ($graph['nodes'] as $node) {
+      $x = $node['position']['x'];
+      $y = $node['position']['y'];
+      $pos[$node['id']] = ['x' => $x, 'y' => $y];
+      $maxX = max($maxX, $x + self::NODE_W);
+      $maxY = max($maxY, $y + self::NODE_H);
+    }
+    $width = $maxX + 40;
+    $height = $maxY + 40;
+
+    $edgesSvg = '';
+    foreach ($graph['edges'] as $edge) {
+      if (!isset($pos[$edge['source']], $pos[$edge['target']])) {
+        continue;
+      }
+      $s = $pos[$edge['source']];
+      $t = $pos[$edge['target']];
+      $x1 = $s['x'] + self::NODE_W;
+      $y1 = $s['y'] + self::NODE_H / 2;
+      $x2 = $t['x'];
+      $y2 = $t['y'] + self::NODE_H / 2;
+      $mx = ($x1 + $x2) / 2;
+      $edgesSvg .= new FormattableMarkup(
+        '<path d="M@x1,@y1 C@cx,@y1 @cx,@y2 @x2e,@y2" fill="none" stroke="#9aa0a6" stroke-width="1.5" marker-end="url(#af-arrow)" />',
+        ['@x1' => $x1, '@y1' => $y1, '@cx' => $mx, '@y2' => $y2, '@x2e' => $x2 - 6],
+      );
+      if (($edge['label'] ?? '') !== '') {
+        $edgesSvg .= new FormattableMarkup(
+          '<text x="@x" y="@y" text-anchor="middle" font-size="11" fill="#5f6368" font-family="sans-serif">@label</text>',
+          ['@x' => $mx, '@y' => ($y1 + $y2) / 2 - 4, '@label' => $edge['label']],
+        );
+      }
+    }
+
+    $nodesSvg = '';
+    foreach ($graph['nodes'] as $node) {
+      $style = $styles[$node['type']] ?? $styles['action'];
+      $x = $pos[$node['id']]['x'];
+      $y = $pos[$node['id']]['y'];
+      $nodesSvg .= new FormattableMarkup(
+        '<g><title>@full</title>'
+        . '<rect x="@x" y="@y" rx="8" ry="8" width="@w" height="@h" fill="@fill" stroke="@stroke" stroke-width="1.5" />'
+        . '<text x="@tx" y="@ty" text-anchor="middle" font-size="12" font-family="sans-serif" fill="@text">@label</text>'
+        . '</g>',
+        [
+          '@full' => $node['label'] . ' (' . $node['type'] . ')',
+          '@x' => $x,
+          '@y' => $y,
+          '@w' => self::NODE_W,
+          '@h' => self::NODE_H,
+          '@fill' => $style['fill'],
+          '@stroke' => $style['stroke'],
+          '@text' => $style['text'],
+          '@tx' => $x + self::NODE_W / 2,
+          '@ty' => $y + self::NODE_H / 2 + 4,
+          '@label' => $this->truncate($node['label'], 26),
+        ],
+      );
+    }
+
+    $title = Html::escape($graph['label'] ?? 'flow');
+    return '<svg viewBox="0 0 ' . $width . ' ' . $height . '" width="100%" '
+      . 'role="img" aria-label="' . $title . ' flow diagram" '
+      . 'xmlns="http://www.w3.org/2000/svg">'
+      . '<defs><marker id="af-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+      . '<path d="M0,0 L10,5 L0,10 z" fill="#9aa0a6" /></marker></defs>'
+      . $edgesSvg . $nodesSvg
+      . '</svg>';
+  }
+
+  /**
+   * The SVG tags a renderer surface must allow through Xss/markup filtering.
+   *
+   * @return string[]
+   *   Allowed tag names.
+   */
+  public static function allowedTags(): array {
+    return ['svg', 'g', 'rect', 'path', 'text', 'title', 'defs', 'marker', 'polygon', 'tspan'];
+  }
+
+  /**
+   * Truncates a label for display inside a fixed-width node box.
+   */
+  protected function truncate(string $text, int $max): string {
+    $text = Html::escape($text);
+    if (mb_strlen($text) <= $max) {
+      return $text;
+    }
+    return mb_substr($text, 0, $max - 1) . '…';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/templates/workflow-template-card.html.twig
+++ b/web/modules/custom/aabenforms_workflows/templates/workflow-template-card.html.twig
@@ -9,19 +9,26 @@
  * - category: Template category.
  * - category_badge: HTML for category badge.
  * - description: Template description.
- * - preview_url: URL for BPMN preview.
+ * - preview_url: URL for the full flow diagram (or legacy BPMN preview).
+ * - graph_svg: Inline SVG node-graph rendered from the ECA flow (or empty).
  * - use_link: Link render array for "Use This Template" button.
  */
 #}
 <div class="template-card" data-template-id="{{ template_id }}">
   <div class="template-card__preview">
-    <div class="bpmn-preview-thumbnail" data-preview-url="{{ preview_url }}">
-      <div class="bpmn-preview-loading">
-        <span class="loading-spinner"></span>
-        <span class="loading-text">Loading preview...</span>
+    {% if graph_svg %}
+      <a href="{{ preview_url }}" class="template-card__graph" title="{{ 'View full diagram'|t }}">
+        {{ graph_svg|raw }}
+      </a>
+    {% else %}
+      <div class="bpmn-preview-thumbnail" data-preview-url="{{ preview_url }}">
+        <div class="bpmn-preview-loading">
+          <span class="loading-spinner"></span>
+          <span class="loading-text">Loading preview...</span>
+        </div>
+        <div class="bpmn-preview-canvas" id="preview-{{ template_id }}"></div>
       </div>
-      <div class="bpmn-preview-canvas" id="preview-{{ template_id }}"></div>
-    </div>
+    {% endif %}
   </div>
 
   <div class="template-card__content">

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/EcaGraphBuilderTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/EcaGraphBuilderTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_workflows\Service\EcaGraphBuilder;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the ECA-to-graph converter.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\EcaGraphBuilder
+ * @group aabenforms_workflows
+ */
+class EcaGraphBuilderTest extends UnitTestCase {
+
+  /**
+   * The builder under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\EcaGraphBuilder
+   */
+  protected EcaGraphBuilder $builder;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->builder = new EcaGraphBuilder($this->createMock(EntityTypeManagerInterface::class));
+  }
+
+  /**
+   * A small gated flow mirroring the building_permit shape.
+   */
+  protected function sampleConfig(): array {
+    return [
+      'label' => 'sample_flow',
+      'events' => [
+        'on_submission' => [
+          'plugin' => 'content_entity:insert',
+          'configuration' => ['type' => 'webform_submission sample'],
+          'successors' => [['id' => 'mitid', 'condition' => '']],
+        ],
+      ],
+      'conditions' => [
+        'gate_ok' => [
+          'plugin' => 'eca_scalar',
+          'configuration' => ['left' => '[x_status]', 'right' => 'verified', 'negate' => FALSE],
+        ],
+        'gate_deny' => [
+          'plugin' => 'eca_scalar',
+          'configuration' => ['left' => '[x_status]', 'right' => 'verified', 'negate' => TRUE],
+        ],
+      ],
+      'actions' => [
+        'mitid' => [
+          'plugin' => 'aabenforms_mitid_validate',
+          'label' => 'Validate MitID',
+          'successors' => [
+            ['id' => 'lookup', 'condition' => 'gate_ok'],
+            ['id' => 'deny', 'condition' => 'gate_deny'],
+          ],
+        ],
+        'lookup' => ['plugin' => 'aabenforms_cpr_lookup', 'label' => 'CPR lookup', 'successors' => []],
+        'deny' => ['plugin' => 'aabenforms_workflow_deny', 'label' => 'Deny', 'successors' => []],
+      ],
+    ];
+  }
+
+  /**
+   * Tests node typing: events, actions, and the deny terminal.
+   *
+   * @covers ::fromConfig
+   */
+  public function testNodeTypes(): void {
+    $graph = $this->builder->fromConfig($this->sampleConfig());
+    $types = [];
+    foreach ($graph['nodes'] as $node) {
+      $types[$node['id']] = $node['type'];
+    }
+    $this->assertSame('event', $types['on_submission']);
+    $this->assertSame('action', $types['mitid']);
+    $this->assertSame('action', $types['lookup']);
+    $this->assertSame('deny', $types['deny'], 'aabenforms_workflow_deny becomes a deny node.');
+  }
+
+  /**
+   * Tests edges carry the gating condition as a readable label.
+   *
+   * @covers ::fromConfig
+   */
+  public function testEdgesCarryConditionLabels(): void {
+    $graph = $this->builder->fromConfig($this->sampleConfig());
+    $byTarget = [];
+    foreach ($graph['edges'] as $edge) {
+      $byTarget[$edge['target']] = $edge;
+    }
+    $this->assertSame('', $byTarget['mitid']['label'], 'Unconditional edge has no label.');
+    $this->assertSame('= verified', $byTarget['lookup']['label']);
+    $this->assertSame('≠ verified', $byTarget['deny']['label']);
+  }
+
+  /**
+   * Tests longest-path layering places downstream nodes further right.
+   *
+   * @covers ::fromConfig
+   * @covers ::assignLayout
+   */
+  public function testLayoutLayersLeftToRight(): void {
+    $graph = $this->builder->fromConfig($this->sampleConfig());
+    $x = [];
+    foreach ($graph['nodes'] as $node) {
+      $x[$node['id']] = $node['position']['x'];
+    }
+    $this->assertLessThan($x['mitid'], $x['on_submission']);
+    $this->assertLessThan($x['lookup'], $x['mitid']);
+    $this->assertSame($x['lookup'], $x['deny'], 'Siblings share a column.');
+  }
+
+  /**
+   * Tests an edge to a non-existent target is dropped (no dangling edges).
+   *
+   * @covers ::fromConfig
+   */
+  public function testDanglingEdgesDropped(): void {
+    $config = $this->sampleConfig();
+    $config['actions']['mitid']['successors'][] = ['id' => 'ghost', 'condition' => ''];
+    $graph = $this->builder->fromConfig($config);
+    foreach ($graph['edges'] as $edge) {
+      $this->assertNotSame('ghost', $edge['target']);
+    }
+  }
+
+}


### PR DESCRIPTION
One consistent node-graph for ECA flows, rendered straight from the ECA event/condition/action/successor graph - including **on the template browser** where you wanted it.

## What

- **`EcaGraphBuilder`** - any `eca.eca.*` flow → `{nodes, edges}` (types `event`/`action`/`deny`; conditions become branch labels `= verified` / `≠ verified`; longest-path auto-layout). Pure `fromConfig()` is unit-tested (4 tests).
- **`FlowGraphRenderer`** - shared service that renders a graph to inline SVG (no JS build step), used by every read-only surface so they draw identically.
- **Template browser** (`/admin/aabenforms/workflow-templates`) - the broken bpmn-js "Loading preview…" thumbnails are replaced by the real node-graph. Every template `X` maps 1:1 to flow `X_flow`, so each card shows that flow's actual structure; "View Full Preview" opens the full diagram. Falls back to the legacy preview if a template has no flow.
- **Per-flow page** `/admin/aabenforms/flow/{eca}/graph` + JSON `.../graph.json` (the feed for the future editable React Flow), and a **"Flow diagram"** operation link on the ECA list.

## Looks like

Template cards render `Submission created` (green) → `Validate MitID` → `= verified` → `CPR lookup` → … with the `≠ verified` branch to a red `Deny`. Verified live on DDEV.

phpcs clean; graph-builder unit tests green.

## Roadmap
- **Next** - editable React Flow in wizard Step 2, serialising edits back to ECA (consumes `graph.json`).