### PR TITLE
feat(case): fripladstilskud flow with auto-decision branch

### DIFF
--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -1,0 +1,85 @@
+uuid: 6b5d4c3e-2a1f-4e8d-9c7b-3f2e1d0c9b8a
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: friplads_flow
+id: friplads_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission friplads'
+    successors:
+      -
+        id: open_case
+        condition: ''
+conditions:
+  gate_eligible:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:household_income]'
+      right: '200000'
+      operator: atmost
+      type: numeric
+      case: false
+  gate_manual:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[webform_submission:values:household_income]'
+      right: '200000'
+      operator: atmost
+      type: numeric
+      case: false
+gateways: {  }
+actions:
+  open_case:
+    label: 'Åbn sag (fripladstilskud)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: friplads
+      case_id_token: case_id
+    successors:
+      -
+        id: t_oplyst_auto
+        condition: gate_eligible
+      -
+        id: t_oplyst_manual
+        condition: gate_manual
+  t_oplyst_auto:
+    label: 'Oplys sag (straksbehandling)'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: oplyst
+      log_message: 'Indkomst ≤ fripladsgrænse - straksbehandling.'
+    successors:
+      -
+        id: t_afgoerelse
+        condition: ''
+  t_afgoerelse:
+    label: 'Automatisk afgørelse'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: afgoerelse
+      log_message: 'Automatisk afgørelse: friplads bevilget.'
+    successors: {  }
+  t_oplyst_manual:
+    label: 'Oplys sag (manuel vurdering)'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: oplyst
+      log_message: 'Indkomst > grænse - sendt til manuel vurdering.'
+    successors: {  }

--- a/config/sync/webform.webform.friplads.yml
+++ b/config/sync/webform.webform.friplads.yml
@@ -1,0 +1,216 @@
+uuid: 9a2c4e6f-1b3d-4c5e-8a7b-2c3d4e5f6a7b
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: friplads
+title: 'Ansøgning om økonomisk fripladstilskud'
+description: 'En forælder søger økonomisk fripladstilskud til dagtilbud. Husstandsindkomsten afgør tilskuddet; lav indkomst straksbehandles automatisk, høj indkomst sendes til manuel vurdering.'
+categories: {  }
+elements: |
+  applicant_cpr:
+    '#type': textfield
+    '#title': 'Dit CPR-nummer'
+    '#required': true
+    '#description': 'DDMMÅÅ-XXXX. Krypteres ved modtagelse. Udfyldes automatisk fra MitID i produktion.'
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  household_income:
+    '#type': number
+    '#title': 'Husstandsindkomst (kr./år)'
+    '#required': true
+    '#min': 0
+    '#step': 1
+    '#description': 'Den samlede årlige husstandsindkomst. Udfyldes automatisk fra eIndkomst i produktion.'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din ansøgning om fripladstilskud er modtaget og behandles.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -1,0 +1,81 @@
+uuid: 6b5d4c3e-2a1f-4e8d-9c7b-3f2e1d0c9b8a
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: friplads_flow
+id: friplads_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission friplads'
+    successors:
+      - id: open_case
+        condition: ''
+conditions:
+  gate_eligible:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:household_income]'
+      right: '200000'
+      operator: atmost
+      type: numeric
+      case: false
+  gate_manual:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[webform_submission:values:household_income]'
+      right: '200000'
+      operator: atmost
+      type: numeric
+      case: false
+gateways: {  }
+actions:
+  open_case:
+    label: 'Åbn sag (fripladstilskud)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: friplads
+      case_id_token: case_id
+    successors:
+      - id: t_oplyst_auto
+        condition: gate_eligible
+      - id: t_oplyst_manual
+        condition: gate_manual
+  t_oplyst_auto:
+    label: 'Oplys sag (straksbehandling)'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: oplyst
+      log_message: 'Indkomst ≤ fripladsgrænse - straksbehandling.'
+    successors:
+      - id: t_afgoerelse
+        condition: ''
+  t_afgoerelse:
+    label: 'Automatisk afgørelse'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: afgoerelse
+      log_message: 'Automatisk afgørelse: friplads bevilget.'
+    successors: {  }
+  t_oplyst_manual:
+    label: 'Oplys sag (manuel vurdering)'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: oplyst
+      log_message: 'Indkomst > grænse - sendt til manuel vurdering.'
+    successors: {  }

--- a/web/modules/custom/aabenforms_case/config/install/webform.webform.friplads.yml
+++ b/web/modules/custom/aabenforms_case/config/install/webform.webform.friplads.yml
@@ -1,0 +1,216 @@
+uuid: 9a2c4e6f-1b3d-4c5e-8a7b-2c3d4e5f6a7b
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: friplads
+title: 'Ansøgning om økonomisk fripladstilskud'
+description: 'En forælder søger økonomisk fripladstilskud til dagtilbud. Husstandsindkomsten afgør tilskuddet; lav indkomst straksbehandles automatisk, høj indkomst sendes til manuel vurdering.'
+categories: {  }
+elements: |
+  applicant_cpr:
+    '#type': textfield
+    '#title': 'Dit CPR-nummer'
+    '#required': true
+    '#description': 'DDMMÅÅ-XXXX. Krypteres ved modtagelse. Udfyldes automatisk fra MitID i produktion.'
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  household_income:
+    '#type': number
+    '#title': 'Husstandsindkomst (kr./år)'
+    '#required': true
+    '#min': 0
+    '#step': 1
+    '#description': 'Den samlede årlige husstandsindkomst. Udfyldes automatisk fra eIndkomst i produktion.'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din ansøgning om fripladstilskud er modtaget og behandles.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/CaseActionBase.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/CaseActionBase.php
@@ -123,6 +123,17 @@ abstract class CaseActionBase extends ConfigurableActionBase {
     if (is_scalar($value)) {
       return (string) $value;
     }
+    // ECA wraps scalars set via addTokenData() in a DataTransferObject, so a
+    // bare token name resolves to an object here, not a string. Honour its
+    // scalar representation before giving up (matches AabenFormsActionBase).
+    if (is_object($value)) {
+      if (method_exists($value, '__toString')) {
+        return (string) $value;
+      }
+      if (method_exists($value, 'getString')) {
+        return (string) $value->getString();
+      }
+    }
     return $default;
   }
 

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/TransitionCaseActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/TransitionCaseActionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_transition ECA action.
+ *
+ * Covers the lawful transition chain used by the fripladstilskud auto-decision
+ * branch (modtaget -> oplyst -> afgoerelse), that the case id is read back from
+ * the ECA token (incl. the bare-token DataTransferObject path), and that an
+ * unlawful transition is rejected rather than silently written.
+ *
+ * @group aabenforms_case
+ */
+class TransitionCaseActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Creates a persisted case in the given status.
+   */
+  protected function makeCase(string $status = 'modtaget'): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create([
+      'title' => 'Friplads',
+      'case_type' => 'friplads',
+      'status' => $status,
+    ]);
+    $case->save();
+    return $case;
+  }
+
+  /**
+   * Runs the transition action against a case id token.
+   */
+  protected function transition(string $caseIdToken, string $target, string $log): void {
+    /** @var \Drupal\Core\Action\ActionManager $manager */
+    $manager = $this->container->get('plugin.manager.action');
+    $action = $manager->createInstance('aabenforms_case_transition', [
+      'case_id_token' => $caseIdToken,
+      'target_status' => $target,
+      'log_message' => $log,
+    ]);
+    $action->execute();
+  }
+
+  /**
+   * Reloads a case fresh from storage.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * The lawful auto-decision chain modtaget -> oplyst -> afgoerelse.
+   */
+  public function testLawfulTransitionChain(): void {
+    $case = $this->makeCase('modtaget');
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+
+    $this->transition('[case_id]', 'oplyst', 'Straksbehandling.');
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('oplyst', $reloaded->getStatus());
+    $this->assertSame('Straksbehandling.', $reloaded->getRevisionLogMessage());
+
+    $this->transition('[case_id]', 'afgoerelse', 'Automatisk afgørelse.');
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('afgoerelse', $reloaded->getStatus());
+  }
+
+  /**
+   * A bare token name (eca DataTransferObject) resolves to the case id.
+   *
+   * Guards the CaseActionBase::getTokenValue object-handling fix: without it a
+   * bare token returns empty and the transition is wrongly rejected.
+   */
+  public function testBareTokenNameResolves(): void {
+    $case = $this->makeCase('modtaget');
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+
+    $this->transition('case_id', 'oplyst', 'Via bart token.');
+    $this->assertSame('oplyst', $this->reload((int) $case->id())->getStatus());
+  }
+
+  /**
+   * An unlawful transition (afgoerelse -> oplyst) is rejected, not written.
+   */
+  public function testUnlawfulTransitionRejected(): void {
+    $case = $this->makeCase('afgoerelse');
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+
+    $this->transition('[case_id]', 'oplyst', 'Forsøg på ulovlig overgang.');
+    $this->assertSame('afgoerelse', $this->reload((int) $case->id())->getStatus(), 'Status is unchanged after an illegal transition');
+  }
+
+}


### PR DESCRIPTION
## What

Second vertical on the `aabenforms_case` engine. Where `underretning` was linear (event → open case), this exercises the genuinely new ECA surface: a **condition-driven auto-decision branch** that drives the case lifecycle automatically.

- **`friplads` webform** - CPR, child name, household income.
- **`friplads_flow`** - opens a case, then an `eca_scalar` **numeric gate** on household income branches:
  - income **≤ threshold** → auto-advances `modtaget → oplyst → afgoerelse` (straksbehandling)
  - income **> threshold** → stops in `oplyst` for manual caseworker handling
  - every transition is an **audited revision** (low-income case ends with 3 revisions).
- **Fix `CaseActionBase::getTokenValue`** to honour ECA `DataTransferObject` token values - a bare token name resolved to empty before, which would have rejected the transition. Restores the object handling from `AabenFormsActionBase`.
- **`TransitionCaseActionTest`** - lawful chain, bare-token resolution (guards the fix), and rejection of an unlawful transition.
- Config shipped in both `config/install` and `config/sync` so a config import activates it on the already-enabled site.

## Verified locally (DDEV, PHP 8.4)
- `drush cim` installs the friplads webform + flow cleanly.
- **PHPUnit: 18/18 green** (3 new). **PHPCS `--standard=Drupal`: clean.**
- Functional branch test: submit with income `150000` → case status `afgoerelse` (3 revisions); income `400000` → status `oplyst` (2 revisions).

## Note
Household income is form-reported here; production would prefill it from eIndkomst (Serviceplatform lookup) - a later increment. Decision-type field and a friplads demo page are also out of scope here.