### PR TITLE
feat(case): friplads decision letter via Digital Post

### DIFF
--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - aabenforms_case
+    - aabenforms_digital_post_eca
     - eca_content
     - modeler_api
 third_party_settings:
@@ -94,6 +95,21 @@ actions:
       afgoerelse_type: medhold
       klagevejledning: ''
       klagefrist_uger: 4
+    successors:
+      -
+        id: send_decision_letter
+        condition: ''
+  send_decision_letter:
+    label: 'Send afgørelsesbrev (Digital Post)'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:applicant_cpr:raw]'
+      recipient_type: cpr
+      sender_cvr_token: ''
+      subject_template: 'Afgørelse: økonomisk fripladstilskud'
+      body_template: '<p>Din ansøgning om økonomisk fripladstilskud er imødekommet (medhold).</p>'
+      type: 'Digital Post'
+      result_token: digital_post_result
     successors: {  }
   t_oplyst_manual:
     label: 'Oplys sag (manuel vurdering)'

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - aabenforms_case
+    - aabenforms_digital_post_eca
     - eca_content
     - modeler_api
 third_party_settings:
@@ -88,6 +89,20 @@ actions:
       afgoerelse_type: medhold
       klagevejledning: ''
       klagefrist_uger: 4
+    successors:
+      - id: send_decision_letter
+        condition: ''
+  send_decision_letter:
+    label: 'Send afgørelsesbrev (Digital Post)'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[webform_submission:values:applicant_cpr:raw]'
+      recipient_type: cpr
+      sender_cvr_token: ''
+      subject_template: 'Afgørelse: økonomisk fripladstilskud'
+      body_template: '<p>Din ansøgning om økonomisk fripladstilskud er imødekommet (medhold).</p>'
+      type: 'Digital Post'
+      result_token: digital_post_result
     successors: {  }
   t_oplyst_manual:
     label: 'Oplys sag (manuel vurdering)'


### PR DESCRIPTION
After the medhold decision, the friplads flow sends the citizen an afgørelsesbrev via the existing `aabenforms_digital_post_send` action (SF1601, fake_db locally; live MeMo/SOAP later). Recipient = applicant CPR. Config only (flow gains a dependency on `aabenforms_digital_post_eca`).

Verified: cim clean, 25/25 phpunit green, phpcs clean; functional submit friplads → a row in `aabenforms_digital_post_log` (subject "Afgørelse: økonomisk fripladstilskud", success). Increment B of four.