### PR TITLE
feat(case): fetch friplads income from CPR (eIndkomst lookup)

### DIFF
--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -27,7 +27,7 @@ conditions:
     plugin: eca_scalar
     configuration:
       negate: false
-      left: '[webform_submission:values:household_income]'
+      left: '[friplads_income]'
       right: '200000'
       operator: atmost
       type: numeric
@@ -36,7 +36,7 @@ conditions:
     plugin: eca_scalar
     configuration:
       negate: true
-      left: '[webform_submission:values:household_income]'
+      left: '[friplads_income]'
       right: '200000'
       operator: atmost
       type: numeric
@@ -49,6 +49,16 @@ actions:
     configuration:
       case_type: friplads
       case_id_token: case_id
+    successors:
+      -
+        id: income_lookup
+        condition: ''
+  income_lookup:
+    label: 'Hent husstandsindkomst (eIndkomst)'
+    plugin: aabenforms_case_income_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:applicant_cpr:raw]'
+      result_token: friplads_income
     successors:
       -
         id: t_oplyst_auto

--- a/config/sync/webform.webform.friplads.yml
+++ b/config/sync/webform.webform.friplads.yml
@@ -22,13 +22,6 @@ elements: |
     '#type': textfield
     '#title': 'Barnets navn'
     '#required': true
-  household_income:
-    '#type': number
-    '#title': 'Husstandsindkomst (kr./år)'
-    '#required': true
-    '#min': 0
-    '#step': 1
-    '#description': 'Den samlede årlige husstandsindkomst. Udfyldes automatisk fra eIndkomst i produktion.'
 css: ''
 javascript: ''
 settings:

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -26,7 +26,7 @@ conditions:
     plugin: eca_scalar
     configuration:
       negate: false
-      left: '[webform_submission:values:household_income]'
+      left: '[friplads_income]'
       right: '200000'
       operator: atmost
       type: numeric
@@ -35,7 +35,7 @@ conditions:
     plugin: eca_scalar
     configuration:
       negate: true
-      left: '[webform_submission:values:household_income]'
+      left: '[friplads_income]'
       right: '200000'
       operator: atmost
       type: numeric
@@ -48,6 +48,15 @@ actions:
     configuration:
       case_type: friplads
       case_id_token: case_id
+    successors:
+      - id: income_lookup
+        condition: ''
+  income_lookup:
+    label: 'Hent husstandsindkomst (eIndkomst)'
+    plugin: aabenforms_case_income_lookup
+    configuration:
+      cpr_token: '[webform_submission:values:applicant_cpr:raw]'
+      result_token: friplads_income
     successors:
       - id: t_oplyst_auto
         condition: gate_eligible

--- a/web/modules/custom/aabenforms_case/config/install/webform.webform.friplads.yml
+++ b/web/modules/custom/aabenforms_case/config/install/webform.webform.friplads.yml
@@ -22,13 +22,6 @@ elements: |
     '#type': textfield
     '#title': 'Barnets navn'
     '#required': true
-  household_income:
-    '#type': number
-    '#title': 'Husstandsindkomst (kr./år)'
-    '#required': true
-    '#min': 0
-    '#step': 1
-    '#description': 'Den samlede årlige husstandsindkomst. Udfyldes automatisk fra eIndkomst i produktion.'
 css: ''
 javascript: ''
 settings:

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/FetchIncomeAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/FetchIncomeAction.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: fetch household income for a CPR (demo eIndkomst lookup).
+ *
+ * Demonstrates the lookup → token → condition shape that drives the
+ * fripladstilskud auto-decision, so income is fetched from the citizen's CPR
+ * rather than self-reported on the form. The CPR is revealed (decrypted at
+ * rest) and the lookup is audited with a hashed identifier.
+ *
+ * DEMO: the income is derived deterministically from the CPR (last digit < 5
+ * → 150000, else 400000). In production this is replaced by a real
+ * Serviceplatform eIndkomst lookup; the action contract (CPR token in, income
+ * token out) stays the same.
+ */
+#[Action(
+  id: 'aabenforms_case_income_lookup',
+  label: new TranslatableMarkup('Fetch household income (eIndkomst)'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Looks up household income for a CPR (demo; production uses Serviceplatform eIndkomst).'),
+  version_introduced: '1.0.0',
+)]
+class FetchIncomeAction extends CaseActionBase {
+
+  /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'cpr_token' => '[webform_submission:values:applicant_cpr:raw]',
+      'result_token' => 'friplads_income',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['cpr_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('CPR token'),
+      '#description' => $this->t('Token holding the CPR to look up income for.'),
+      '#default_value' => $this->configuration['cpr_token'],
+      '#required' => TRUE,
+    ];
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token (income)'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['cpr_token'] = $form_state->getValue('cpr_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $rawCpr = $this->getTokenValue((string) ($this->configuration['cpr_token'] ?? ''), '');
+      $resultToken = trim((string) ($this->configuration['result_token'] ?? 'friplads_income')) ?: 'friplads_income';
+      $cpr = $this->cprAccess->reveal($rawCpr);
+      $digits = preg_replace('/\D/', '', $cpr);
+
+      if ($digits === '') {
+        $this->recordStep('Indkomstopslag', 'Intet CPR at slå op.', 'failed');
+        return;
+      }
+
+      // DEMO derivation - deterministic per CPR. Production: SF eIndkomst.
+      $lastDigit = (int) substr($digits, -1);
+      $income = $lastDigit < 5 ? 150000 : 400000;
+
+      $this->setTokenValue($resultToken, (string) $income);
+      $this->recordStep('Indkomstopslag', sprintf('Husstandsindkomst hentet: %d kr. (demo).', $income));
+      $this->auditLogger->log('income_lookup', $digits, 'friplads', 'success', [
+        'action_id' => $this->getPluginId(),
+        'demo' => TRUE,
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Fetch income');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/FetchIncomeActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/FetchIncomeActionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_income_lookup (demo eIndkomst) action.
+ *
+ * @group aabenforms_case
+ */
+class FetchIncomeActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Runs the income lookup for a CPR and returns the resulting income token.
+   */
+  protected function incomeFor(string $cpr): ?string {
+    $tokens = $this->container->get('eca.token_services');
+    $tokens->addTokenData('cpr', $cpr);
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_income_lookup', [
+        'cpr_token' => 'cpr',
+        'result_token' => 'friplads_income',
+      ])
+      ->execute();
+    $value = $tokens->getTokenData('friplads_income');
+    return $value === NULL ? NULL : (string) $value;
+  }
+
+  /**
+   * The demo derivation is deterministic: last digit < 5 → low, else high.
+   */
+  public function testIncomeDerivedFromCpr(): void {
+    // Last digit 4 → low income (eligible band).
+    $this->assertSame('150000', $this->incomeFor('0101801234'));
+    // Last digit 7 → high income (manual band).
+    $this->assertSame('400000', $this->incomeFor('0101801237'));
+  }
+
+  /**
+   * An empty CPR records a failed step and sets no income.
+   */
+  public function testEmptyCprIsHandled(): void {
+    $this->assertNull($this->incomeFor(''));
+  }
+
+}


### PR DESCRIPTION
## What

Second half of the casework increment: income is now **fetched from the citizen's CPR** rather than self-reported on the form — the real shape of fripladstilskud, and a demonstration of the lookup → token → condition pattern.

- **`FetchIncomeAction`** (`aabenforms_case_income_lookup`): reveals the CPR, derives household income, sets an income token, and audits the lookup with a hashed identifier. **Demo:** the income is deterministic from the CPR (last digit < 5 → 150000, else 400000); production swaps in a Serviceplatform eIndkomst lookup with the same token contract.
- **`friplads_flow`**: `open_case → income_lookup → income gate (on the fetched [friplads_income]) → auto-decision (medhold) or manual branch`.
- **`friplads` webform** drops the `household_income` field (income is fetched, not asked).
- **`FetchIncomeActionTest`**: deterministic derivation + empty-CPR handling.

## Verified locally (DDEV, PHP 8.4)
- **PHPUnit: 24/24 green** (2 new). **PHPCS `--standard=Drupal`: clean.**
- `drush cim` installs the updated flow + webform cleanly.
- Functional end-to-end: friplads with a CPR ending in `4` (low income) → case `afgoerelse`, `medhold`; ending in `7` (high income) → `oplyst` (manual). Income is fetched from the CPR, not the form.

## Out of scope
Real Serviceplatform eIndkomst integration (this is the demo derivation behind the same action contract), SF1470 journaling, the appeal (genvurdering/klagesag) flow, and the decision letter via Digital Post.