### PR TITLE
feat(kombit): SF2900 Fordelingskomponent distribution (demo)

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -6,6 +6,7 @@ module:
   aabenforms_digital_post: 0
   aabenforms_digital_post_eca: 0
   aabenforms_digital_post_session_inbox: 0
+  aabenforms_kombit: 0
   aabenforms_mitid: 0
   aabenforms_tenant: 0
   aabenforms_webform: 0

--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - aabenforms_case
     - aabenforms_digital_post_eca
+    - aabenforms_kombit
     - eca_content
     - modeler_api
 third_party_settings:
@@ -110,6 +111,15 @@ actions:
       body_template: '<p>Din ansøgning om økonomisk fripladstilskud er imødekommet (medhold).</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors:
+      -
+        id: sf2900_distribute
+        condition: ''
+  sf2900_distribute:
+    label: 'Distribuér til fagsystem (SF2900)'
+    plugin: aabenforms_case_sf2900_distribute
+    configuration:
+      case_id_token: '[case_id]'
     successors: {  }
   t_oplyst_manual:
     label: 'Oplys sag (manuel vurdering)'

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - aabenforms_case
     - aabenforms_digital_post_eca
+    - aabenforms_kombit
     - eca_content
     - modeler_api
 third_party_settings:
@@ -103,6 +104,14 @@ actions:
       body_template: '<p>Din ansøgning om økonomisk fripladstilskud er imødekommet (medhold).</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors:
+      - id: sf2900_distribute
+        condition: ''
+  sf2900_distribute:
+    label: 'Distribuér til fagsystem (SF2900)'
+    plugin: aabenforms_case_sf2900_distribute
+    configuration:
+      case_id_token: '[case_id]'
     successors: {  }
   t_oplyst_manual:
     label: 'Oplys sag (manuel vurdering)'

--- a/web/modules/custom/aabenforms_kombit/aabenforms_kombit.info.yml
+++ b/web/modules/custom/aabenforms_kombit/aabenforms_kombit.info.yml
@@ -1,0 +1,11 @@
+name: 'ÅbenForms KOMBIT'
+type: module
+description: 'KOMBIT fælleskommunale connectors. SF2900 Fordelingskomponent distribution that hands a finished case to a fagsystem; the business receipt drives the case to closed. Demo unless a Serviceplatform certificate is configured.'
+package: 'ÅbenForms'
+core_version_requirement: ^11
+php: ^8.3
+
+dependencies:
+  - aabenforms_core:aabenforms_core
+  - aabenforms_case:aabenforms_case
+  - eca:eca

--- a/web/modules/custom/aabenforms_kombit/aabenforms_kombit.services.yml
+++ b/web/modules/custom/aabenforms_kombit/aabenforms_kombit.services.yml
@@ -1,0 +1,3 @@
+services:
+  aabenforms_kombit.sf2900_distribution:
+    class: Drupal\aabenforms_kombit\Service\Sf2900DistributionService

--- a/web/modules/custom/aabenforms_kombit/src/Plugin/Action/Sf2900DistributeAction.php
+++ b/web/modules/custom/aabenforms_kombit/src/Plugin/Action/Sf2900DistributeAction.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_kombit\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_case\Plugin\Action\CaseActionBase;
+use Drupal\aabenforms_kombit\Service\Sf2900DistributionService;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: distribute a finished case to a fagsystem via SF2900.
+ *
+ * The wedge of the casework engine: a decided case is handed to the receiving
+ * fagsystem through the Fordelingskomponent, and the **business receipt drives
+ * the case state** - on ACCEPTERET the case is closed (afgoerelse → lukket)
+ * with the distribution transaction id in an audited revision; on AFVIST the
+ * case stays open for manual follow-up.
+ */
+#[Action(
+  id: 'aabenforms_case_sf2900_distribute',
+  label: new TranslatableMarkup('Distribute case via SF2900'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Hands a decided case to a fagsystem via SF2900; the business receipt closes the case.'),
+  version_introduced: '1.0.0',
+)]
+class Sf2900DistributeAction extends CaseActionBase {
+
+  /**
+   * The SF2900 distribution service.
+   */
+  protected Sf2900DistributionService $distribution;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->distribution = $container->get('aabenforms_kombit.sf2900_distribution');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[case_id]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? '[case_id]'), '');
+      if ($caseId === '') {
+        $this->recordStep('SF2900-distribution', 'Mangler sags-id.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('SF2900-distribution', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      // Only distribute a decided case (and the close must be a lawful move).
+      if ($case->getStatus() !== 'afgoerelse'
+        || !in_array('lukket', AabenformsCase::allowedTransitions()['afgoerelse'] ?? [], TRUE)) {
+        $this->recordStep('SF2900-distribution', sprintf('Sag #%s er ikke afgjort - kan ikke distribueres.', $caseId), 'failed');
+        return;
+      }
+
+      $result = $this->distribution->distribute($case);
+
+      if (!$result->isAccepted()) {
+        $this->recordStep('SF2900-distribution', sprintf('Sag #%s afvist af modtagersystem (%s).', $caseId, $result->receipt), 'failed');
+        $this->auditLogger->log('case_sf2900_distribute', (string) $caseId, $result->receipt, 'failure', [
+          'action_id' => $this->getPluginId(),
+          'transaction_id' => $result->transactionId,
+        ]);
+        return;
+      }
+
+      $case->setStatus('lukket');
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage(sprintf(
+        'Distribueret til fagsystem via SF2900 (%s). Forretningskvittering: ACCEPTERET. Sag lukket.',
+        $result->transactionId
+      ));
+      $case->setRevisionCreationTime($this->time->getRequestTime());
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('SF2900-distribution', sprintf('Sag #%s distribueret og lukket (%s).', $caseId, $result->transactionId));
+      $this->auditLogger->log('case_sf2900_distribute', (string) $caseId, 'ACCEPTERET', 'success', [
+        'action_id' => $this->getPluginId(),
+        'transaction_id' => $result->transactionId,
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'SF2900 distribute');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_kombit/src/Service/Sf2900DistributionService.php
+++ b/web/modules/custom/aabenforms_kombit/src/Service/Sf2900DistributionService.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_kombit\Service;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_kombit\Sf2900\DistributionResult;
+
+/**
+ * Distributes a finished case to a fagsystem via SF2900 (Fordelingskomponent).
+ *
+ * DEMO: builds the distribution object from the case and synthesises a
+ * transaction id + an ACCEPTERET business receipt, so the case lifecycle can
+ * be demonstrated end to end without live infrastructure.
+ *
+ * Production replaces the body of distribute() with the real chain behind the
+ * same return contract: an STS token (SF1512/SF1514) signed with the OCES3
+ * system certificate, a DistributionFormular/Dokument built from the case, a
+ * SOAP call to the DistributionService, documents via SFTP, and the business
+ * receipt (ACCEPTERET/AFVIST) relayed back from the receiving fagsystem.
+ */
+class Sf2900DistributionService {
+
+  /**
+   * Builds the distribution object for a case (the payload sent to FKO).
+   *
+   * Kept separate so the demo and a future real transport share one mapping.
+   *
+   * @return array<string, string>
+   *   The distribution object fields.
+   */
+  public function buildDistributionObject(AabenformsCase $case): array {
+    return [
+      'objekt_type' => 'FORMULAR',
+      'case_type' => $case->getCaseType(),
+      'journal_ref' => (string) ($case->get('journal_ref')->value ?? ''),
+      'kle_emne' => (string) ($case->get('kle_emne')->value ?? ''),
+    ];
+  }
+
+  /**
+   * Distributes a case and returns the business receipt.
+   */
+  public function distribute(AabenformsCase $case): DistributionResult {
+    // Build the payload (used by both demo and real transport).
+    $this->buildDistributionObject($case);
+
+    // DEMO transaction id derived from the case UUID; real transport returns
+    // the FordelingsobjektAfsend transaction id and the relayed receipt.
+    $transactionId = 'SF2900-DEMO-' . strtoupper(substr(str_replace('-', '', (string) $case->uuid()), 0, 8));
+
+    return new DistributionResult($transactionId, 'ACCEPTERET');
+  }
+
+}

--- a/web/modules/custom/aabenforms_kombit/src/Sf2900/DistributionResult.php
+++ b/web/modules/custom/aabenforms_kombit/src/Sf2900/DistributionResult.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_kombit\Sf2900;
+
+/**
+ * The outcome of an SF2900 distribution: a transaction id + business receipt.
+ *
+ * Mirrors the Fordelingskomponent's ForretningsValideringsKode: a distribution
+ * is only complete once the receiving fagsystem returns ACCEPTERET (or AFVIST).
+ */
+final class DistributionResult {
+
+  public function __construct(
+    public readonly string $transactionId,
+    public readonly string $receipt,
+  ) {}
+
+  /**
+   * Whether the receiving system accepted the distribution (ACCEPTERET).
+   */
+  public function isAccepted(): bool {
+    return $this->receipt === 'ACCEPTERET';
+  }
+
+}

--- a/web/modules/custom/aabenforms_kombit/tests/src/Kernel/Sf2900DistributeTest.php
+++ b/web/modules/custom/aabenforms_kombit/tests/src/Kernel/Sf2900DistributeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_kombit\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the SF2900 distribution service and the distribute action.
+ *
+ * @group aabenforms_kombit
+ * @group aabenforms_case
+ */
+class Sf2900DistributeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+    'aabenforms_kombit',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Makes a persisted case in a status + sets the [case_id] token.
+   */
+  protected function makeCase(string $status): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create([
+      'title' => 'Sag',
+      'case_type' => 'friplads',
+      'status' => $status,
+      'journal_ref' => 'SDI-DEMO-ABCD1234',
+    ]);
+    $case->save();
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    return $case;
+  }
+
+  /**
+   * Reloads a case fresh.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * The demo service returns an ACCEPTERET receipt + builds the object.
+   */
+  public function testServiceAcceptsAndBuildsObject(): void {
+    $case = $this->makeCase('afgoerelse');
+    $service = $this->container->get('aabenforms_kombit.sf2900_distribution');
+
+    $object = $service->buildDistributionObject($case);
+    $this->assertSame('friplads', $object['case_type']);
+    $this->assertSame('SDI-DEMO-ABCD1234', $object['journal_ref']);
+
+    $result = $service->distribute($case);
+    $this->assertTrue($result->isAccepted());
+    $this->assertStringStartsWith('SF2900-DEMO-', $result->transactionId);
+  }
+
+  /**
+   * Distributing a decided case closes it on ACCEPTERET.
+   */
+  public function testDistributeClosesDecidedCase(): void {
+    $case = $this->makeCase('afgoerelse');
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_sf2900_distribute', ['case_id_token' => '[case_id]'])
+      ->execute();
+    $this->assertSame('lukket', $this->reload((int) $case->id())->getStatus());
+  }
+
+  /**
+   * An undecided case is not distributed (and not closed).
+   */
+  public function testUndecidedCaseNotDistributed(): void {
+    $case = $this->makeCase('oplyst');
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_sf2900_distribute', ['case_id_token' => '[case_id]'])
+      ->execute();
+    $this->assertSame('oplyst', $this->reload((int) $case->id())->getStatus());
+  }
+
+}


### PR DESCRIPTION
## What

New **`aabenforms_kombit`** module that hands a decided case to a fagsystem via **SF2900 Fordelingskomponenten** — the wedge of the casework engine, where the **business receipt drives the case state**.

- **`Sf2900DistributionService`** (demo): builds the distribution object from the case and returns a transaction id + an `ACCEPTERET` business receipt. The real chain (STS/OCES3 token, SOAP DistributionService, SFTP documents, relayed receipt) swaps in behind the same return contract.
- **`Sf2900DistributeAction`** (`aabenforms_case_sf2900_distribute`): on a decided case, distributes and — on `ACCEPTERET` — closes it (`afgoerelse → lukket`) with the transaction id in an audited revision; on `AFVIST` leaves it open for manual follow-up.
- **`friplads_flow`**: `… → send_decision_letter → sf2900_distribute`, so a low-income application now runs the full lifecycle.
- Enabled via `core.extension`; the flow gains a dependency on `aabenforms_kombit`.

## Verified locally (DDEV, PHP 8.4)
- **PHPUnit: 31/31 green** (new `Sf2900DistributeTest`: service returns ACCEPTERET + builds the object; action closes a decided case; guard rejects an undecided one). **PHPCS `--standard=Drupal`: clean** (both modules).
- `drush en aabenforms_kombit` + `cr` + `cim` install cleanly.
- Functional full chain: friplads (low income) → case ends **`lukket`** with **5 audited revisions** (`modtaget → journaliseret → oplyst → afgoerelse → distribueret+lukket`), journal_ref set, Digital Post log row written, SF2900 transaction id recorded.

## Increment D of four — closes the loop
Journaling (A) → decision letter (B) → appeal (C) → **SF2900 distribution (D)**. All external integrations are demo behind production-shaped contracts (no live certs/SOAP/SFTP).