### PR TITLE
feat(case): lawful decision (afgørelse) with FVL §19/§25 enforcement

### DIFF
--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -68,12 +68,13 @@ actions:
         id: t_afgoerelse
         condition: ''
   t_afgoerelse:
-    label: 'Automatisk afgørelse'
-    plugin: aabenforms_case_transition
+    label: 'Automatisk afgørelse (medhold)'
+    plugin: aabenforms_case_decide
     configuration:
       case_id_token: '[case_id]'
-      target_status: afgoerelse
-      log_message: 'Automatisk afgørelse: friplads bevilget.'
+      afgoerelse_type: medhold
+      klagevejledning: ''
+      klagefrist_uger: 4
     successors: {  }
   t_oplyst_manual:
     label: 'Oplys sag (manuel vurdering)'

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -64,12 +64,13 @@ actions:
       - id: t_afgoerelse
         condition: ''
   t_afgoerelse:
-    label: 'Automatisk afgørelse'
-    plugin: aabenforms_case_transition
+    label: 'Automatisk afgørelse (medhold)'
+    plugin: aabenforms_case_decide
     configuration:
       case_id_token: '[case_id]'
-      target_status: afgoerelse
-      log_message: 'Automatisk afgørelse: friplads bevilget.'
+      afgoerelse_type: medhold
+      klagevejledning: ''
+      klagefrist_uger: 4
     successors: {  }
   t_oplyst_manual:
     label: 'Oplys sag (manuel vurdering)'

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: make a lawful decision (afgørelse) on a case.
+ *
+ * Enforces the forvaltningslov in code so a decision cannot be issued wrongly:
+ * - FVL §25: a klagevejledning is mandatory on a bebyrdende outcome (afslag /
+ *   delvist medhold) and not required on full medhold.
+ * - FVL §19: partshøring must be afsluttet (not still afventer) before a
+ *   bebyrdende decision.
+ * On success it sets the decision type, computes the appeal deadline
+ * (klagefrist) for bebyrdende outcomes, transitions the case to "afgoerelse"
+ * (honouring the lifecycle guard), and records an auditable revision whose log
+ * carries the outcome + klagevejledning + klagefrist.
+ */
+#[Action(
+  id: 'aabenforms_case_decide',
+  label: new TranslatableMarkup('Make case decision'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Issues a lawful decision (afgørelse) with mandatory klagevejledning on adverse outcomes.'),
+  version_introduced: '1.0.0',
+)]
+class MakeDecisionAction extends CaseActionBase {
+
+  /**
+   * Outcomes that are adverse to the citizen and require a klagevejledning.
+   */
+  protected const ADVERSE = ['afslag', 'delvist'];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[case_id]',
+      'afgoerelse_type' => '',
+      'klagevejledning' => '',
+      'klagefrist_uger' => 4,
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['afgoerelse_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Decision type'),
+      '#options' => [
+        'medhold' => $this->t('Medhold (granted)'),
+        'delvist' => $this->t('Delvist medhold (partial)'),
+        'afslag' => $this->t('Afslag (denied)'),
+      ],
+      '#default_value' => $this->configuration['afgoerelse_type'],
+      '#required' => TRUE,
+    ];
+    $form['klagevejledning'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Klagevejledning'),
+      '#description' => $this->t('Mandatory for adverse outcomes (afslag / delvist). Names the appeal authority (Ankestyrelsen) and the deadline.'),
+      '#default_value' => $this->configuration['klagevejledning'],
+      '#rows' => 3,
+    ];
+    $form['klagefrist_uger'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Appeal deadline (weeks)'),
+      '#min' => 1,
+      '#default_value' => $this->configuration['klagefrist_uger'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['afgoerelse_type'] = $form_state->getValue('afgoerelse_type');
+    $this->configuration['klagevejledning'] = $form_state->getValue('klagevejledning');
+    $this->configuration['klagefrist_uger'] = $form_state->getValue('klagefrist_uger');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? '[case_id]'), '');
+      $type = (string) ($this->configuration['afgoerelse_type'] ?? '');
+      $klagevejledning = trim((string) ($this->configuration['klagevejledning'] ?? ''));
+      $uger = max(1, (int) ($this->configuration['klagefrist_uger'] ?? 4));
+
+      if ($caseId === '') {
+        $this->recordStep('Afgørelse', 'Mangler sags-id.', 'failed');
+        return;
+      }
+      if (!in_array($type, ['medhold', 'delvist', 'afslag'], TRUE)) {
+        $this->recordStep('Afgørelse', sprintf('Ukendt afgørelsestype "%s".', $type), 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Afgørelse', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      $adverse = in_array($type, self::ADVERSE, TRUE);
+
+      // FVL §19: partshøring must be concluded before an adverse decision.
+      if ($adverse && (string) $case->get('partshoering_state')->value === 'afventer') {
+        $this->recordStep('Afgørelse afvist', 'Partshøring er ikke afsluttet (FVL §19).', 'failed');
+        return;
+      }
+
+      // FVL §25: a klagevejledning is mandatory on an adverse outcome.
+      if ($adverse && $klagevejledning === '') {
+        $this->recordStep('Afgørelse afvist', 'Bebyrdende afgørelse mangler klagevejledning (FVL §25).', 'failed');
+        return;
+      }
+
+      // Lifecycle guard: the case must be in a state that may reach afgoerelse.
+      $current = $case->getStatus();
+      if (!in_array('afgoerelse', AabenformsCase::allowedTransitions()[$current] ?? [], TRUE)) {
+        $this->recordStep('Afgørelse afvist', sprintf('Kan ikke afgøre fra status "%s".', $current), 'failed');
+        return;
+      }
+
+      $now = $this->time->getRequestTime();
+      $case->set('afgoerelse_type', $type);
+      if ($adverse) {
+        $case->set('klagefrist', $now + ($uger * 7 * 86400));
+      }
+      $case->setStatus('afgoerelse');
+      $case->setNewRevision(TRUE);
+      $logParts = [sprintf('Afgørelse: %s.', $type)];
+      if ($adverse) {
+        $logParts[] = 'Klagevejledning: ' . $klagevejledning;
+        $logParts[] = sprintf('Klagefrist: %d uger.', $uger);
+      }
+      $case->setRevisionLogMessage(implode(' ', $logParts));
+      $case->setRevisionCreationTime($now);
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Afgørelse truffet', sprintf('Sag #%s: %s.', $caseId, $type));
+      $this->auditLogger->log('case_decision', (string) $caseId, $type, 'success', [
+        'action_id' => $this->getPluginId(),
+        'adverse' => $adverse,
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Make case decision');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/SetPartshoeringAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/SetPartshoeringAction.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: set the partshøring (FVL §19) state on a case.
+ *
+ * "afventer" opens a hearing (in a real flow paired with a høringsbrev);
+ * "afsluttet" concludes it. MakeDecisionAction blocks an adverse decision
+ * while the state is "afventer". Each change is an auditable revision.
+ */
+#[Action(
+  id: 'aabenforms_case_partshoering',
+  label: new TranslatableMarkup('Set partshøring state'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Opens or concludes a party hearing (partshøring, FVL §19) on a case.'),
+  version_introduced: '1.0.0',
+)]
+class SetPartshoeringAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[case_id]',
+      'state' => 'afventer',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['state'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Partshøring state'),
+      '#options' => [
+        'afventer' => $this->t('Afventer svar (open)'),
+        'afsluttet' => $this->t('Afsluttet (concluded)'),
+      ],
+      '#default_value' => $this->configuration['state'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['state'] = $form_state->getValue('state');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? '[case_id]'), '');
+      $state = (string) ($this->configuration['state'] ?? '');
+
+      if ($caseId === '' || !in_array($state, ['afventer', 'afsluttet'], TRUE)) {
+        $this->recordStep('Partshøring', 'Mangler sags-id eller ugyldig tilstand.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Partshøring', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      $now = $this->time->getRequestTime();
+      $case->set('partshoering_state', $state);
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage($state === 'afventer' ? 'Partshøring åbnet.' : 'Partshøring afsluttet.');
+      $case->setRevisionCreationTime($now);
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Partshøring', sprintf('Sag #%s: %s.', $caseId, $state));
+      $this->auditLogger->log('case_partshoering', (string) $caseId, $state, 'success', [
+        'action_id' => $this->getPluginId(),
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Set partshøring');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_decide action and its FVL §19/§25 enforcement.
+ *
+ * @group aabenforms_case
+ */
+class MakeDecisionActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Creates a persisted case in "oplyst" (ready for a decision) + sets token.
+   */
+  protected function caseInOplyst(): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create([
+      'title' => 'Friplads',
+      'case_type' => 'friplads',
+      'status' => 'oplyst',
+    ]);
+    $case->save();
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    return $case;
+  }
+
+  /**
+   * Invokes an aabenforms_case action plugin.
+   */
+  protected function invoke(string $pluginId, array $config): void {
+    $this->container->get('plugin.manager.action')->createInstance($pluginId, $config)->execute();
+  }
+
+  /**
+   * Reloads a case fresh.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * Full medhold needs no klagevejledning and sets no klagefrist.
+   */
+  public function testMedholdGranted(): void {
+    $case = $this->caseInOplyst();
+    $this->invoke('aabenforms_case_decide', [
+      'afgoerelse_type' => 'medhold',
+    ]);
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('afgoerelse', $reloaded->getStatus());
+    $this->assertSame('medhold', (string) $reloaded->get('afgoerelse_type')->value);
+    $this->assertNull($reloaded->get('klagefrist')->value, 'Medhold sets no klagefrist');
+  }
+
+  /**
+   * FVL §25: an adverse decision without a klagevejledning is rejected.
+   */
+  public function testAdverseWithoutKlagevejledningBlocked(): void {
+    $case = $this->caseInOplyst();
+    $this->invoke('aabenforms_case_decide', [
+      'afgoerelse_type' => 'afslag',
+      'klagevejledning' => '',
+    ]);
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('oplyst', $reloaded->getStatus(), 'Status unchanged - decision blocked');
+    $this->assertNull($reloaded->get('afgoerelse_type')->value);
+  }
+
+  /**
+   * An adverse decision with a klagevejledning sets the appeal deadline.
+   */
+  public function testAdverseWithKlagevejledningSetsKlagefrist(): void {
+    $case = $this->caseInOplyst();
+    $now = $this->container->get('datetime.time')->getRequestTime();
+    $this->invoke('aabenforms_case_decide', [
+      'afgoerelse_type' => 'afslag',
+      'klagevejledning' => 'Du kan klage til Ankestyrelsen inden for 4 uger.',
+      'klagefrist_uger' => 4,
+    ]);
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('afgoerelse', $reloaded->getStatus());
+    $this->assertSame('afslag', (string) $reloaded->get('afgoerelse_type')->value);
+    $this->assertSame($now + (4 * 7 * 86400), (int) $reloaded->get('klagefrist')->value);
+  }
+
+  /**
+   * FVL §19: an adverse decision is blocked while partshøring is "afventer".
+   */
+  public function testPartshoeringGateBlocksAdverse(): void {
+    $case = $this->caseInOplyst();
+    // Open a hearing via the partshøring action, then attempt an adverse decision.
+    $this->invoke('aabenforms_case_partshoering', ['state' => 'afventer']);
+    $this->assertSame('afventer', (string) $this->reload((int) $case->id())->get('partshoering_state')->value);
+
+    $this->invoke('aabenforms_case_decide', [
+      'afgoerelse_type' => 'afslag',
+      'klagevejledning' => 'Klagevejledning til Ankestyrelsen.',
+    ]);
+    $this->assertSame('oplyst', $this->reload((int) $case->id())->getStatus(), 'Decision blocked until partshøring is concluded');
+  }
+
+}


### PR DESCRIPTION
## What

The afgørelse layer - compliance baked into code so a decision cannot be issued unlawfully.

- **`MakeDecisionAction`** (`aabenforms_case_decide`): sets the decision type, transitions the case to `afgoerelse` (via the lifecycle guard), records an auditable revision. Enforces:
  - **FVL §25** - a klagevejledning is mandatory on an adverse outcome (`afslag`/`delvist`); the appeal deadline (`klagefrist`) is computed (default 4 weeks). Full `medhold` needs none.
  - **FVL §19** - an adverse decision is blocked while `partshoering_state` is `afventer`.
- **`SetPartshoeringAction`** (`aabenforms_case_partshoering`): opens/concludes a party hearing, audited.
- **`friplads_flow`** auto-decision now issues a real `medhold` afgørelse instead of a bare status transition.

## Verified locally (DDEV, PHP 8.4)
- **PHPUnit: 22/22 green** (4 new): medhold; §25 block (adverse without klagevejledning → status unchanged); klagefrist set on adverse + klagevejledning; §19 gate (blocked while partshøring afventer).
- **PHPCS `--standard=Drupal`: clean.**
- `drush cim` installs the upgraded flow (note: a fresh container/`cr` is needed before importing a flow that references new action plugins; the deploy rebuilds the image so this is automatic on prod).
- Functional: friplads with income `120000` → case `afgoerelse`, `afgoerelse_type=medhold`, no klagefrist.

## Out of scope
eIndkomst/SF income lookup (next increment), a dedicated klagevejledning entity field (kept in the audited revision log for now), and the genvurdering/klagesag (appeal) flow + decision letter via Digital Post.