### PR TITLE
config: activate aabenforms_case on deploy

### DIFF
--- a/config/sync/aabenforms_case.settings.yml
+++ b/config/sync/aabenforms_case.settings.yml
@@ -1,0 +1,15 @@
+_core:
+  default_config_hash: jBwrXX5YgTee5LvU3BViXR70O27P33-P12RFySTdd1c
+frister:
+  underretning:
+    unit: hours
+    amount: 24
+  underretning_anerkend:
+    unit: hverdage
+    amount: 6
+  friplads:
+    unit: straks
+    amount: 0
+  default:
+    unit: hverdage
+    amount: 28

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: 4GIX5Esnc_umpXUBj4IIocRX7Mt5fPhm4AgXfE3E56E
 module:
+  aabenforms_case: 0
   aabenforms_core: 0
   aabenforms_digital_post: 0
   aabenforms_digital_post_eca: 0

--- a/config/sync/eca.eca.underretning_flow.yml
+++ b/config/sync/eca.eca.underretning_flow.yml
@@ -1,0 +1,36 @@
+uuid: 4f8b2c1d-6e3a-4b9c-9d7e-0a1b2c3d4e5f
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: underretning_flow
+_core:
+  default_config_hash: PU1hFHgCRtNdT_K-8xuIzvwlvvNMJampiQvElFRuw8Q
+id: underretning_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission underretning'
+    successors:
+      -
+        id: open_case
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  open_case:
+    label: 'Åbn sag (underretning)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: underretning
+      case_id_token: case_id
+    successors: {  }

--- a/config/sync/webform.webform.underretning.yml
+++ b/config/sync/webform.webform.underretning.yml
@@ -1,0 +1,230 @@
+uuid: 7c1e9a2b-3d4f-4a6b-8c0d-1a2b3c4d5e6f
+langcode: da
+status: open
+dependencies: {  }
+_core:
+  default_config_hash: 9MMHA8dL1gT8_-lw9hTkGYahRhNfDuQuS1chnuPwIpw
+open: null
+close: null
+weight: 0
+uid: 1
+template: false
+archive: false
+id: underretning
+title: 'Underretning om bekymring for et barn'
+description: 'En borger eller fagperson underretter kommunen om bekymring for et barns trivsel. Åbner en sag med lovbestemt frist (vurder senest 24 timer; anerkend senest 6 hverdage).'
+categories: {  }
+elements: |
+  reporter_type:
+    '#type': select
+    '#title': 'Hvem underretter'
+    '#required': true
+    '#options':
+      borger: 'Borger (kan være anonym)'
+      fagperson: 'Fagperson (skærpet underretningspligt - kan ikke være anonym)'
+  reporter_contact:
+    '#type': textfield
+    '#title': 'Dit navn og kontakt'
+    '#description': 'Påkrævet for fagpersoner. Borgere kan vælge at være anonyme.'
+    '#states':
+      required:
+        ':input[name="reporter_type"]':
+          value: fagperson
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  child_cpr:
+    '#type': textfield
+    '#title': 'Barnets CPR-nummer'
+    '#description': 'DDMMÅÅ-XXXX. Krypteres ved modtagelse.'
+  concern_details:
+    '#type': textarea
+    '#title': 'Beskriv din bekymring'
+    '#required': true
+    '#rows': 6
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din underretning er modtaget, og kommunen vurderer den hurtigst muligt.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }


### PR DESCRIPTION
## What

Activates the `aabenforms_case` engine (merged dormant in #128) by adding it to config so a config import on deploy installs it.

- `config/sync/core.extension.yml` - adds `aabenforms_case`.
- Ships the module's config into `config/sync/` so `drush cim` keeps them (and does not delete them as orphan active config): `webform.webform.underretning`, `eca.eca.underretning_flow`, `aabenforms_case.settings`.

## Verified locally (the real deploy path)
- `drush pmu aabenforms_case` (uninstall) then **`drush cim`** → re-installs the module, creates the case entity schema, creates the ECA flow (status: on), webform present.
- Functional after import: submitting an `underretning` opens a case with `status=modtaget` and `frist_due` exactly 24h after receipt.

## Note
Once deployed, encrypting the `child_cpr` field on a real submission needs `AABENFORMS_CPR_KEY` set on VPS2 (otherwise plaintext + warning - degraded, not broken). The case engine itself does not touch CPR.