### PR TITLE
feat(case): SF1470 journaling (demo)

### DIFF
--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -51,6 +51,15 @@ actions:
       case_id_token: case_id
     successors:
       -
+        id: journal_case
+        condition: ''
+  journal_case:
+    label: 'Journalisér sag (SF1470)'
+    plugin: aabenforms_case_journal
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
+      -
         id: income_lookup
         condition: ''
   income_lookup:

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -49,6 +49,14 @@ actions:
       case_type: friplads
       case_id_token: case_id
     successors:
+      - id: journal_case
+        condition: ''
+  journal_case:
+    label: 'Journalisér sag (SF1470)'
+    plugin: aabenforms_case_journal
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
       - id: income_lookup
         condition: ''
   income_lookup:

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/JournalCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/JournalCaseAction.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: journalise a case into the Sags- og Dokumentindeks (SF1470).
+ *
+ * Registers the case so it surfaces across the ecosystem (SAPA/Borgerblikket).
+ * Stores the returned reference on the case's journal_ref field and records an
+ * auditable revision. Idempotent: an already-journalised case keeps its
+ * reference.
+ *
+ * DEMO: the reference is synthesised deterministically from the case UUID
+ * (SDI-DEMO-XXXXXXXX). When a Serviceplatform certificate is configured this
+ * is where a real SF1470 SOAP registration would run; the action contract
+ * (case in, journal_ref out) stays the same.
+ */
+#[Action(
+  id: 'aabenforms_case_journal',
+  label: new TranslatableMarkup('Journalise case (SF1470)'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Registers the case in the Sags- og Dokumentindeks (SF1470); demo unless a Serviceplatform certificate is configured.'),
+  version_introduced: '1.0.0',
+)]
+class JournalCaseAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[case_id]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? '[case_id]'), '');
+      if ($caseId === '') {
+        $this->recordStep('Journalisering', 'Mangler sags-id.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Journalisering', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      // Idempotent: keep an existing reference.
+      $existing = (string) ($case->get('journal_ref')->value ?? '');
+      if ($existing !== '') {
+        $this->recordStep('Journalisering', sprintf('Sag #%s allerede journaliseret (%s).', $caseId, $existing));
+        return;
+      }
+
+      // DEMO reference derived from the case UUID. Real SF1470 SOAP goes here.
+      $ref = 'SDI-DEMO-' . strtoupper(substr(str_replace('-', '', (string) $case->uuid()), 0, 8));
+      $case->set('journal_ref', $ref);
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage(sprintf('Journaliseret i Sags- og Dokumentindeks: %s.', $ref));
+      $case->setRevisionCreationTime($this->time->getRequestTime());
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->setTokenValue('journal_ref', $ref);
+      $this->recordStep('Journalisering', sprintf('Sag #%s journaliseret: %s.', $caseId, $ref));
+      $this->auditLogger->log('case_journaled', (string) $caseId, $ref, 'success', [
+        'action_id' => $this->getPluginId(),
+        'demo' => TRUE,
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Journalise case');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/JournalCaseActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/JournalCaseActionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_journal (SF1470 demo) action.
+ *
+ * @group aabenforms_case
+ */
+class JournalCaseActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Makes a persisted case + sets the [case_id] token.
+   */
+  protected function makeCase(): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create(['title' => 'Sag', 'case_type' => 'friplads', 'status' => 'modtaget']);
+    $case->save();
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    return $case;
+  }
+
+  /**
+   * Runs the journal action.
+   */
+  protected function journal(): void {
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_journal', ['case_id_token' => '[case_id]'])
+      ->execute();
+  }
+
+  /**
+   * Reloads a case fresh.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * Journaling sets a reference and records a revision; it is idempotent.
+   */
+  public function testJournalSetsReferenceIdempotently(): void {
+    $case = $this->makeCase();
+    $this->journal();
+    $reloaded = $this->reload((int) $case->id());
+    $ref = (string) $reloaded->get('journal_ref')->value;
+    $this->assertNotEmpty($ref, 'A journal reference was set');
+    $this->assertStringStartsWith('SDI-DEMO-', $ref);
+
+    // Re-journaling keeps the same reference.
+    $this->journal();
+    $this->assertSame($ref, (string) $this->reload((int) $case->id())->get('journal_ref')->value);
+  }
+
+}


### PR DESCRIPTION
Registers each case in the Sags- og Dokumentindeks so it surfaces across the ecosystem (SAPA/Borgerblikket).

- **JournalCaseAction** (`aabenforms_case_journal`): stores the returned reference on `journal_ref` with an audited revision; idempotent. Demo derives the reference from the case UUID (`SDI-DEMO-XXXXXXXX`); real SF1470 SOAP swaps in behind the same contract (cert-gated demo fallback, like CPR lookup).
- `friplads_flow`: `open_case → journal_case → income_lookup → …`

Verified: 25/25 phpunit green, phpcs clean, cim installs the updated flow, functional submit → case has `journal_ref` set. Increment A of four (journaling → decision letter → appeal → SF2900).