### PR TITLE
feat(case): aabenforms_case engine - persistent cases, deadline clock, underretning flow

### DIFF
--- a/web/modules/custom/aabenforms_case/aabenforms_case.info.yml
+++ b/web/modules/custom/aabenforms_case/aabenforms_case.info.yml
@@ -1,0 +1,11 @@
+name: 'ÅbenForms Case'
+type: module
+description: 'Persistent case (sag) entity with a lawful lifecycle and a deadline (frist) clock, opened from webform submissions via ECA. Foundation for municipal casework.'
+package: 'ÅbenForms'
+core_version_requirement: ^11
+php: ^8.3
+
+dependencies:
+  - aabenforms_core:aabenforms_core
+  - eca:eca
+  - webform:webform

--- a/web/modules/custom/aabenforms_case/aabenforms_case.links.menu.yml
+++ b/web/modules/custom/aabenforms_case/aabenforms_case.links.menu.yml
@@ -1,0 +1,6 @@
+entity.aabenforms_case.collection:
+  title: 'Cases'
+  description: 'Caseworker inbox: open cases and their deadlines.'
+  route_name: entity.aabenforms_case.collection
+  parent: system.admin_content
+  weight: 10

--- a/web/modules/custom/aabenforms_case/aabenforms_case.permissions.yml
+++ b/web/modules/custom/aabenforms_case/aabenforms_case.permissions.yml
@@ -1,0 +1,9 @@
+view aabenforms_case:
+  title: 'View ÅbenForms cases'
+  description: 'Caseworkers with this permission can read cases (incl. via JSON:API).'
+  restrict access: true
+
+administer aabenforms_case:
+  title: 'Administer ÅbenForms cases'
+  description: 'Create, edit, transition and delete cases.'
+  restrict access: true

--- a/web/modules/custom/aabenforms_case/aabenforms_case.services.yml
+++ b/web/modules/custom/aabenforms_case/aabenforms_case.services.yml
@@ -1,0 +1,5 @@
+services:
+  aabenforms_case.frist_clock:
+    class: Drupal\aabenforms_case\Service\FristClock
+    arguments:
+      - '@config.factory'

--- a/web/modules/custom/aabenforms_case/config/install/aabenforms_case.settings.yml
+++ b/web/modules/custom/aabenforms_case/config/install/aabenforms_case.settings.yml
@@ -1,0 +1,13 @@
+frister:
+  underretning:
+    unit: hours
+    amount: 24
+  underretning_anerkend:
+    unit: hverdage
+    amount: 6
+  friplads:
+    unit: straks
+    amount: 0
+  default:
+    unit: hverdage
+    amount: 28

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.underretning_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.underretning_flow.yml
@@ -1,0 +1,33 @@
+uuid: 4f8b2c1d-6e3a-4b9c-9d7e-0a1b2c3d4e5f
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: underretning_flow
+id: underretning_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission underretning'
+    successors:
+      - id: open_case
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  open_case:
+    label: 'Åbn sag (underretning)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: underretning
+      case_id_token: case_id
+    successors: {  }

--- a/web/modules/custom/aabenforms_case/config/install/webform.webform.underretning.yml
+++ b/web/modules/custom/aabenforms_case/config/install/webform.webform.underretning.yml
@@ -1,0 +1,228 @@
+uuid: 7c1e9a2b-3d4f-4a6b-8c0d-1a2b3c4d5e6f
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: underretning
+title: 'Underretning om bekymring for et barn'
+description: 'En borger eller fagperson underretter kommunen om bekymring for et barns trivsel. Åbner en sag med lovbestemt frist (vurder senest 24 timer; anerkend senest 6 hverdage).'
+categories: {  }
+elements: |
+  reporter_type:
+    '#type': select
+    '#title': 'Hvem underretter'
+    '#required': true
+    '#options':
+      borger: 'Borger (kan være anonym)'
+      fagperson: 'Fagperson (skærpet underretningspligt - kan ikke være anonym)'
+  reporter_contact:
+    '#type': textfield
+    '#title': 'Dit navn og kontakt'
+    '#description': 'Påkrævet for fagpersoner. Borgere kan vælge at være anonyme.'
+    '#states':
+      required:
+        ':input[name="reporter_type"]':
+          value: fagperson
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  child_cpr:
+    '#type': textfield
+    '#title': 'Barnets CPR-nummer'
+    '#description': 'DDMMÅÅ-XXXX. Krypteres ved modtagelse.'
+  concern_details:
+    '#type': textarea
+    '#title': 'Beskriv din bekymring'
+    '#required': true
+    '#rows': 6
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din underretning er modtaget, og kommunen vurderer den hurtigst muligt.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_case/config/schema/aabenforms_case.schema.yml
+++ b/web/modules/custom/aabenforms_case/config/schema/aabenforms_case.schema.yml
@@ -1,0 +1,17 @@
+aabenforms_case.settings:
+  type: config_object
+  label: 'ÅbenForms Case settings'
+  mapping:
+    frister:
+      type: sequence
+      label: 'Per-area deadlines'
+      sequence:
+        type: mapping
+        label: 'Deadline definition'
+        mapping:
+          unit:
+            type: string
+            label: 'Unit (hours, hverdage, straks)'
+          amount:
+            type: integer
+            label: 'Amount'

--- a/web/modules/custom/aabenforms_case/src/AabenformsCaseAccessControlHandler.php
+++ b/web/modules/custom/aabenforms_case/src/AabenformsCaseAccessControlHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access control for the Case entity.
+ *
+ * Cases hold citizen casework data and must never be world-readable. Because
+ * jsonapi_frontend exposes every entity by default, this handler is the gate
+ * that keeps cases behind the caseworker permissions. View/update require
+ * "view aabenforms_case"; everything else requires "administer aabenforms_case".
+ */
+class AabenformsCaseAccessControlHandler extends EntityAccessControlHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account): AccessResultInterface {
+    if ($account->hasPermission('administer aabenforms_case')) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    return match ($operation) {
+      'view' => AccessResult::allowedIfHasPermission($account, 'view aabenforms_case'),
+      default => AccessResult::neutral()->cachePerPermissions(),
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL): AccessResultInterface {
+    return AccessResult::allowedIfHasPermission($account, 'administer aabenforms_case');
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/AabenformsCaseInterface.php
+++ b/web/modules/custom/aabenforms_case/src/AabenformsCaseInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
+
+/**
+ * Provides an interface for the ÅbenForms Case entity.
+ */
+interface AabenformsCaseInterface extends ContentEntityInterface, EntityChangedInterface, RevisionLogInterface {
+
+  /**
+   * Gets the casework area / case type (e.g. "underretning").
+   */
+  public function getCaseType(): string;
+
+  /**
+   * Gets the lawful lifecycle status machine name.
+   */
+  public function getStatus(): string;
+
+  /**
+   * Sets the lifecycle status machine name.
+   */
+  public function setStatus(string $status): static;
+
+  /**
+   * Gets the deadline (frist) due timestamp, or NULL when unset.
+   */
+  public function getFristDue(): ?int;
+
+  /**
+   * Gets the receipt-date timestamp (deadline clock start), or NULL.
+   */
+  public function getModtagelsesdato(): ?int;
+
+  /**
+   * Gets the referenced webform submission id, or NULL.
+   */
+  public function getSubmissionId(): ?string;
+
+}

--- a/web/modules/custom/aabenforms_case/src/AabenformsCaseListBuilder.php
+++ b/web/modules/custom/aabenforms_case/src/AabenformsCaseListBuilder.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_case\Service\FristClock;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Admin list builder for cases at /admin/aabenforms/cases.
+ */
+class AabenformsCaseListBuilder extends EntityListBuilder {
+
+  /**
+   * Constructs the list builder.
+   */
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    EntityStorageInterface $storage,
+    protected DateFormatterInterface $dateFormatter,
+    protected TimeInterface $time,
+    protected FristClock $fristClock,
+  ) {
+    parent::__construct($entity_type, $storage);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type): static {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager')->getStorage($entity_type->id()),
+      $container->get('date.formatter'),
+      $container->get('datetime.time'),
+      $container->get('aabenforms_case.frist_clock'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader(): array {
+    $header['id'] = new TranslatableMarkup('ID');
+    $header['title'] = new TranslatableMarkup('Title');
+    $header['case_type'] = new TranslatableMarkup('Type');
+    $header['status'] = new TranslatableMarkup('Status');
+    $header['frist'] = new TranslatableMarkup('Deadline');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity): array {
+    assert($entity instanceof AabenformsCase);
+    $statuses = AabenformsCase::statusOptions();
+    $row['id'] = $entity->id();
+    $row['title'] = $entity->label();
+    $row['case_type'] = $entity->getCaseType();
+    $row['status'] = $statuses[$entity->getStatus()] ?? $entity->getStatus();
+
+    $due = $entity->getFristDue();
+    if ($due === NULL) {
+      $row['frist'] = new TranslatableMarkup('—');
+    }
+    else {
+      $state = $this->fristClock->computeState($due, $this->time->getRequestTime());
+      $row['frist'] = new TranslatableMarkup('@date (@state)', [
+        '@date' => $this->dateFormatter->format($due, 'short'),
+        '@state' => $state,
+      ]);
+    }
+
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Entity/AabenformsCase.php
+++ b/web/modules/custom/aabenforms_case/src/Entity/AabenformsCase.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Entity;
+
+use Drupal\aabenforms_case\AabenformsCaseInterface;
+use Drupal\Core\Entity\Attribute\ContentEntityType;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Form\DeleteMultipleForm;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\RevisionableContentEntityBase;
+use Drupal\Core\Entity\RevisionLogEntityTrait;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\aabenforms_case\AabenformsCaseAccessControlHandler;
+use Drupal\aabenforms_case\AabenformsCaseListBuilder;
+
+/**
+ * Defines the ÅbenForms Case (sag) entity.
+ *
+ * A case is the persistent record of a piece of municipal casework. It is
+ * opened from a webform submission (via the aabenforms_case_open ECA action),
+ * carries a lawful lifecycle status and a deadline (frist) clock, and is
+ * revisionable so that every status transition leaves an auditable revision
+ * with a log message (who/when/why) - the compliance backbone.
+ *
+ * Privacy by design: the case references its submission and never copies the
+ * raw CPR. The CPR stays encrypted at rest on the submission
+ * (aabenforms_core_webform_submission_presave + CprAccess).
+ */
+#[ContentEntityType(
+  id: 'aabenforms_case',
+  label: new TranslatableMarkup('Case'),
+  label_collection: new TranslatableMarkup('Cases'),
+  label_singular: new TranslatableMarkup('case'),
+  label_plural: new TranslatableMarkup('cases'),
+  label_count: [
+    'singular' => '@count case',
+    'plural' => '@count cases',
+  ],
+  handlers: [
+    'list_builder' => AabenformsCaseListBuilder::class,
+    'access' => AabenformsCaseAccessControlHandler::class,
+    'form' => [
+      'default' => ContentEntityForm::class,
+      'edit' => ContentEntityForm::class,
+      'delete' => ContentEntityDeleteForm::class,
+      'delete-multiple-confirm' => DeleteMultipleForm::class,
+    ],
+    'route_provider' => [
+      'html' => AdminHtmlRouteProvider::class,
+    ],
+  ],
+  base_table: 'aabenforms_case',
+  revision_table: 'aabenforms_case_revision',
+  admin_permission: 'administer aabenforms_case',
+  entity_keys: [
+    'id' => 'id',
+    'revision' => 'vid',
+    'uuid' => 'uuid',
+    'label' => 'title',
+  ],
+  revision_metadata_keys: [
+    'revision_user' => 'revision_user',
+    'revision_created' => 'revision_created',
+    'revision_log_message' => 'revision_log_message',
+  ],
+  links: [
+    'collection' => '/admin/aabenforms/cases',
+    'edit-form' => '/admin/aabenforms/cases/{aabenforms_case}/edit',
+    'delete-form' => '/admin/aabenforms/cases/{aabenforms_case}/delete',
+  ],
+)]
+class AabenformsCase extends RevisionableContentEntityBase implements AabenformsCaseInterface {
+
+  use EntityChangedTrait;
+  use RevisionLogEntityTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCaseType(): string {
+    return (string) $this->get('case_type')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatus(): string {
+    return (string) $this->get('status')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setStatus(string $status): static {
+    $this->set('status', $status);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFristDue(): ?int {
+    $value = $this->get('frist_due')->value;
+    return $value === NULL ? NULL : (int) $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getModtagelsesdato(): ?int {
+    $value = $this->get('modtagelsesdato')->value;
+    return $value === NULL ? NULL : (int) $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSubmissionId(): ?string {
+    $target = $this->get('submission_ref')->target_id;
+    return $target === NULL ? NULL : (string) $target;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
+    /** @var \Drupal\Core\Field\BaseFieldDefinition[] $fields */
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['title'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Title'))
+      ->setRequired(TRUE)
+      ->setRevisionable(TRUE)
+      ->setSetting('max_length', 255)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['case_type'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Case type'))
+      ->setDescription(new TranslatableMarkup('The casework area, e.g. underretning, friplads.'))
+      ->setRequired(TRUE)
+      ->setRevisionable(TRUE)
+      ->setSetting('max_length', 64)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Status'))
+      ->setDescription(new TranslatableMarkup('Lawful case lifecycle state.'))
+      ->setRevisionable(TRUE)
+      ->setRequired(TRUE)
+      ->setDefaultValue('modtaget')
+      ->setSetting('allowed_values', self::statusOptions())
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['submission_ref'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(new TranslatableMarkup('Webform submission'))
+      ->setDescription(new TranslatableMarkup('The submission this case was opened from. The raw CPR stays encrypted on the submission and is never copied here.'))
+      ->setSetting('target_type', 'webform_submission')
+      ->setRevisionable(TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['kle_emne'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('KLE-emne (UUID)'))
+      ->setDescription(new TranslatableMarkup('Classification (SF1510 Klassifikation) UUID used for journalising and SF2900 routing.'))
+      ->setRevisionable(TRUE)
+      ->setSetting('max_length', 64)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['handlekommune'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Handling municipality'))
+      ->setRevisionable(TRUE)
+      ->setSetting('max_length', 64)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['betalingskommune'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Paying municipality'))
+      ->setRevisionable(TRUE)
+      ->setSetting('max_length', 64)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['modtagelsesdato'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(new TranslatableMarkup('Receipt date'))
+      ->setDescription(new TranslatableMarkup('When the case was received - the start of the RSL §3 deadline clock.'))
+      ->setRevisionable(TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['frist_due'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(new TranslatableMarkup('Deadline (frist) due'))
+      ->setDescription(new TranslatableMarkup('Computed by the FristClock from the receipt date and the per-area deadline.'))
+      ->setRevisionable(TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['partshoering_state'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Partshøring state'))
+      ->setRevisionable(TRUE)
+      ->setDefaultValue('ikke_paakraevet')
+      ->setSetting('allowed_values', [
+        'ikke_paakraevet' => 'Ikke påkrævet',
+        'afventer' => 'Afventer svar',
+        'afsluttet' => 'Afsluttet',
+      ])
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['afgoerelse_type'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Decision type'))
+      ->setRevisionable(TRUE)
+      ->setSetting('allowed_values', [
+        'medhold' => 'Medhold',
+        'delvist' => 'Delvist medhold',
+        'afslag' => 'Afslag',
+      ])
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['klagefrist'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(new TranslatableMarkup('Appeal deadline (klagefrist)'))
+      ->setRevisionable(TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['journal_ref'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Journal reference'))
+      ->setDescription(new TranslatableMarkup('Reference returned by the Sags- og Dokumentindeks (SF1470) registration.'))
+      ->setRevisionable(TRUE)
+      ->setSetting('max_length', 128)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['assigned_to'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(new TranslatableMarkup('Assigned caseworker'))
+      ->setSetting('target_type', 'user')
+      ->setRevisionable(TRUE)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(new TranslatableMarkup('Created'))
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(new TranslatableMarkup('Changed'));
+
+    // Revision log fields (revision_user, revision_created, revision_log_message).
+    $fields += static::revisionLogBaseFieldDefinitions($entity_type);
+
+    return $fields;
+  }
+
+  /**
+   * The allowed case lifecycle states.
+   *
+   * @return array<string, string>
+   *   Machine name => human label.
+   */
+  public static function statusOptions(): array {
+    return [
+      'modtaget' => 'Modtaget',
+      'oplyst' => 'Oplyst',
+      'partshoering' => 'Partshøring',
+      'afgoerelse' => 'Afgørelse',
+      'paaklaget' => 'Påklaget',
+      'lukket' => 'Lukket',
+    ];
+  }
+
+  /**
+   * The lawful forward transitions allowed from each state.
+   *
+   * @return array<string, string[]>
+   *   Source state => list of allowed target states.
+   */
+  public static function allowedTransitions(): array {
+    return [
+      'modtaget' => ['oplyst', 'lukket'],
+      'oplyst' => ['partshoering', 'afgoerelse', 'lukket'],
+      'partshoering' => ['afgoerelse', 'lukket'],
+      'afgoerelse' => ['paaklaget', 'lukket'],
+      'paaklaget' => ['afgoerelse', 'lukket'],
+      'lukket' => [],
+    ];
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/CaseActionBase.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/CaseActionBase.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\eca\Plugin\Action\ConfigurableActionBase;
+use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for ÅbenForms Case ECA actions.
+ *
+ * Deliberately decoupled from aabenforms_workflows so the case foundation
+ * depends only on aabenforms_core + eca + webform (lighter, easier to test).
+ * It re-uses the same conventions as aabenforms_workflows' AabenFormsActionBase
+ * (token helpers, execution-collector steps, audit logging) via setter
+ * injection, because eca's ActionBase constructor is final.
+ */
+abstract class CaseActionBase extends ConfigurableActionBase {
+
+  /**
+   * Collects workflow execution steps for the synchronous API response.
+   */
+  protected WorkflowExecutionCollector $executionCollector;
+
+  /**
+   * The audit logger.
+   */
+  protected AuditLogger $auditLogger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    /** @var static $instance */
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->executionCollector = $container->get('aabenforms_core.workflow_execution_collector');
+    $instance->auditLogger = $container->get('aabenforms_core.audit_logger');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, ?AccountInterface $account = NULL, $return_as_object = FALSE): AccessResultInterface|bool {
+    $result = AccessResult::allowed();
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+  /**
+   * Records a workflow step for the API response.
+   */
+  protected function recordStep(string $label, string $description, string $status = 'completed'): void {
+    $this->executionCollector->addStep($this->getPluginId(), $label, $description, $status);
+  }
+
+  /**
+   * Logs an action execution.
+   *
+   * @param string $message
+   *   The log message (may contain {placeholders}).
+   * @param array $context
+   *   Placeholder context.
+   * @param string $level
+   *   Log level (info, warning, error).
+   */
+  protected function log(string $message, array $context = [], string $level = 'info'): void {
+    $context['action'] = $this->getPluginId();
+    $this->logger->$level($message, $context);
+  }
+
+  /**
+   * Routes an action failure to the log and the execution collector.
+   */
+  protected function handleError(\Throwable $e, string $contextMessage = ''): void {
+    $this->log('Action failed: {message}. Context: {context}', [
+      'message' => $e->getMessage(),
+      'context' => $contextMessage,
+      'exception' => $e,
+    ], 'error');
+    $this->executionCollector->addStep(
+      $this->getPluginId(),
+      $contextMessage ?: 'Action failed',
+      $e->getMessage(),
+      'failed',
+      $e->getMessage()
+    );
+  }
+
+  /**
+   * Sets a token value in the ECA token environment.
+   */
+  protected function setTokenValue(string $tokenName, mixed $value): void {
+    $this->tokenService->addTokenData($tokenName, $value);
+  }
+
+  /**
+   * Reads a token value, resolving bracketed references.
+   *
+   * Mirrors AabenFormsActionBase::getTokenValue: a '[...]' reference is
+   * replaced against the token environment; a bare key is a direct data-bag
+   * lookup.
+   */
+  protected function getTokenValue(string $fieldKey, string $default): string {
+    if (str_contains($fieldKey, '[')) {
+      $replaced = $this->tokenService->replaceClear($fieldKey, []);
+      $replaced = is_string($replaced) ? trim($replaced) : '';
+      return $replaced !== '' ? $replaced : $default;
+    }
+    $value = $this->tokenService->getTokenData($fieldKey);
+    if (is_string($value)) {
+      return $value;
+    }
+    if ($value === NULL) {
+      return $default;
+    }
+    if (is_scalar($value)) {
+      return (string) $value;
+    }
+    return $default;
+  }
+
+  /**
+   * Resolves the webform submission for the current ECA invocation.
+   */
+  protected function getSubmission(mixed $entity = NULL): ?WebformSubmissionInterface {
+    if ($entity instanceof WebformSubmissionInterface) {
+      return $entity;
+    }
+    $token_value = $this->tokenService->getTokenData('webform_submission');
+    return $token_value instanceof WebformSubmissionInterface ? $token_value : NULL;
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/OpenCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/OpenCaseAction.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Service\FristClock;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Open a case from the current submission.
+ *
+ * Creates an aabenforms_case referencing the webform submission, stamps the
+ * receipt date (now), computes the deadline via the FristClock for the
+ * configured area, and starts the case in the "modtaget" state. The new case
+ * id is written to the [case_id] token so later actions (transition, journal,
+ * SF2900 distribute) can act on it.
+ *
+ * Privacy: the case stores only a reference to the submission, never the raw
+ * CPR - that stays encrypted on the submission.
+ */
+#[Action(
+  id: 'aabenforms_case_open',
+  label: new TranslatableMarkup('Open case'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Opens a persistent case from the submission, with a deadline (frist) clock.'),
+  version_introduced: '1.0.0',
+)]
+class OpenCaseAction extends CaseActionBase {
+
+  /**
+   * The deadline clock.
+   */
+  protected FristClock $fristClock;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->fristClock = $container->get('aabenforms_case.frist_clock');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_type' => 'sag',
+      'case_id_token' => 'case_id',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_type'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case type / area'),
+      '#description' => $this->t('Casework area key, e.g. "underretning" or "friplads". Drives the deadline lookup in aabenforms_case.settings.'),
+      '#default_value' => $this->configuration['case_type'],
+      '#required' => TRUE,
+    ];
+
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token (case id)'),
+      '#description' => $this->t('Token name to receive the new case id, for later actions.'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_type'] = $form_state->getValue('case_type');
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $submission = $this->getSubmission();
+      $caseType = trim((string) ($this->configuration['case_type'] ?? 'sag')) ?: 'sag';
+      $resultToken = trim((string) ($this->configuration['case_id_token'] ?? 'case_id')) ?: 'case_id';
+
+      $now = $this->time->getRequestTime();
+      $due = $this->fristClock->computeDue($now, $caseType);
+
+      $submissionId = $submission?->id();
+      $title = sprintf(
+        '%s - indsendelse %s',
+        ucfirst($caseType),
+        $submissionId !== NULL ? '#' . $submissionId : 'uden submission'
+      );
+
+      $storage = $this->entityTypeManager->getStorage('aabenforms_case');
+      $case = $storage->create([
+        'title' => $title,
+        'case_type' => $caseType,
+        'status' => 'modtaget',
+        'submission_ref' => $submissionId,
+        'modtagelsesdato' => $now,
+        'frist_due' => $due,
+        'revision_log_message' => 'Sag oprettet fra indsendelse.',
+      ]);
+      $case->save();
+
+      $this->setTokenValue($resultToken, (string) $case->id());
+      $this->recordStep(
+        'Sag oprettet',
+        sprintf('Sag #%s (%s) oprettet med frist.', $case->id(), $caseType)
+      );
+
+      $this->auditLogger->log(
+        'case_opened',
+        (string) $case->id(),
+        $caseType,
+        'success',
+        [
+          'action_id' => $this->getPluginId(),
+          'submission_id' => $submissionId,
+        ]
+      );
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Open case');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/TransitionCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/TransitionCaseAction.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: Transition a case to a new lifecycle state.
+ *
+ * Loads the case referenced by the configured token, validates that the move
+ * is a lawful forward transition (AabenformsCase::allowedTransitions), and
+ * saves a NEW revision carrying the transition log message - so the lifecycle
+ * history is auditable (who/when/why). Rejects illegal transitions instead of
+ * silently writing a bad state.
+ */
+#[Action(
+  id: 'aabenforms_case_transition',
+  label: new TranslatableMarkup('Transition case'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Moves a case to a new lawful lifecycle state, recording an auditable revision.'),
+  version_introduced: '1.0.0',
+)]
+class TransitionCaseAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => 'case_id',
+      'target_status' => '',
+      'log_message' => 'Status ændret.',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#description' => $this->t('Token holding the case id, e.g. case_id or [case_id].'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+
+    $form['target_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Target status'),
+      '#options' => AabenformsCase::statusOptions(),
+      '#default_value' => $this->configuration['target_status'],
+      '#required' => TRUE,
+    ];
+
+    $form['log_message'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Revision log message'),
+      '#default_value' => $this->configuration['log_message'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['target_status'] = $form_state->getValue('target_status');
+    $this->configuration['log_message'] = $form_state->getValue('log_message');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? 'case_id'), '');
+      $target = (string) ($this->configuration['target_status'] ?? '');
+      $logMessage = (string) ($this->configuration['log_message'] ?? 'Status ændret.');
+
+      if ($caseId === '' || $target === '') {
+        $this->recordStep('Sagsovergang', 'Mangler sags-id eller målstatus.', 'failed');
+        return;
+      }
+
+      $storage = $this->entityTypeManager->getStorage('aabenforms_case');
+      $case = $storage->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Sagsovergang', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      $current = $case->getStatus();
+      $allowed = AabenformsCase::allowedTransitions()[$current] ?? [];
+      if (!in_array($target, $allowed, TRUE)) {
+        $this->log('Illegal case transition {from}->{to} on case {id}', [
+          'from' => $current,
+          'to' => $target,
+          'id' => $caseId,
+        ], 'warning');
+        $this->recordStep(
+          'Sagsovergang afvist',
+          sprintf('Ulovlig overgang %s -> %s.', $current, $target),
+          'failed'
+        );
+        return;
+      }
+
+      $case->setStatus($target);
+      // Force a new revision so the transition is auditable.
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage($logMessage);
+      $case->setRevisionCreationTime($this->time->getRequestTime());
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Sagsovergang', sprintf('Sag #%s: %s -> %s.', $caseId, $current, $target));
+      $this->auditLogger->log(
+        'case_transition',
+        (string) $caseId,
+        sprintf('%s->%s', $current, $target),
+        'success',
+        ['action_id' => $this->getPluginId()]
+      );
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Transition case');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Service/FristClock.php
+++ b/web/modules/custom/aabenforms_case/src/Service/FristClock.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Computes statutory deadlines (frister) and their traffic-light state.
+ *
+ * Deadlines are driven by per-area configuration in aabenforms_case.settings
+ * (key "frister"), so a new casework area only needs config, not code. Each
+ * area defines a duration as either calendar hours or working days
+ * (hverdage), the latter skipping weekends per RSL/forvaltningslov practice.
+ *
+ * NOTE: Danish public holidays are not yet subtracted from working-day math
+ * (TODO: add a holiday calendar). Weekends are handled.
+ */
+class FristClock {
+
+  public function __construct(
+    protected ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * Computes the deadline timestamp for a case area.
+   *
+   * @param int $receiptTs
+   *   The receipt (modtagelse) Unix timestamp the clock starts from.
+   * @param string $area
+   *   The casework area key (e.g. "underretning"). Falls back to the
+   *   "default" area when the key is not configured.
+   *
+   * @return int
+   *   The due Unix timestamp.
+   */
+  public function computeDue(int $receiptTs, string $area): int {
+    [$unit, $amount] = $this->resolveArea($area);
+
+    return match ($unit) {
+      'hours' => $receiptTs + ($amount * 3600),
+      'hverdage' => $this->addWorkingDays($receiptTs, $amount),
+      // "straks" (immediate) and any unknown unit: due is the receipt itself.
+      default => $receiptTs,
+    };
+  }
+
+  /**
+   * Returns the traffic-light state for a deadline.
+   *
+   * @param int $dueTs
+   *   The due Unix timestamp.
+   * @param int $nowTs
+   *   The current Unix timestamp.
+   *
+   * @return string
+   *   One of "groen", "gul", "roed".
+   */
+  public function computeState(int $dueTs, int $nowTs): string {
+    if ($nowTs >= $dueTs) {
+      return 'roed';
+    }
+    // Amber when the deadline is less than 24 hours away.
+    if (($dueTs - $nowTs) <= 86400) {
+      return 'gul';
+    }
+    return 'groen';
+  }
+
+  /**
+   * Resolves the configured [unit, amount] for an area.
+   *
+   * @return array{0:string,1:int}
+   *   The unit ("hours", "hverdage", "straks", ...) and integer amount.
+   */
+  protected function resolveArea(string $area): array {
+    $frister = $this->configFactory->get('aabenforms_case.settings')->get('frister') ?? [];
+    $config = $frister[$area] ?? $frister['default'] ?? ['unit' => 'hverdage', 'amount' => 28];
+    $unit = (string) ($config['unit'] ?? 'hverdage');
+    $amount = (int) ($config['amount'] ?? 0);
+    return [$unit, $amount];
+  }
+
+  /**
+   * Adds N working days (Mon-Fri) to a timestamp.
+   *
+   * The time-of-day of the receipt is preserved; only whole working days are
+   * counted forward, skipping Saturdays and Sundays.
+   */
+  protected function addWorkingDays(int $receiptTs, int $days): int {
+    if ($days <= 0) {
+      return $receiptTs;
+    }
+    $ts = $receiptTs;
+    $added = 0;
+    while ($added < $days) {
+      $ts += 86400;
+      $weekday = (int) gmdate('N', $ts);
+      // N: 1 (Mon) .. 7 (Sun); count only 1-5.
+      if ($weekday <= 5) {
+        $added++;
+      }
+    }
+    return $ts;
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseEntityTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseEntityTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the AabenformsCase entity: schema, fields, defaults, revisions.
+ *
+ * @group aabenforms_case
+ */
+class CaseEntityTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+  }
+
+  /**
+   * Creates a case and asserts defaults + persistence.
+   */
+  public function testCreateAndDefaults(): void {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create([
+      'title' => 'Underretning - indsendelse #1',
+      'case_type' => 'underretning',
+      'frist_due' => 1704186000,
+      'modtagelsesdato' => 1704099600,
+    ]);
+    $case->save();
+
+    $this->assertNotNull($case->id());
+    $this->assertSame('modtaget', $case->getStatus(), 'Default status is modtaget');
+    $this->assertSame('underretning', $case->getCaseType());
+    $this->assertSame(1704186000, $case->getFristDue());
+    $this->assertSame(1704099600, $case->getModtagelsesdato());
+
+    // Reload from storage to prove it persisted.
+    $storage->resetCache();
+    $reloaded = $storage->load($case->id());
+    $this->assertInstanceOf(AabenformsCase::class, $reloaded);
+    $this->assertSame('Underretning - indsendelse #1', $reloaded->label());
+  }
+
+  /**
+   * A status change with a new revision leaves an auditable revision trail.
+   */
+  public function testTransitionCreatesRevision(): void {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create([
+      'title' => 'Sag',
+      'case_type' => 'underretning',
+    ]);
+    $case->save();
+    $firstVid = $case->getRevisionId();
+
+    $case->setStatus('oplyst');
+    $case->setNewRevision(TRUE);
+    $case->setRevisionLogMessage('Oplyst af sagsbehandler.');
+    $case->save();
+
+    $this->assertNotSame($firstVid, $case->getRevisionId(), 'A new revision was created');
+    $this->assertSame('oplyst', $case->getStatus());
+    $this->assertSame('Oplyst af sagsbehandler.', $case->getRevisionLogMessage());
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/OpenCaseActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/OpenCaseActionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\webform\Entity\Webform;
+use Drupal\webform\Entity\WebformSubmission;
+
+/**
+ * Tests the aabenforms_case_open ECA action end-to-end.
+ *
+ * Proves a submission opens a case with the deadline (frist) computed from the
+ * per-area config, references the submission, and starts in "modtaget".
+ *
+ * @group aabenforms_case
+ */
+class OpenCaseActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('webform_submission');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('webform', ['webform']);
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+
+    // Set the per-area deadlines directly rather than installing the module's
+    // config/install (which also contains the ECA flow + webform that pull in
+    // eca_content/modeler_api not enabled here).
+    $this->config('aabenforms_case.settings')
+      ->set('frister', [
+        'underretning' => ['unit' => 'hours', 'amount' => 24],
+        'default' => ['unit' => 'hverdage', 'amount' => 28],
+      ])
+      ->save();
+  }
+
+  /**
+   * Invokes the action with a submission token and asserts the case.
+   */
+  public function testOpenCaseFromSubmission(): void {
+    // A minimal webform + submission (no CPR field, so the core presave
+    // encryption hook is a no-op and needs no encryption profile).
+    Webform::create(['id' => 'underretning', 'title' => 'Underretning'])->save();
+    $submission = WebformSubmission::create([
+      'webform_id' => 'underretning',
+      'data' => ['concern_details' => 'Bekymring for et barn.'],
+    ]);
+    $submission->save();
+
+    // Put the submission on the token environment, as a content_entity:insert
+    // event would, then run the action.
+    $tokenService = $this->container->get('eca.token_services');
+    $tokenService->addTokenData('webform_submission', $submission);
+
+    /** @var \Drupal\Core\Action\ActionManager $actionManager */
+    $actionManager = $this->container->get('plugin.manager.action');
+    $action = $actionManager->createInstance('aabenforms_case_open', [
+      'case_type' => 'underretning',
+      'case_id_token' => 'case_id',
+    ]);
+    $action->execute();
+
+    // Exactly one case was created from the submission.
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $cases = $storage->loadMultiple();
+    $this->assertCount(1, $cases, 'One case was created');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = reset($cases);
+
+    // Its id was written back to the token (eca wraps scalars, so cast).
+    $this->assertSame(
+      (string) $case->id(),
+      (string) $tokenService->getTokenData('case_id'),
+      'case_id token holds the new case id'
+    );
+    $this->assertSame('underretning', $case->getCaseType());
+    $this->assertSame('modtaget', $case->getStatus());
+    $this->assertSame((int) $submission->id(), (int) $case->getSubmissionId());
+
+    // The underretning area is configured as 24 hours, so the deadline is
+    // exactly 24h after the receipt date.
+    $this->assertSame(
+      $case->getModtagelsesdato() + (24 * 3600),
+      $case->getFristDue(),
+      'Frist is 24h after receipt for the underretning area'
+    );
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Unit/CaseLifecycleTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Unit/CaseLifecycleTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Unit;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the case lifecycle invariants (pure static maps, no bootstrap).
+ *
+ * @group aabenforms_case
+ */
+class CaseLifecycleTest extends UnitTestCase {
+
+  /**
+   * Every transition target must be a defined status.
+   */
+  public function testTransitionsReferenceKnownStatuses(): void {
+    $statuses = array_keys(AabenformsCase::statusOptions());
+    foreach (AabenformsCase::allowedTransitions() as $from => $targets) {
+      $this->assertContains($from, $statuses, "Source state '$from' is a known status");
+      foreach ($targets as $to) {
+        $this->assertContains($to, $statuses, "Target state '$to' is a known status");
+        $this->assertNotSame($from, $to, "Transition '$from' does not loop to itself");
+      }
+    }
+  }
+
+  /**
+   * Every status must appear in the transition table (no orphan states).
+   */
+  public function testEveryStatusHasTransitionEntry(): void {
+    $transitions = AabenformsCase::allowedTransitions();
+    foreach (array_keys(AabenformsCase::statusOptions()) as $status) {
+      $this->assertArrayHasKey($status, $transitions, "Status '$status' has a transition entry");
+    }
+  }
+
+  /**
+   * Closed ("lukket") is terminal and every case can always be closed.
+   */
+  public function testClosedIsTerminalAndAlwaysReachable(): void {
+    $transitions = AabenformsCase::allowedTransitions();
+    $this->assertSame([], $transitions['lukket'], '"lukket" is terminal');
+
+    foreach ($transitions as $from => $targets) {
+      if ($from === 'lukket') {
+        continue;
+      }
+      $this->assertContains('lukket', $targets, "State '$from' can transition to lukket");
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Unit\Service;
+
+use Drupal\aabenforms_case\Service\FristClock;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\aabenforms_case\Service\FristClock
+ *
+ * @group aabenforms_case
+ */
+class FristClockTest extends UnitTestCase {
+
+  /**
+   * Monday 2024-01-01 09:00:00 UTC.
+   */
+  protected const MONDAY_0900 = 1704099600;
+
+  /**
+   * Builds a FristClock with the given per-area config.
+   *
+   * @param array<string, array{unit:string, amount:int}> $frister
+   *   The per-area deadline config.
+   */
+  protected function clock(array $frister): FristClock {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->with('frister')->willReturn($frister);
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('aabenforms_case.settings')->willReturn($config);
+
+    return new FristClock($factory);
+  }
+
+  /**
+   * @covers ::computeDue
+   */
+  public function testComputeDueHours(): void {
+    $clock = $this->clock(['underretning' => ['unit' => 'hours', 'amount' => 24]]);
+    $this->assertSame(
+      self::MONDAY_0900 + (24 * 3600),
+      $clock->computeDue(self::MONDAY_0900, 'underretning')
+    );
+  }
+
+  /**
+   * @covers ::computeDue
+   * @covers ::addWorkingDays
+   */
+  public function testComputeDueWorkingDaysSkipsWeekend(): void {
+    $clock = $this->clock(['anerkend' => ['unit' => 'hverdage', 'amount' => 6]]);
+    // From Monday, 6 working days lands on the next Tuesday (8 calendar days),
+    // skipping the intervening Saturday and Sunday.
+    $expected = self::MONDAY_0900 + (8 * 86400);
+    $this->assertSame($expected, $clock->computeDue(self::MONDAY_0900, 'anerkend'));
+  }
+
+  /**
+   * @covers ::computeDue
+   */
+  public function testComputeDueStraksIsImmediate(): void {
+    $clock = $this->clock(['friplads' => ['unit' => 'straks', 'amount' => 0]]);
+    $this->assertSame(self::MONDAY_0900, $clock->computeDue(self::MONDAY_0900, 'friplads'));
+  }
+
+  /**
+   * @covers ::computeDue
+   */
+  public function testUnknownAreaFallsBackToDefault(): void {
+    $clock = $this->clock(['default' => ['unit' => 'hours', 'amount' => 1]]);
+    $this->assertSame(
+      self::MONDAY_0900 + 3600,
+      $clock->computeDue(self::MONDAY_0900, 'no_such_area')
+    );
+  }
+
+  /**
+   * @covers ::computeState
+   * @dataProvider stateProvider
+   */
+  public function testComputeState(int $due, int $now, string $expected): void {
+    $clock = $this->clock([]);
+    $this->assertSame($expected, $clock->computeState($due, $now));
+  }
+
+  /**
+   * Data provider for ::testComputeState.
+   *
+   * @return array<string, array{0:int,1:int,2:string}>
+   *   Cases: [due, now, expected].
+   */
+  public static function stateProvider(): array {
+    $now = self::MONDAY_0900;
+    return [
+      'overdue' => [$now - 1, $now, 'roed'],
+      'due now' => [$now, $now, 'roed'],
+      'within 24h' => [$now + 3600, $now, 'gul'],
+      'exactly 24h' => [$now + 86400, $now, 'gul'],
+      'more than 24h' => [$now + 86401, $now, 'groen'],
+    ];
+  }
+
+}


### PR DESCRIPTION
## What

Introduces the **case (sag) foundation** for municipal casework - the open workflow/sagsbehandling layer between citizen self-service and the fagsystem.

### Backend module `aabenforms_case`
- **`AabenformsCase`** - revisionable content entity (status lifecycle, frist fields, KLE-emne, handle-/betalingskommune, journal ref, assigned caseworker). Every status transition leaves an **auditable revision** (who/when/why). References its submission and **never copies the raw CPR** (stays encrypted on the submission).
- **`FristClock`** service - per-area deadlines from config (calendar hours or working days, weekends skipped) + green/amber/red state.
- **ECA actions** - `aabenforms_case_open` (open a case from a submission, stamp the receipt date, compute the deadline) and `aabenforms_case_transition` (lawful, audited state changes). A decoupled local action base keeps the foundation depending only on `aabenforms_core` + `eca` + `webform`.
- **Access handler** keeps cases behind caseworker permissions, so JSON:API does not expose them publicly.
- **First vertical**: `underretning` webform + ECA flow that opens a case with the statutory 24-hour clock.

## Verified locally (DDEV, PHP 8.4)
- `drush en aabenforms_case` clean - entity schema, config schema, webform + ECA flow all install.
- **PHPUnit: 15/15 green** (unit: FristClock + lifecycle invariants; kernel: entity CRUD + revision, open-case action end to end).
- **PHPCS `--standard=Drupal`: clean.**
- Functional: submitting an `underretning` opens a case with `status=modtaget`, `frist_due` exactly 24h after receipt, and `submission_ref` set.
- Security: anonymous JSON:API request returns `data: []` ("resources omitted because of insufficient authorization") - cases are not leaked.

## Out of scope (later increments)
Fripladstilskud (auto-decision), partshøring/afgørelse/klagevejledning templates, journalisering, content_moderation hardening.