### PR TITLE
Harden /mitid/session: mask CPR, audit reads, source CPR from verified session (audit critical #3)

### DIFF
--- a/config/sync/eca.eca.building_permit_flow.yml
+++ b/config/sync/eca.eca.building_permit_flow.yml
@@ -64,7 +64,7 @@ actions:
     label: 'CPR registry lookup'
     plugin: aabenforms_cpr_lookup
     configuration:
-      cpr_token: '[webform_submission:values:cpr:raw]'
+      cpr_token: '[building_session:cpr]'
       result_token: citizen_data
       use_cache: true
     successors:
@@ -87,7 +87,7 @@ actions:
     label: 'Send confirmation via Digital Post'
     plugin: aabenforms_digital_post_send
     configuration:
-      recipient_token: '[webform_submission:values:cpr:raw]'
+      recipient_token: '[building_session:cpr]'
       recipient_type: cpr
       sender_cvr_token: ''
       subject_template: 'Modtaget: ansøgning om byggetilladelse'

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -304,7 +304,19 @@ class SendDigitalPostAction extends AabenFormsActionBase {
       }
     }
 
-    // Strategy 2: ECA token data registry lookup.
+    // Strategy 2: resolve a bracketed token via ECA token replacement. This
+    // handles session-backed sub-keys like [building_session:cpr], where the
+    // token environment holds DataType objects (not plain strings/arrays) that
+    // getTokenData() cannot return directly - the recipient CPR comes from the
+    // VERIFIED MitID session, never the spoofable submitted form value.
+    if (str_contains($token, '[') && method_exists($this->tokenService, 'replaceClear')) {
+      $replaced = $this->tokenService->replaceClear($token, []);
+      if (is_string($replaced) && trim($replaced) !== '') {
+        return trim($replaced);
+      }
+    }
+
+    // Strategy 3: flat ECA token data registry lookup (plain string/array).
     $key = trim($token, '[]');
     $value = $this->tokenService->getTokenData($key);
     if (is_string($value)) {

--- a/web/modules/custom/aabenforms_mitid/src/Controller/MitIdController.php
+++ b/web/modules/custom/aabenforms_mitid/src/Controller/MitIdController.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\aabenforms_mitid\Controller;
 
+use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_mitid\Service\MitIdOidcClient;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
@@ -24,13 +26,33 @@ class MitIdController extends ControllerBase {
   protected MitIdOidcClient $oidcClient;
 
   /**
+   * The MitID session manager.
+   *
+   * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager
+   */
+  protected MitIdSessionManager $sessionManager;
+
+  /**
+   * The audit logger.
+   *
+   * @var \Drupal\aabenforms_core\Service\AuditLogger
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
    * Constructs a MitIdController.
    *
    * @param \Drupal\aabenforms_mitid\Service\MitIdOidcClient $oidc_client
    *   The OIDC client service.
+   * @param \Drupal\aabenforms_mitid\Service\MitIdSessionManager $session_manager
+   *   The MitID session manager.
+   * @param \Drupal\aabenforms_core\Service\AuditLogger $audit_logger
+   *   The audit logger.
    */
-  public function __construct(MitIdOidcClient $oidc_client) {
+  public function __construct(MitIdOidcClient $oidc_client, MitIdSessionManager $session_manager, AuditLogger $audit_logger) {
     $this->oidcClient = $oidc_client;
+    $this->sessionManager = $session_manager;
+    $this->auditLogger = $audit_logger;
   }
 
   /**
@@ -38,7 +60,9 @@ class MitIdController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('aabenforms_mitid.oidc_client')
+      $container->get('aabenforms_mitid.oidc_client'),
+      $container->get('aabenforms_mitid.session_manager'),
+      $container->get('aabenforms_core.audit_logger')
     );
   }
 
@@ -234,26 +258,35 @@ class MitIdController extends ControllerBase {
    *   Session data or error.
    */
   public function getSession(string $session_id): JsonResponse {
-    $sessionManager = \Drupal::service('aabenforms_mitid.session_manager');
-    $session = $sessionManager->getSession($session_id);
+    $session = $this->sessionManager->getSession($session_id);
 
     if (!$session) {
+      // Audit the miss too - probing for valid session ids is exactly what an
+      // attacker would do against a bearer-capability endpoint.
+      $this->auditLogger->logWorkflowAccess($session_id, 'session_data_read', 'not_found', []);
       return new JsonResponse(['error' => 'Session not found or expired'], 404);
     }
 
-    $address = $sessionManager->getAddressFromSession($session_id);
+    // This endpoint is reachable by anyone presenting the (unguessable, 15-min)
+    // workflow_id - the capability the citizen received at login. Record every
+    // PII read so disclosure is auditable, and never put the full CPR on the
+    // wire: the SPA only needs it for display (masked), and citizen flows read
+    // the real CPR server-side from this same MitID session, not from the
+    // response. mitid_uuid/auth_time/issuer/tokens stay server-side only.
+    $cpr = (string) ($session['cpr'] ?? '');
+    $this->auditLogger->logWorkflowAccess($session_id, 'session_data_read', 'success', [
+      'assurance_level' => $session['assurance_level'] ?? 'unknown',
+    ]);
 
-    // Return session data in JSON:API-like format for frontend compatibility.
-    // Additive shape: name/cpr/email/expiry have always been here; the demo
-    // route consumes given_name/family_name/birthdate/address/assurance_level
-    // when present. mitid_uuid/auth_time/issuer remain server-side only.
+    $address = $this->sessionManager->getAddressFromSession($session_id);
+
     return new JsonResponse([
       'data' => [
         'type' => 'mitid-session',
         'id' => $session_id,
         'attributes' => [
           'name' => $session['name'] ?? $session['given_name'] ?? '',
-          'cpr' => $session['cpr'] ?? '',
+          'cpr' => $this->maskCpr($cpr),
           'email' => $session['email'] ?? '',
           'expiry' => $session['expires_at'] ?? '',
           'given_name' => $session['given_name'] ?? '',
@@ -264,6 +297,23 @@ class MitIdController extends ControllerBase {
         ],
       ],
     ]);
+  }
+
+  /**
+   * Masks a CPR to DDMMYY-XXXX for display, never exposing the serial.
+   *
+   * @param string $cpr
+   *   The full CPR, or empty.
+   *
+   * @return string
+   *   The masked CPR, or empty when none was present.
+   */
+  protected function maskCpr(string $cpr): string {
+    $digits = preg_replace('/\D/', '', $cpr);
+    if (strlen($digits) < 6) {
+      return '';
+    }
+    return substr($digits, 0, 6) . '-XXXX';
   }
 
 }


### PR DESCRIPTION
Closes the last verified critical from the expert audit: `/mitid/session/{id}` shipped `_access: 'TRUE'` and returned the **full CPR** + name/birthdate/address to anyone presenting the `workflow_id`, with no audit trail.

The `workflow_id` is an unguessable 15-min **bearer capability** (by design - it's why the cross-origin SPA can read the session). So this isn't "anyone"; it's capability auth. But the full CPR never needs to be on the wire, and PII reads must be auditable.

## Changes

- **`MitIdController::getSession`** - masks CPR to `DDMMYY-XXXX` (display only), **audit-logs every read** (success *and* not_found - probing a bearer endpoint is an attack signal), and injects services instead of `\Drupal::service()`.
- **`building_permit_flow`** - sources the CPR for the registry lookup **and the Digital Post recipient** from the **verified MitID session** (`[building_session...]`) instead of the submitted (now-masked, spoofable) form value. This also closes the audit's separate **"Digital Post recipient taken from request body"** finding.
- **`SendDigitalPostAction::resolveRecipient`** - resolves bracketed tokens via `replaceClear`, so session sub-keys work (ECA stores token data as `DataType` objects that `getTokenData` can't return as strings - the same getTokenData→replaceClear bug pattern fixed elsewhere).

## Verified end to end (no submitted CPR at all)

| | Result |
|---|---|
| MitID → CPR lookup → audit → Digital Post | all **complete** (CPR + recipient from the session) |
| `/mitid/session` CPR field | `250692-XXXX` (masked) |
| `session_data_read` audit rows | written (`workflow_access` / `session_data_read` / `success`) |

Existing digital-post (6) and mitid (50) unit tests stay green; phpcs clean.

## Notes
- Masking is global to the endpoint; only `building_permit` is wired to the prefill SPA today, so other gated citizen flows should likewise source CPR from the session before being fronted by an SPA (follow-up).
- The `wf-id`-in-URL bearer stays (capability auth); moving it out of the path (it can leak via logs/referrers) is a separate, larger hardening worth a follow-up.