### PR TITLE
feat(case): appeal / genvurdering flow (paaklaget)

### DIFF
--- a/config/sync/eca.eca.klage_flow.yml
+++ b/config/sync/eca.eca.klage_flow.yml
@@ -1,0 +1,34 @@
+uuid: 8d7c6b5a-4e3f-4d2c-9b8a-1c2d3e4f5a6b
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: klage_flow
+id: klage_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission klage'
+    successors:
+      -
+        id: appeal_case
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  appeal_case:
+    label: 'Registrér klage (genvurdering)'
+    plugin: aabenforms_case_appeal
+    configuration:
+      case_id_token: '[webform_submission:values:case_id]'
+      grounds_token: '[webform_submission:values:klage_begrundelse]'
+    successors: {  }

--- a/config/sync/webform.webform.klage.yml
+++ b/config/sync/webform.webform.klage.yml
@@ -1,0 +1,216 @@
+uuid: 3c5e7a9b-4d6f-4a8c-9b1d-5e6f7a8b9c0d
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: klage
+title: 'Klage over afgørelse'
+description: 'En borger klager over en afgørelse i en sag. Sagen sendes til genvurdering (status påklaget).'
+categories: {  }
+elements: |
+  case_id:
+    '#type': number
+    '#title': 'Sagsnummer'
+    '#required': true
+    '#min': 1
+    '#description': 'Nummeret på den sag, du klager over.'
+  applicant_cpr:
+    '#type': textfield
+    '#title': 'Dit CPR-nummer'
+    '#required': true
+    '#description': 'DDMMÅÅ-XXXX. Krypteres ved modtagelse.'
+  klage_begrundelse:
+    '#type': textarea
+    '#title': 'Begrundelse for klagen'
+    '#required': true
+    '#rows': 6
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din klage er modtaget, og sagen sendes til genvurdering.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.klage_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.klage_flow.yml
@@ -1,0 +1,33 @@
+uuid: 8d7c6b5a-4e3f-4d2c-9b8a-1c2d3e4f5a6b
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: klage_flow
+id: klage_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission klage'
+    successors:
+      - id: appeal_case
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  appeal_case:
+    label: 'Registrér klage (genvurdering)'
+    plugin: aabenforms_case_appeal
+    configuration:
+      case_id_token: '[webform_submission:values:case_id]'
+      grounds_token: '[webform_submission:values:klage_begrundelse]'
+    successors: {  }

--- a/web/modules/custom/aabenforms_case/config/install/webform.webform.klage.yml
+++ b/web/modules/custom/aabenforms_case/config/install/webform.webform.klage.yml
@@ -1,0 +1,216 @@
+uuid: 3c5e7a9b-4d6f-4a8c-9b1d-5e6f7a8b9c0d
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: klage
+title: 'Klage over afgørelse'
+description: 'En borger klager over en afgørelse i en sag. Sagen sendes til genvurdering (status påklaget).'
+categories: {  }
+elements: |
+  case_id:
+    '#type': number
+    '#title': 'Sagsnummer'
+    '#required': true
+    '#min': 1
+    '#description': 'Nummeret på den sag, du klager over.'
+  applicant_cpr:
+    '#type': textfield
+    '#title': 'Dit CPR-nummer'
+    '#required': true
+    '#description': 'DDMMÅÅ-XXXX. Krypteres ved modtagelse.'
+  klage_begrundelse:
+    '#type': textarea
+    '#title': 'Begrundelse for klagen'
+    '#required': true
+    '#rows': 6
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din klage er modtaget, og sagen sendes til genvurdering.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/AppealCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/AppealCaseAction.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: lodge an appeal (klage) against a decided case.
+ *
+ * Moves a case from "afgoerelse" to "paaklaget" (the lifecycle guard rejects
+ * an appeal of a case that has not been decided), stores the appeal grounds in
+ * an auditable revision, and audits the event. The genvurdering outcome is then
+ * a normal caseworker decision (paaklaget → afgoerelse) or a close
+ * (paaklaget → lukket), both already supported.
+ */
+#[Action(
+  id: 'aabenforms_case_appeal',
+  label: new TranslatableMarkup('Appeal case (klage)'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Lodges an appeal against a decided case, moving it to paaklaget for genvurdering.'),
+  version_introduced: '1.0.0',
+)]
+class AppealCaseAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[webform_submission:values:case_id]',
+      'grounds_token' => '[webform_submission:values:klage_begrundelse]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['grounds_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Appeal grounds token'),
+      '#default_value' => $this->configuration['grounds_token'],
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['grounds_token'] = $form_state->getValue('grounds_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? ''), '');
+      $grounds = trim($this->getTokenValue((string) ($this->configuration['grounds_token'] ?? ''), ''));
+
+      if ($caseId === '') {
+        $this->recordStep('Klage', 'Mangler sags-id.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Klage', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      $current = $case->getStatus();
+      if (!in_array('paaklaget', AabenformsCase::allowedTransitions()[$current] ?? [], TRUE)) {
+        $this->recordStep('Klage afvist', sprintf('Kan ikke påklage en sag med status "%s".', $current), 'failed');
+        return;
+      }
+
+      $case->setStatus('paaklaget');
+      $case->setNewRevision(TRUE);
+      $log = 'Klage modtaget.';
+      if ($grounds !== '') {
+        $log .= ' Begrundelse: ' . $grounds;
+      }
+      $case->setRevisionLogMessage($log);
+      $case->setRevisionCreationTime($this->time->getRequestTime());
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Klage modtaget', sprintf('Sag #%s sendt til genvurdering.', $caseId));
+      $this->auditLogger->log('case_appeal', (string) $caseId, 'paaklaget', 'success', [
+        'action_id' => $this->getPluginId(),
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Appeal case');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/AppealCaseActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/AppealCaseActionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_appeal action and the genvurdering path.
+ *
+ * @group aabenforms_case
+ */
+class AppealCaseActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Makes a persisted case in a given status + sets the case_id token.
+   */
+  protected function makeCase(string $status): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create(['title' => 'Sag', 'case_type' => 'friplads', 'status' => $status]);
+    $case->save();
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    return $case;
+  }
+
+  /**
+   * Invokes an action plugin.
+   */
+  protected function invoke(string $pluginId, array $config): void {
+    $this->container->get('plugin.manager.action')->createInstance($pluginId, $config)->execute();
+  }
+
+  /**
+   * Reloads a case fresh.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * A decided case can be appealed → paaklaget, grounds in the revision log.
+   */
+  public function testAppealOfDecidedCase(): void {
+    $case = $this->makeCase('afgoerelse');
+    $this->invoke('aabenforms_case_appeal', [
+      'case_id_token' => 'case_id',
+      'grounds_token' => 'grounds',
+    ]);
+    // grounds_token resolves empty (unset) here; status is the key assertion.
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('paaklaget', $reloaded->getStatus());
+  }
+
+  /**
+   * A case that has not been decided cannot be appealed.
+   */
+  public function testAppealOfUndecidedCaseRejected(): void {
+    $case = $this->makeCase('oplyst');
+    $this->invoke('aabenforms_case_appeal', ['case_id_token' => 'case_id']);
+    $this->assertSame('oplyst', $this->reload((int) $case->id())->getStatus());
+  }
+
+  /**
+   * Genvurdering: a paaklaget case can be decided again (→ afgoerelse).
+   */
+  public function testGenvurderingDecidesFromPaaklaget(): void {
+    $case = $this->makeCase('paaklaget');
+    $this->invoke('aabenforms_case_decide', ['afgoerelse_type' => 'medhold']);
+    $this->assertSame('afgoerelse', $this->reload((int) $case->id())->getStatus());
+  }
+
+}


### PR DESCRIPTION
Adds the appeal half of the case lifecycle.

- **AppealCaseAction** (`aabenforms_case_appeal`): moves a decided case `afgoerelse → paaklaget` (the lifecycle guard rejects appealing an undecided case) and stores the klage grounds in an audited revision.
- **klage** webform (sagsnummer, CPR, begrundelse) + **klage_flow** wiring it to the appeal action.
- Genvurdering reuses the existing `decide`/transition (`paaklaget → afgoerelse` / `lukket`) — no new code.

Verified: 28/28 phpunit green (3 new), phpcs clean, cim installs the klage webform + flow; functional end-to-end: decide a friplads case, submit a klage referencing it → case `paaklaget`. Increment C of four.