### PR TITLE
Harden casework lifecycle + fail-closed identity/CPR handling (pressure-test Tier-1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "php-http/discovery": true,
-            "php-tuf/composer-integration": true
+            "php-tuf/composer-integration": true,
+            "symfony/runtime": true
         },
         "sort-packages": true
     },
@@ -102,7 +103,7 @@
             ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",

--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -6,6 +6,7 @@ dependencies:
     - aabenforms_case
     - aabenforms_digital_post_eca
     - aabenforms_kombit
+    - aabenforms_workflows
     - eca_content
     - modeler_api
 third_party_settings:
@@ -22,9 +23,27 @@ events:
       type: 'webform_submission friplads'
     successors:
       -
-        id: open_case
+        id: mitid_validate
         condition: ''
 conditions:
+  gate_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[friplads_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[friplads_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
   gate_eligible:
     plugin: eca_scalar
     configuration:
@@ -45,6 +64,28 @@ conditions:
       case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validér MitID-session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_friplads
+      result_token: friplads_mitid_valid
+      session_data_token: friplads_session
+    successors:
+      -
+        id: open_case
+        condition: gate_mitid_ok
+      -
+        id: deny_identity
+        condition: gate_mitid_deny
+  deny_identity:
+    label: 'Afvis: identitet ikke bekræftet'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: friplads_denied
+      step_label: 'Identitet ikke bekræftet'
+      message: 'Ansøgningen blev ikke behandlet, fordi din identitet ikke kunne bekræftes med MitID. Log ind med MitID og prøv igen.'
+    successors: {  }
   open_case:
     label: 'Åbn sag (fripladstilskud)'
     plugin: aabenforms_case_open

--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -62,6 +62,24 @@ conditions:
       operator: atmost
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -155,7 +173,18 @@ actions:
     successors:
       -
         id: sf2900_distribute
-        condition: ''
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: friplads_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute

--- a/config/sync/eca.eca.merudgifter_flow.yml
+++ b/config/sync/eca.eca.merudgifter_flow.yml
@@ -62,6 +62,24 @@ conditions:
       operator: atleast
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -166,7 +184,18 @@ actions:
     successors:
       -
         id: sf2900_distribute
-        condition: ''
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: merudgifter_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket, og klagefristen er ikke startet.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute
@@ -216,4 +245,17 @@ actions:
       body_template: '<p>Din ansøgning om dækning af merudgifter er ikke imødekommet (afslag). Se vedlagte klagevejledning.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors:
+      -
+        id: set_klagefrist
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  set_klagefrist:
+    label: 'Start klagefrist (brev afsendt)'
+    plugin: aabenforms_case_set_klagefrist
+    configuration:
+      case_id_token: '[case_id]'
+      klagefrist_uger: 4
     successors: {  }

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -62,6 +62,24 @@ conditions:
       operator: atmost
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -155,7 +173,18 @@ actions:
     successors:
       -
         id: sf2900_distribute
-        condition: ''
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: friplads_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -6,6 +6,7 @@ dependencies:
     - aabenforms_case
     - aabenforms_digital_post_eca
     - aabenforms_kombit
+    - aabenforms_workflows
     - eca_content
     - modeler_api
 third_party_settings:
@@ -21,9 +22,28 @@ events:
     configuration:
       type: 'webform_submission friplads'
     successors:
-      - id: open_case
+      -
+        id: mitid_validate
         condition: ''
 conditions:
+  gate_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[friplads_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[friplads_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
   gate_eligible:
     plugin: eca_scalar
     configuration:
@@ -44,6 +64,28 @@ conditions:
       case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validér MitID-session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_friplads
+      result_token: friplads_mitid_valid
+      session_data_token: friplads_session
+    successors:
+      -
+        id: open_case
+        condition: gate_mitid_ok
+      -
+        id: deny_identity
+        condition: gate_mitid_deny
+  deny_identity:
+    label: 'Afvis: identitet ikke bekræftet'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: friplads_denied
+      step_label: 'Identitet ikke bekræftet'
+      message: 'Ansøgningen blev ikke behandlet, fordi din identitet ikke kunne bekræftes med MitID. Log ind med MitID og prøv igen.'
+    successors: {  }
   open_case:
     label: 'Åbn sag (fripladstilskud)'
     plugin: aabenforms_case_open
@@ -51,7 +93,8 @@ actions:
       case_type: friplads
       case_id_token: case_id
     successors:
-      - id: journal_case
+      -
+        id: journal_case
         condition: ''
   journal_case:
     label: 'Journalisér sag (SF1470)'
@@ -59,7 +102,8 @@ actions:
     configuration:
       case_id_token: '[case_id]'
     successors:
-      - id: income_lookup
+      -
+        id: income_lookup
         condition: ''
   income_lookup:
     label: 'Hent husstandsindkomst (eIndkomst)'
@@ -68,9 +112,11 @@ actions:
       cpr_token: '[webform_submission:values:applicant_cpr:raw]'
       result_token: friplads_income
     successors:
-      - id: t_oplyst_auto
+      -
+        id: t_oplyst_auto
         condition: gate_eligible
-      - id: t_oplyst_manual
+      -
+        id: t_oplyst_manual
         condition: gate_manual
   t_oplyst_auto:
     label: 'Oplys sag (straksbehandling)'
@@ -80,7 +126,8 @@ actions:
       target_status: oplyst
       log_message: 'Indkomst ≤ fripladsgrænse - straksbehandling.'
     successors:
-      - id: t_afgoerelse
+      -
+        id: t_afgoerelse
         condition: ''
   t_afgoerelse:
     label: 'Automatisk afgørelse (medhold)'
@@ -91,7 +138,8 @@ actions:
       klagevejledning: ''
       klagefrist_uger: 4
     successors:
-      - id: send_decision_letter
+      -
+        id: send_decision_letter
         condition: ''
   send_decision_letter:
     label: 'Send afgørelsesbrev (Digital Post)'
@@ -105,7 +153,8 @@ actions:
       type: 'Digital Post'
       result_token: digital_post_result
     successors:
-      - id: sf2900_distribute
+      -
+        id: sf2900_distribute
         condition: ''
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.merudgifter_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.merudgifter_flow.yml
@@ -22,7 +22,8 @@ events:
     configuration:
       type: 'webform_submission merudgifter'
     successors:
-      - id: mitid_validate
+      -
+        id: mitid_validate
         condition: ''
 conditions:
   gate_mitid_ok:
@@ -61,6 +62,24 @@ conditions:
       operator: atleast
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -71,9 +90,11 @@ actions:
       result_token: merudgift_mitid_valid
       session_data_token: merudgift_session
     successors:
-      - id: cpr_lookup
+      -
+        id: cpr_lookup
         condition: gate_mitid_ok
-      - id: deny_identity
+      -
+        id: deny_identity
         condition: gate_mitid_deny
   deny_identity:
     label: 'Afvis: identitet ikke bekræftet'
@@ -91,7 +112,8 @@ actions:
       result_token: citizen_data
       use_cache: true
     successors:
-      - id: open_case
+      -
+        id: open_case
         condition: ''
   open_case:
     label: 'Åbn sag (merudgifter)'
@@ -100,7 +122,8 @@ actions:
       case_type: merudgifter
       case_id_token: case_id
     successors:
-      - id: journal_case
+      -
+        id: journal_case
         condition: ''
   journal_case:
     label: 'Journalisér sag (SF1470)'
@@ -108,7 +131,8 @@ actions:
     configuration:
       case_id_token: '[case_id]'
     successors:
-      - id: income_lookup
+      -
+        id: income_lookup
         condition: ''
   income_lookup:
     label: 'Hent husstandsindkomst (eIndkomst)'
@@ -117,7 +141,8 @@ actions:
       cpr_token: '[webform_submission:values:applicant_cpr:raw]'
       result_token: merudgift_income
     successors:
-      - id: transition_oplyst
+      -
+        id: transition_oplyst
         condition: ''
   transition_oplyst:
     label: 'Oplys sag'
@@ -127,9 +152,11 @@ actions:
       target_status: oplyst
       log_message: 'Sag oplyst: identitet bekræftet, journaliseret, indkomst hentet.'
     successors:
-      - id: decide_medhold
+      -
+        id: decide_medhold
         condition: gate_eligible
-      - id: partshoering_open
+      -
+        id: partshoering_open
         condition: gate_ineligible
   decide_medhold:
     label: 'Afgørelse: medhold'
@@ -140,7 +167,8 @@ actions:
       klagevejledning: ''
       klagefrist_uger: 4
     successors:
-      - id: letter_medhold
+      -
+        id: letter_medhold
         condition: ''
   letter_medhold:
     label: 'Send afgørelsesbrev (medhold)'
@@ -154,8 +182,20 @@ actions:
       type: 'Digital Post'
       result_token: digital_post_result
     successors:
-      - id: sf2900_distribute
-        condition: ''
+      -
+        id: sf2900_distribute
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: merudgifter_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket, og klagefristen er ikke startet.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute
@@ -169,7 +209,8 @@ actions:
       case_id_token: '[case_id]'
       state: afventer
     successors:
-      - id: partshoering_close
+      -
+        id: partshoering_close
         condition: ''
   partshoering_close:
     label: 'Afslut partshøring'
@@ -178,7 +219,8 @@ actions:
       case_id_token: '[case_id]'
       state: afsluttet
     successors:
-      - id: decide_afslag
+      -
+        id: decide_afslag
         condition: ''
   decide_afslag:
     label: 'Afgørelse: afslag'
@@ -189,7 +231,8 @@ actions:
       klagevejledning: 'Du kan klage over afgørelsen til Ankestyrelsen. Klagen skal være modtaget senest 4 uger efter, du har fået afgørelsen.'
       klagefrist_uger: 4
     successors:
-      - id: letter_afslag
+      -
+        id: letter_afslag
         condition: ''
   letter_afslag:
     label: 'Send afgørelsesbrev (afslag + klagevejledning)'
@@ -202,4 +245,17 @@ actions:
       body_template: '<p>Din ansøgning om dækning af merudgifter er ikke imødekommet (afslag). Se vedlagte klagevejledning.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors:
+      -
+        id: set_klagefrist
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  set_klagefrist:
+    label: 'Start klagefrist (brev afsendt)'
+    plugin: aabenforms_case_set_klagefrist
+    configuration:
+      case_id_token: '[case_id]'
+      klagefrist_uger: 4
     successors: {  }

--- a/web/modules/custom/aabenforms_case/src/Entity/AabenformsCase.php
+++ b/web/modules/custom/aabenforms_case/src/Entity/AabenformsCase.php
@@ -7,6 +7,8 @@ namespace Drupal\aabenforms_case\Entity;
 use Drupal\aabenforms_case\AabenformsCaseInterface;
 use Drupal\Core\Entity\Attribute\ContentEntityType;
 use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Form\DeleteMultipleForm;
 use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
@@ -128,6 +130,65 @@ class AabenformsCase extends RevisionableContentEntityBase implements Aabenforms
 
   /**
    * {@inheritdoc}
+   *
+   * Enforces the lawful lifecycle at the storage layer so no save path - not
+   * the admin edit form, JSON:API, Views Bulk Operations, nor a stray
+   * programmatic write - can reach a state the ECA actions would refuse. A
+   * closed case is immutable, an illegal transition throws, and every mutation
+   * is forced to a new audited revision (the compliance backbone must never
+   * silently overwrite history via a default entity-form save).
+   */
+  public function preSave(EntityStorageInterface $storage): void {
+    parent::preSave($storage);
+
+    // Nothing to guard on the founding save.
+    if ($this->isNew()) {
+      return;
+    }
+
+    $original = $this->originalStatus();
+    if ($original !== NULL) {
+      // A closed case is terminal: no field on it may change.
+      if ($original === 'lukket') {
+        throw new EntityStorageException(sprintf('Sag %s er lukket og kan ikke ændres.', (string) $this->id()));
+      }
+      $new = $this->getStatus();
+      if ($new !== $original && !in_array($new, self::allowedTransitions()[$original] ?? [], TRUE)) {
+        throw new EntityStorageException(sprintf('Ulovlig statusovergang på sag %s: %s → %s.', (string) $this->id(), $original, $new));
+      }
+    }
+
+    // Every change to a case is an audited revision. ECA actions set a
+    // meaningful log message; a bare entity-form save gets a default one.
+    $this->setNewRevision(TRUE);
+    if ((string) ($this->getRevisionLogMessage() ?? '') === '') {
+      $this->setRevisionLogMessage('Sag opdateret.');
+    }
+    $this->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    $this->setRevisionUserId((int) \Drupal::currentUser()->id());
+  }
+
+  /**
+   * Reads the persisted status from before this save, if available.
+   *
+   * @return string|null
+   *   The original status, or NULL when there is no loaded original.
+   */
+  protected function originalStatus(): ?string {
+    $original = NULL;
+    if (method_exists($this, 'getOriginal')) {
+      // Drupal >= 11.2.
+      $original = $this->getOriginal();
+    }
+    elseif (isset($this->original)) {
+      // @phpstan-ignore-line - deprecated property fallback for Drupal < 11.2.
+      $original = $this->original;
+    }
+    return $original instanceof AabenformsCaseInterface ? $original->getStatus() : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
     /** @var \Drupal\Core\Field\BaseFieldDefinition[] $fields */
@@ -158,7 +219,10 @@ class AabenformsCase extends RevisionableContentEntityBase implements Aabenforms
       ->setDefaultValue('modtaget')
       ->setSetting('allowed_values', self::statusOptions())
       ->setDisplayConfigurable('view', TRUE)
-      ->setDisplayConfigurable('form', TRUE);
+      // Status is only ever changed through the lawful, audited transition
+      // actions (aabenforms_case_transition / _decide / _appeal / _sf2900),
+      // never freely via the entity form - preSave() enforces this.
+      ->setDisplayConfigurable('form', FALSE);
 
     $fields['submission_ref'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(new TranslatableMarkup('Webform submission'))

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
@@ -48,6 +48,7 @@ class MakeDecisionAction extends CaseActionBase {
       'afgoerelse_type' => '',
       'klagevejledning' => '',
       'klagefrist_uger' => 4,
+      'partshoering_exemption' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -86,6 +87,13 @@ class MakeDecisionAction extends CaseActionBase {
       '#default_value' => $this->configuration['klagefrist_uger'],
       '#required' => TRUE,
     ];
+    $form['partshoering_exemption'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Partshøring exemption (FVL §19 stk. 2)'),
+      '#description' => $this->t('Only for an adverse decision where partshøring was lawfully NOT required (FVL §19 stk. 2). State the reason; it is recorded on the case. Leave empty when a partshøring must have been concluded first.'),
+      '#default_value' => $this->configuration['partshoering_exemption'],
+      '#rows' => 2,
+    ];
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -97,6 +105,7 @@ class MakeDecisionAction extends CaseActionBase {
     $this->configuration['afgoerelse_type'] = $form_state->getValue('afgoerelse_type');
     $this->configuration['klagevejledning'] = $form_state->getValue('klagevejledning');
     $this->configuration['klagefrist_uger'] = $form_state->getValue('klagefrist_uger');
+    $this->configuration['partshoering_exemption'] = $form_state->getValue('partshoering_exemption');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -126,11 +135,23 @@ class MakeDecisionAction extends CaseActionBase {
       }
 
       $adverse = in_array($type, self::ADVERSE, TRUE);
+      $exemption = trim((string) ($this->configuration['partshoering_exemption'] ?? ''));
 
-      // FVL §19: partshøring must be concluded before an adverse decision.
-      if ($adverse && (string) $case->get('partshoering_state')->value === 'afventer') {
-        $this->recordStep('Afgørelse afvist', 'Partshøring er ikke afsluttet (FVL §19).', 'failed');
-        return;
+      // FVL §19: a party must be heard before an adverse decision. A concluded
+      // hearing (afsluttet) satisfies it; an open hearing (afventer) blocks it;
+      // and skipping the hearing (ikke_paakraevet / unset) is only lawful under
+      // an explicit §19 stk. 2 exemption whose reason is recorded on the case -
+      // never a silent default.
+      if ($adverse) {
+        $partshoering = (string) $case->get('partshoering_state')->value;
+        if ($partshoering === 'afventer') {
+          $this->recordStep('Afgørelse afvist', 'Partshøring er ikke afsluttet (FVL §19).', 'failed');
+          return;
+        }
+        if ($partshoering !== 'afsluttet' && $exemption === '') {
+          $this->recordStep('Afgørelse afvist', 'Partshøring mangler: angiv enten en afsluttet partshøring eller en begrundet §19 stk. 2-undtagelse.', 'failed');
+          return;
+        }
       }
 
       // FVL §25: a klagevejledning is mandatory on an adverse outcome.
@@ -157,6 +178,9 @@ class MakeDecisionAction extends CaseActionBase {
       if ($adverse) {
         $logParts[] = 'Klagevejledning: ' . $klagevejledning;
         $logParts[] = sprintf('Klagefrist: %d uger.', $uger);
+        if ((string) $case->get('partshoering_state')->value !== 'afsluttet' && $exemption !== '') {
+          $logParts[] = 'Partshøring undladt (FVL §19 stk. 2): ' . $exemption;
+        }
       }
       $case->setRevisionLogMessage(implode(' ', $logParts));
       $case->setRevisionCreationTime($now);

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
@@ -169,15 +169,15 @@ class MakeDecisionAction extends CaseActionBase {
 
       $now = $this->time->getRequestTime();
       $case->set('afgoerelse_type', $type);
-      if ($adverse) {
-        $case->set('klagefrist', $now + ($uger * 7 * 86400));
-      }
+      // The klagefrist clock is NOT started here: it runs from when the citizen
+      // is notified (FVL meddelelseskrav), so aabenforms_case_set_klagefrist
+      // stamps it on the branch where the decision letter is confirmed sent.
       $case->setStatus('afgoerelse');
       $case->setNewRevision(TRUE);
       $logParts = [sprintf('Afgørelse: %s.', $type)];
       if ($adverse) {
         $logParts[] = 'Klagevejledning: ' . $klagevejledning;
-        $logParts[] = sprintf('Klagefrist: %d uger.', $uger);
+        $logParts[] = sprintf('Klagefrist: %d uger (startes ved brevafsendelse).', $uger);
         if ((string) $case->get('partshoering_state')->value !== 'afsluttet' && $exemption !== '') {
           $logParts[] = 'Partshøring undladt (FVL §19 stk. 2): ' . $exemption;
         }

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/OpenCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/OpenCaseAction.php
@@ -110,6 +110,25 @@ class OpenCaseAction extends CaseActionBase {
       );
 
       $storage = $this->entityTypeManager->getStorage('aabenforms_case');
+
+      // Idempotency: never open a second case for the same submission. A
+      // content_entity:insert event can fire more than once (retry, re-save,
+      // resubmission), and a duplicate case would mean two frist clocks, two
+      // ambiguous [case_id] tokens, and double journalising/distribution.
+      if ($submissionId !== NULL) {
+        $existingIds = $storage->getQuery()
+          ->accessCheck(FALSE)
+          ->condition('submission_ref', $submissionId)
+          ->range(0, 1)
+          ->execute();
+        if ($existingIds !== []) {
+          $existingId = (string) reset($existingIds);
+          $this->setTokenValue($resultToken, $existingId);
+          $this->recordStep('Sag findes', sprintf('Sag #%s findes allerede for indsendelse #%s.', $existingId, $submissionId));
+          return;
+        }
+      }
+
       $case = $storage->create([
         'title' => $title,
         'case_type' => $caseType,
@@ -117,8 +136,13 @@ class OpenCaseAction extends CaseActionBase {
         'submission_ref' => $submissionId,
         'modtagelsesdato' => $now,
         'frist_due' => $due,
-        'revision_log_message' => 'Sag oprettet fra indsendelse.',
       ]);
+      // Attribute the founding revision (who opened the case), like every
+      // transition revision does.
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage('Sag oprettet fra indsendelse.');
+      $case->setRevisionCreationTime($now);
+      $case->setRevisionUserId((int) $this->currentUser->id());
       $case->save();
 
       $this->setTokenValue($resultToken, (string) $case->id());

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/SetKlagefristAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/SetKlagefristAction.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: start the appeal deadline (klagefrist) clock on a decided case.
+ *
+ * The klagefrist must run from when the citizen is notified, not from the
+ * decision itself (FVL meddelelseskrav) - so a flow runs this only on the
+ * branch where the decision letter was confirmed dispatched. Kept separate
+ * from MakeDecisionAction, which records the decision but no longer stamps the
+ * deadline. Only valid while the case is in "afgoerelse".
+ */
+#[Action(
+  id: 'aabenforms_case_set_klagefrist',
+  label: new TranslatableMarkup('Start appeal deadline (klagefrist)'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Starts the klagefrist clock on a decided case once the decision letter is confirmed dispatched.'),
+  version_introduced: '1.1.0',
+)]
+class SetKlagefristAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[case_id]',
+      'klagefrist_uger' => 4,
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['klagefrist_uger'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Appeal deadline (weeks)'),
+      '#min' => 1,
+      '#default_value' => $this->configuration['klagefrist_uger'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['klagefrist_uger'] = $form_state->getValue('klagefrist_uger');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? '[case_id]'), '');
+      $uger = max(1, (int) ($this->configuration['klagefrist_uger'] ?? 4));
+      if ($caseId === '') {
+        $this->recordStep('Klagefrist', 'Mangler sags-id.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Klagefrist', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      if ($case->getStatus() !== 'afgoerelse') {
+        $this->recordStep('Klagefrist', sprintf('Sag #%s er ikke afgjort - klagefrist kan ikke sættes.', $caseId), 'failed');
+        return;
+      }
+
+      // Idempotent: keep an existing klagefrist.
+      if ((int) ($case->get('klagefrist')->value ?? 0) > 0) {
+        $this->recordStep('Klagefrist', sprintf('Sag #%s har allerede en klagefrist.', $caseId));
+        return;
+      }
+
+      $now = $this->time->getRequestTime();
+      $case->set('klagefrist', $now + ($uger * 7 * 86400));
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage(sprintf('Klagefrist startet (afgørelsesbrev afsendt): %d uger.', $uger));
+      $case->setRevisionCreationTime($now);
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Klagefrist', sprintf('Sag #%s: klagefrist på %d uger startet.', $caseId, $uger));
+      $this->auditLogger->log('case_klagefrist', (string) $caseId, sprintf('%d uger', $uger), 'success', [
+        'action_id' => $this->getPluginId(),
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Set klagefrist');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/SetPartshoeringAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/SetPartshoeringAction.php
@@ -89,6 +89,16 @@ class SetPartshoeringAction extends CaseActionBase {
         return;
       }
 
+      // A hearing only makes sense while the case is being informed. Refuse to
+      // touch partshøring on a decided, appealed, or closed case (that would
+      // rewrite the record after the fact and, unguarded, was the path that
+      // normalised skipping FVL §19).
+      $status = $case->getStatus();
+      if (!in_array($status, ['oplyst', 'partshoering'], TRUE)) {
+        $this->recordStep('Partshøring', sprintf('Sag #%s kan ikke partshøres i status "%s".', $caseId, $status), 'failed');
+        return;
+      }
+
       $now = $this->time->getRequestTime();
       $case->set('partshoering_state', $state);
       $case->setNewRevision(TRUE);

--- a/web/modules/custom/aabenforms_case/src/Service/FristClock.php
+++ b/web/modules/custom/aabenforms_case/src/Service/FristClock.php
@@ -12,12 +12,28 @@ use Drupal\Core\Config\ConfigFactoryInterface;
  * Deadlines are driven by per-area configuration in aabenforms_case.settings
  * (key "frister"), so a new casework area only needs config, not code. Each
  * area defines a duration as either calendar hours or working days
- * (hverdage), the latter skipping weekends per RSL/forvaltningslov practice.
+ * (hverdage), the latter skipping weekends AND Danish public holidays per
+ * RSL/forvaltningslov practice.
  *
- * NOTE: Danish public holidays are not yet subtracted from working-day math
- * (TODO: add a holiday calendar). Weekends are handled.
+ * Working-day math runs in Europe/Copenhagen (not UTC), so the weekday of a
+ * receipt logged near local midnight is classified correctly, and the due
+ * moment is normalised to end-of-day (23:59:59 local) on the final working
+ * day - the citizen-favourable reading (the authority has the whole day).
+ *
+ * Danish public holidays subtracted: nytårsdag, skærtorsdag, langfredag,
+ * 2. påskedag, Kristi himmelfartsdag, 2. pinsedag, juledag, 2. juledag.
+ * Store bededag is deliberately NOT included: it was abolished as a public
+ * holiday from 2024 (lov nr. 214 af 13/03/2023). Grundlovsdag and juleaften
+ * are not statutory helligdage and are left out of the statutory clock; a
+ * kommune that also closes those days can extend the set via the
+ * "ekstra_lukkedage" config key (list of MM-DD strings).
  */
 class FristClock {
+
+  /**
+   * The timezone all working-day math is evaluated in.
+   */
+  protected const TZ = 'Europe/Copenhagen';
 
   public function __construct(
     protected ConfigFactoryInterface $configFactory,
@@ -83,26 +99,103 @@ class FristClock {
   }
 
   /**
-   * Adds N working days (Mon-Fri) to a timestamp.
+   * Adds N working days to a timestamp, skipping weekends and Danish holidays.
    *
-   * The time-of-day of the receipt is preserved; only whole working days are
-   * counted forward, skipping Saturdays and Sundays.
+   * Evaluated in Europe/Copenhagen. The due moment is the end of the final
+   * working day (23:59:59 local), so a "20 hverdage" frist expires at the
+   * close of the 20th working day rather than at the receipt's time-of-day.
    */
   protected function addWorkingDays(int $receiptTs, int $days): int {
     if ($days <= 0) {
       return $receiptTs;
     }
-    $ts = $receiptTs;
+    $tz = new \DateTimeZone(self::TZ);
+    $date = (new \DateTimeImmutable('@' . $receiptTs))->setTimezone($tz);
+
     $added = 0;
     while ($added < $days) {
-      $ts += 86400;
-      $weekday = (int) gmdate('N', $ts);
-      // N: 1 (Mon) .. 7 (Sun); count only 1-5.
-      if ($weekday <= 5) {
+      $date = $date->modify('+1 day');
+      if ($this->isWorkingDay($date)) {
         $added++;
       }
     }
-    return $ts;
+
+    // Normalise to end-of-day local so "day" boundaries do not drift with the
+    // receipt's time-of-day.
+    return (int) $date->setTime(23, 59, 59)->getTimestamp();
+  }
+
+  /**
+   * TRUE when the date is a Danish working day (Mon-Fri, not a helligdag).
+   */
+  protected function isWorkingDay(\DateTimeInterface $date): bool {
+    // N: 1 (Mon) .. 7 (Sun).
+    if ((int) $date->format('N') >= 6) {
+      return FALSE;
+    }
+    return !$this->isHoliday($date);
+  }
+
+  /**
+   * TRUE when the date is a Danish public holiday or configured lukkedag.
+   */
+  protected function isHoliday(\DateTimeInterface $date): bool {
+    $year = (int) $date->format('Y');
+    $md = $date->format('m-d');
+    if (in_array($md, $this->holidayMonthDays($year), TRUE)) {
+      return TRUE;
+    }
+    // Kommune-specific extra closing days (e.g. grundlovsdag, juleaften).
+    $extra = $this->configFactory->get('aabenforms_case.settings')->get('ekstra_lukkedage') ?? [];
+    return in_array($md, array_map('strval', $extra), TRUE);
+  }
+
+  /**
+   * Returns the Danish public holidays for a year as MM-DD strings.
+   *
+   * @return string[]
+   *   Holiday dates formatted as "m-d" in the Copenhagen calendar year.
+   */
+  protected function holidayMonthDays(int $year): array {
+    $easter = $this->easterSunday($year);
+    $days = [
+      // Fixed helligdage.
+      '01-01',
+      '12-25',
+      '12-26',
+    ];
+    // Moveable feasts relative to Easter Sunday.
+    foreach ([-3, -2, 1, 39, 50] as $offset) {
+      // -3 skærtorsdag, -2 langfredag, +1 2. påskedag,
+      // +39 Kristi himmelfart, +50 2. pinsedag.
+      $days[] = $easter->modify(sprintf('%+d days', $offset))->format('m-d');
+    }
+    return $days;
+  }
+
+  /**
+   * Computes Easter Sunday for a Gregorian year (Anonymous Gregorian algorithm).
+   */
+  protected function easterSunday(int $year): \DateTimeImmutable {
+    $a = $year % 19;
+    $b = intdiv($year, 100);
+    $c = $year % 100;
+    $d = intdiv($b, 4);
+    $e = $b % 4;
+    $f = intdiv($b + 8, 25);
+    $g = intdiv($b - $f + 1, 3);
+    $h = (19 * $a + $b - $d - $g + 15) % 30;
+    $i = intdiv($c, 4);
+    $k = $c % 4;
+    $l = (32 + 2 * $e + 2 * $i - $h - $k) % 7;
+    $m = intdiv($a + 11 * $h + 22 * $l, 451);
+    $month = intdiv($h + $l - 7 * $m + 114, 31);
+    $day = (($h + $l - 7 * $m + 114) % 31) + 1;
+
+    return new \DateTimeImmutable(
+      sprintf('%04d-%02d-%02d', $year, $month, $day),
+      new \DateTimeZone(self::TZ)
+    );
   }
 
 }

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseLifecycleEnforcementTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseLifecycleEnforcementTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that the lawful lifecycle is enforced at the storage layer.
+ *
+ * The ECA actions validate transitions, but the entity itself must be the
+ * backstop so no other save path (admin form, JSON:API, VBO, programmatic)
+ * can reach an unlawful state or silently overwrite the audited revision.
+ *
+ * @group aabenforms_case
+ */
+class CaseLifecycleEnforcementTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Creates and persists a case in the given status (founding save is exempt).
+   */
+  protected function caseIn(string $status): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create(['title' => 'Sag', 'case_type' => 'friplads', 'status' => $status]);
+    $case->save();
+    return $case;
+  }
+
+  /**
+   * Reloads a case fresh from storage.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * An illegal status transition is rejected at save time.
+   */
+  public function testIllegalTransitionThrows(): void {
+    $case = $this->reload((int) $this->caseIn('modtaget')->id());
+    // modtaget may only reach oplyst or lukket - never afgoerelse directly.
+    $case->setStatus('afgoerelse');
+    $this->expectException(EntityStorageException::class);
+    $case->save();
+  }
+
+  /**
+   * A lawful transition is allowed and mints a new audited revision.
+   */
+  public function testLawfulTransitionMintsRevision(): void {
+    $case = $this->caseIn('modtaget');
+    $id = (int) $case->id();
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+
+    $before = (int) $storage->getQuery()->accessCheck(FALSE)->allRevisions()->condition('id', $id)->count()->execute();
+    $reloaded = $this->reload($id);
+    $reloaded->setStatus('oplyst');
+    $reloaded->save();
+    $after = (int) $storage->getQuery()->accessCheck(FALSE)->allRevisions()->condition('id', $id)->count()->execute();
+
+    $this->assertSame('oplyst', $this->reload($id)->getStatus());
+    $this->assertSame($before + 1, $after, 'Every update mints a new revision');
+  }
+
+  /**
+   * A closed case is immutable - no field may change.
+   */
+  public function testClosedCaseIsImmutable(): void {
+    $case = $this->reload((int) $this->caseIn('lukket')->id());
+    $case->set('title', 'Ændret efter lukning');
+    $this->expectException(EntityStorageException::class);
+    $case->save();
+  }
+
+  /**
+   * Partshøring cannot be set on a decided case (SetPartshoeringAction guard).
+   */
+  public function testPartshoeringRejectedOnDecidedCase(): void {
+    $case = $this->caseIn('afgoerelse');
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_partshoering', ['state' => 'afventer'])
+      ->execute();
+    $this->assertSame(
+      'ikke_paakraevet',
+      (string) $this->reload((int) $case->id())->get('partshoering_state')->value,
+      'Partshøring state unchanged on a decided case'
+    );
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseLifecycleEnforcementTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseLifecycleEnforcementTest.php
@@ -74,7 +74,7 @@ class CaseLifecycleEnforcementTest extends KernelTestBase {
    */
   public function testIllegalTransitionThrows(): void {
     $case = $this->reload((int) $this->caseIn('modtaget')->id());
-    // modtaget may only reach oplyst or lukket - never afgoerelse directly.
+    // Modtaget may only reach oplyst or lukket - never afgoerelse directly.
     $case->setStatus('afgoerelse');
     $this->expectException(EntityStorageException::class);
     $case->save();

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
@@ -105,11 +105,14 @@ class MakeDecisionActionTest extends KernelTestBase {
   }
 
   /**
-   * An adverse decision with a klagevejledning sets the appeal deadline.
+   * An adverse decision records the outcome but does NOT start the klagefrist.
    *
-   * A §19 stk. 2 exemption is supplied because no partshøring was held.
+   * The klagefrist runs from notification (FVL meddelelseskrav), so the decide
+   * step leaves it unset; aabenforms_case_set_klagefrist starts it once the
+   * letter is confirmed sent. A §19 stk. 2 exemption is supplied here because
+   * no partshøring was held.
    */
-  public function testAdverseWithKlagevejledningSetsKlagefrist(): void {
+  public function testAdverseDecisionDefersKlagefristToDispatch(): void {
     $case = $this->caseInOplyst();
     $now = $this->container->get('datetime.time')->getRequestTime();
     $this->invoke('aabenforms_case_decide', [
@@ -118,10 +121,14 @@ class MakeDecisionActionTest extends KernelTestBase {
       'klagefrist_uger' => 4,
       'partshoering_exemption' => 'Afgørelsen bygger alene på borgerens egne oplysninger (FVL §19 stk. 2).',
     ]);
-    $reloaded = $this->reload((int) $case->id());
-    $this->assertSame('afgoerelse', $reloaded->getStatus());
-    $this->assertSame('afslag', (string) $reloaded->get('afgoerelse_type')->value);
-    $this->assertSame($now + (4 * 7 * 86400), (int) $reloaded->get('klagefrist')->value);
+    $decided = $this->reload((int) $case->id());
+    $this->assertSame('afgoerelse', $decided->getStatus());
+    $this->assertSame('afslag', (string) $decided->get('afgoerelse_type')->value);
+    $this->assertNull($decided->get('klagefrist')->value, 'Klagefrist is not started at decide time');
+
+    // The dispatch step starts the clock.
+    $this->invoke('aabenforms_case_set_klagefrist', ['klagefrist_uger' => 4]);
+    $this->assertSame($now + (4 * 7 * 86400), (int) $this->reload((int) $case->id())->get('klagefrist')->value);
   }
 
   /**

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
@@ -106,6 +106,8 @@ class MakeDecisionActionTest extends KernelTestBase {
 
   /**
    * An adverse decision with a klagevejledning sets the appeal deadline.
+   *
+   * A §19 stk. 2 exemption is supplied because no partshøring was held.
    */
   public function testAdverseWithKlagevejledningSetsKlagefrist(): void {
     $case = $this->caseInOplyst();
@@ -114,11 +116,44 @@ class MakeDecisionActionTest extends KernelTestBase {
       'afgoerelse_type' => 'afslag',
       'klagevejledning' => 'Du kan klage til Ankestyrelsen inden for 4 uger.',
       'klagefrist_uger' => 4,
+      'partshoering_exemption' => 'Afgørelsen bygger alene på borgerens egne oplysninger (FVL §19 stk. 2).',
     ]);
     $reloaded = $this->reload((int) $case->id());
     $this->assertSame('afgoerelse', $reloaded->getStatus());
     $this->assertSame('afslag', (string) $reloaded->get('afgoerelse_type')->value);
     $this->assertSame($now + (4 * 7 * 86400), (int) $reloaded->get('klagefrist')->value);
+  }
+
+  /**
+   * FVL §19: an adverse decision is blocked when no hearing was held and no
+   * exemption is given - the silent-skip path is closed.
+   */
+  public function testAdverseWithoutHearingOrExemptionBlocked(): void {
+    $case = $this->caseInOplyst();
+    // Default partshoering_state is "ikke_paakraevet"; no exemption supplied.
+    $this->invoke('aabenforms_case_decide', [
+      'afgoerelse_type' => 'afslag',
+      'klagevejledning' => 'Klagevejledning til Ankestyrelsen.',
+    ]);
+    $reloaded = $this->reload((int) $case->id());
+    $this->assertSame('oplyst', $reloaded->getStatus(), 'Adverse decision blocked without hearing or §19 stk. 2 exemption');
+    $this->assertNull($reloaded->get('afgoerelse_type')->value);
+  }
+
+  /**
+   * An adverse decision succeeds once partshøring is concluded (afsluttet).
+   */
+  public function testAdverseAfterHearingConcluded(): void {
+    $case = $this->caseInOplyst();
+    $this->invoke('aabenforms_case_partshoering', ['state' => 'afventer']);
+    $this->invoke('aabenforms_case_partshoering', ['state' => 'afsluttet']);
+    $this->assertSame('afsluttet', (string) $this->reload((int) $case->id())->get('partshoering_state')->value);
+
+    $this->invoke('aabenforms_case_decide', [
+      'afgoerelse_type' => 'afslag',
+      'klagevejledning' => 'Klagevejledning til Ankestyrelsen.',
+    ]);
+    $this->assertSame('afgoerelse', $this->reload((int) $case->id())->getStatus(), 'Adverse decision allowed after concluded hearing');
   }
 
   /**

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
@@ -125,8 +125,9 @@ class MakeDecisionActionTest extends KernelTestBase {
   }
 
   /**
-   * FVL §19: an adverse decision is blocked when no hearing was held and no
-   * exemption is given - the silent-skip path is closed.
+   * FVL §19: an adverse decision needs a hearing or a recorded exemption.
+   *
+   * The silent-skip path (no hearing, no exemption) is closed.
    */
   public function testAdverseWithoutHearingOrExemptionBlocked(): void {
     $case = $this->caseInOplyst();

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/OpenCaseActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/OpenCaseActionTest.php
@@ -112,4 +112,34 @@ class OpenCaseActionTest extends KernelTestBase {
     );
   }
 
+  /**
+   * A re-fired insert event must not open a second case for one submission.
+   */
+  public function testOpenCaseIsIdempotent(): void {
+    Webform::create(['id' => 'underretning', 'title' => 'Underretning'])->save();
+    $submission = WebformSubmission::create([
+      'webform_id' => 'underretning',
+      'data' => ['concern_details' => 'Bekymring.'],
+    ]);
+    $submission->save();
+
+    $tokenService = $this->container->get('eca.token_services');
+    $tokenService->addTokenData('webform_submission', $submission);
+    $actionManager = $this->container->get('plugin.manager.action');
+
+    $run = fn() => $actionManager
+      ->createInstance('aabenforms_case_open', ['case_type' => 'underretning', 'case_id_token' => 'case_id'])
+      ->execute();
+
+    $run();
+    $firstId = (string) $tokenService->getTokenData('case_id');
+    // Simulate the content_entity:insert event firing a second time.
+    $run();
+    $secondId = (string) $tokenService->getTokenData('case_id');
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $this->assertCount(1, $storage->loadMultiple(), 'Only one case exists for the submission');
+    $this->assertSame($firstId, $secondId, 'The second run reuses the same case id');
+  }
+
 }

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/SetKlagefristActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/SetKlagefristActionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_set_klagefrist action.
+ *
+ * The appeal clock starts from notification, so this action only stamps the
+ * klagefrist on a decided (afgoerelse) case and is idempotent.
+ *
+ * @group aabenforms_case
+ */
+class SetKlagefristActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Creates a persisted case in the given status and sets the case_id token.
+   */
+  protected function caseIn(string $status): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create(['title' => 'Sag', 'case_type' => 'merudgifter', 'status' => $status]);
+    $case->save();
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    return $case;
+  }
+
+  /**
+   * Reloads a case fresh.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * Runs the action.
+   */
+  protected function setKlagefrist(int $uger = 4): void {
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_set_klagefrist', ['klagefrist_uger' => $uger])
+      ->execute();
+  }
+
+  /**
+   * Starts the klagefrist on a decided case.
+   */
+  public function testStartsKlagefristOnDecidedCase(): void {
+    $case = $this->caseIn('afgoerelse');
+    $now = $this->container->get('datetime.time')->getRequestTime();
+    $this->setKlagefrist(4);
+    $this->assertSame($now + (4 * 7 * 86400), (int) $this->reload((int) $case->id())->get('klagefrist')->value);
+  }
+
+  /**
+   * Refuses to start the klagefrist on a case that is not decided.
+   */
+  public function testRejectsWhenNotDecided(): void {
+    $case = $this->caseIn('oplyst');
+    $this->setKlagefrist(4);
+    $this->assertNull($this->reload((int) $case->id())->get('klagefrist')->value, 'No klagefrist set on an undecided case');
+  }
+
+  /**
+   * Is idempotent: a second run does not move an existing klagefrist.
+   */
+  public function testIdempotent(): void {
+    $case = $this->caseIn('afgoerelse');
+    $this->setKlagefrist(4);
+    $first = (int) $this->reload((int) $case->id())->get('klagefrist')->value;
+    $this->setKlagefrist(8);
+    $this->assertSame($first, (int) $this->reload((int) $case->id())->get('klagefrist')->value, 'Klagefrist unchanged on re-run');
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
@@ -26,15 +26,31 @@ class FristClockTest extends UnitTestCase {
    *
    * @param array<string, array{unit:string, amount:int}> $frister
    *   The per-area deadline config.
+   * @param string[] $extraClosingDays
+   *   Kommune-specific extra closing days as "m-d" strings.
    */
-  protected function clock(array $frister): FristClock {
+  protected function clock(array $frister, array $extraClosingDays = []): FristClock {
     $config = $this->createMock(ImmutableConfig::class);
-    $config->method('get')->with('frister')->willReturn($frister);
+    $config->method('get')->willReturnMap([
+      ['frister', $frister],
+      ['ekstra_lukkedage', $extraClosingDays],
+    ]);
 
     $factory = $this->createMock(ConfigFactoryInterface::class);
     $factory->method('get')->with('aabenforms_case.settings')->willReturn($config);
 
     return new FristClock($factory);
+  }
+
+  /**
+   * Formats a due timestamp as a Copenhagen "Y-m-d H:i:s" string.
+   */
+  protected function due(FristClock $clock, string $receiptCph, string $area): string {
+    $receipt = new \DateTimeImmutable($receiptCph, new \DateTimeZone('Europe/Copenhagen'));
+    $ts = $clock->computeDue($receipt->getTimestamp(), $area);
+    return (new \DateTimeImmutable('@' . $ts))
+      ->setTimezone(new \DateTimeZone('Europe/Copenhagen'))
+      ->format('Y-m-d H:i:s');
   }
 
   /**
@@ -49,15 +65,83 @@ class FristClockTest extends UnitTestCase {
   }
 
   /**
+   * Working days skip weekends and land at end-of-day (Copenhagen).
+   *
    * @covers ::computeDue
    * @covers ::addWorkingDays
    */
-  public function testComputeDueWorkingDaysSkipsWeekend(): void {
-    $clock = $this->clock(['anerkend' => ['unit' => 'hverdage', 'amount' => 6]]);
-    // From Monday, 6 working days lands on the next Tuesday (8 calendar days),
-    // skipping the intervening Saturday and Sunday.
-    $expected = self::MONDAY_0900 + (8 * 86400);
-    $this->assertSame($expected, $clock->computeDue(self::MONDAY_0900, 'anerkend'));
+  public function testWorkingDaysSkipWeekendEndOfDay(): void {
+    $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 5]]);
+    // Mon 2025-03-03 10:00 + 5 hverdage: Tue/Wed/Thu/Fri, skip Sat/Sun, Mon.
+    $this->assertSame('2025-03-10 23:59:59', $this->due($clock, '2025-03-03 10:00:00', 'x'));
+  }
+
+  /**
+   * Danish public holidays around Easter are not counted as working days.
+   *
+   * @covers ::addWorkingDays
+   */
+  public function testEasterHolidaysSkipped(): void {
+    $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 3]]);
+    // Easter 2025-04-20. Receipt Wed 04-16; skærtorsdag 04-17, langfredag
+    // 04-18, weekend, 2. påskedag 04-21 are all skipped, so 3 hverdage lands
+    // Thu 04-24 (eight calendar days later).
+    $this->assertSame('2025-04-24 23:59:59', $this->due($clock, '2025-04-16 09:00:00', 'x'));
+  }
+
+  /**
+   * Christmas holidays (25-26 Dec) are skipped.
+   *
+   * @covers ::addWorkingDays
+   */
+  public function testChristmasHolidaysSkipped(): void {
+    $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 2]]);
+    // Receipt Wed 2025-12-24; juledag 12-25 + 2. juledag 12-26 + weekend
+    // skipped, so 2 hverdage lands Tue 2025-12-30.
+    $this->assertSame('2025-12-30 23:59:59', $this->due($clock, '2025-12-24 09:00:00', 'x'));
+  }
+
+  /**
+   * Store bededag is NOT a holiday (abolished 2024): it counts as a working day.
+   *
+   * @covers ::addWorkingDays
+   */
+  public function testStoreBededagIsAWorkingDay(): void {
+    $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 1]]);
+    // 4th Friday after Easter 2025 = 2025-05-16 (former store bededag).
+    // Receipt Thu 2025-05-15 + 1 hverdag must land on that Friday, not skip it.
+    $this->assertSame('2025-05-16 23:59:59', $this->due($clock, '2025-05-15 09:00:00', 'x'));
+  }
+
+  /**
+   * Kommune-specific extra closing days (e.g. grundlovsdag) are honoured.
+   *
+   * @covers ::isHoliday
+   */
+  public function testExtraClosingDaysSkipped(): void {
+    // Grundlovsdag 2025-06-05 is a Thursday, not a statutory helligdag.
+    $withExtra = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 1]], ['06-05']);
+    $this->assertSame('2025-06-06 23:59:59', $this->due($withExtra, '2025-06-04 09:00:00', 'x'));
+
+    $withoutExtra = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 1]]);
+    $this->assertSame('2025-06-05 23:59:59', $this->due($withoutExtra, '2025-06-04 09:00:00', 'x'));
+  }
+
+  /**
+   * Weekday is computed in Copenhagen time, not UTC.
+   *
+   * @covers ::addWorkingDays
+   */
+  public function testWeekdayComputedInCopenhagenTimezone(): void {
+    $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 1]]);
+    // 2025-01-05 23:30 UTC is Monday 2025-01-06 00:30 CET. In UTC the weekday
+    // would be Sunday; in Copenhagen it is Monday, so 1 hverdag lands Tue 01-07.
+    $receipt = new \DateTimeImmutable('2025-01-05 23:30:00', new \DateTimeZone('UTC'));
+    $ts = $clock->computeDue($receipt->getTimestamp(), 'x');
+    $due = (new \DateTimeImmutable('@' . $ts))
+      ->setTimezone(new \DateTimeZone('Europe/Copenhagen'))
+      ->format('Y-m-d');
+    $this->assertSame('2025-01-07', $due);
   }
 
   /**

--- a/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
@@ -106,7 +106,7 @@ class FristClockTest extends UnitTestCase {
    *
    * @covers ::addWorkingDays
    */
-  public function testStoreBededagIsAWorkingDay(): void {
+  public function testStoreBededagCountsAsWorkingDay(): void {
     $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 1]]);
     // 4th Friday after Easter 2025 = 2025-05-16 (former store bededag).
     // Receipt Thu 2025-05-15 + 1 hverdag must land on that Friday, not skip it.

--- a/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
+++ b/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
@@ -73,8 +73,14 @@ class CprAccess {
    *
    * @return string
    *   The prefixed ciphertext, or the original value if empty/already
-   *   protected, or - if encryption is misconfigured - the original value
-   *   with an error logged (so a submission is never lost).
+   *   protected.
+   *
+   * @throws \RuntimeException
+   *   When encryption is misconfigured (missing profile/key). Fails hard so a
+   *   CPR is NEVER written in plaintext: it is safer to reject the submission
+   *   than to store personal data unencrypted (databeskyttelsesloven). The
+   *   sole caller (the webform-submission presave hook) lets this abort the
+   *   save; the error message carries no CPR.
    */
   public function protect(string $cpr): string {
     if ($cpr === '' || $this->isProtected($cpr)) {
@@ -84,8 +90,8 @@ class CprAccess {
       return self::PREFIX . base64_encode($this->encryption->encrypt($cpr));
     }
     catch (\Throwable $e) {
-      $this->logger->error('CPR encryption failed; value stored unencrypted: {error}', ['error' => $e->getMessage()]);
-      return $cpr;
+      $this->logger->error('CPR encryption failed; refusing to store plaintext: {error}', ['error' => $e->getMessage()]);
+      throw new \RuntimeException('CPR-kryptering er ikke konfigureret; indsendelsen blev afvist for at undgå at gemme CPR i klartekst.', 0, $e);
     }
   }
 

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
@@ -92,13 +92,14 @@ class CprAccessTest extends UnitTestCase {
   }
 
   /**
-   * A misconfigured key never silently corrupts: protect keeps the value.
+   * A misconfigured key fails hard: protect throws rather than store plaintext.
    *
    * @covers ::protect
    */
-  public function testProtectFailsSafe(): void {
+  public function testProtectFailsHardWhenEncryptionUnavailable(): void {
     $this->encryption->method('encrypt')->willThrowException(new \RuntimeException('no key'));
-    $this->assertSame('0101901234', $this->cprAccess->protect('0101901234'));
+    $this->expectException(\RuntimeException::class);
+    $this->cprAccess->protect('0101901234');
   }
 
 }

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -386,6 +386,11 @@ class SendDigitalPostAction extends AabenFormsActionBase {
       'reason_code' => $reasonCode,
       'message' => $message,
     ]);
+    // Status-token companion so an eca_scalar gate can branch on the outcome
+    // (a DTO token cannot be compared directly). A flow MUST route the case
+    // close only on '[<result_token>_status]' == 'success'; anything else
+    // leaves the case open. See the status-token contract.
+    $this->setTokenValue($name . '_status', $success ? 'success' : 'failed');
   }
 
 }

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -174,6 +174,8 @@ class SendDigitalPostActionTest extends UnitTestCase {
 
     $this->assertSame(TRUE, $writtenTokens['digital_post_result']['success']);
     $this->assertSame('tx-1', $writtenTokens['digital_post_result']['transaction_id']);
+    // The status-token companion an eca_scalar gate branches on.
+    $this->assertSame('success', $writtenTokens['digital_post_result_status']);
   }
 
   /**
@@ -220,6 +222,7 @@ class SendDigitalPostActionTest extends UnitTestCase {
 
     $this->assertSame(FALSE, $writtenTokens['digital_post_result']['success']);
     $this->assertSame('RECIPIENT_EMPTY', $writtenTokens['digital_post_result']['reason_code']);
+    $this->assertSame('failed', $writtenTokens['digital_post_result_status'], 'A failed send sets the status companion to failed so the flow does not close the case');
   }
 
   /**

--- a/web/modules/custom/aabenforms_digital_post/src/Service/Sf1601ClientFactory.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Service/Sf1601ClientFactory.php
@@ -32,7 +32,11 @@ final class Sf1601ClientFactory {
       ->get('aabenforms_digital_post.settings')
       ->get('test_mode');
     return match ($mode) {
-      'fake_db', '' => $this->fakeDbClient,
+      // Fail closed on empty/unset: a wiped or missing config must NEVER
+      // silently fall back to the fake transport (that would turn undelivered
+      // official letters into fake successes). An explicit mode is required.
+      '' => throw new DigitalPostException('Digital Post test_mode is not configured; refusing to send. Set it explicitly (fake_db in dev).'),
+      'fake_db' => $this->fakeDbClient,
       'wiremock' => $this->wireMockClient,
       'live_test', 'live' => throw new DigitalPostException(sprintf(
         'test_mode "%s" is not supported in session 1. Use fake_db or wiremock.',

--- a/web/modules/custom/aabenforms_workflows/config/install/eca.eca.caseworker_review_flow.yml
+++ b/web/modules/custom/aabenforms_workflows/config/install/eca.eca.caseworker_review_flow.yml
@@ -5,6 +5,11 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: caseworker_review_flow
 id: caseworker_review_flow
 weight: null
 template: null
@@ -12,46 +17,38 @@ events:
   both_parents_complete:
     plugin: 'content_entity:update'
     configuration:
-      type: webform_submission
+      type: 'webform_submission parent_request_form'
     successors:
-      - id: check_both_complete
-        condition: ''
+      -
+        id: caseworker_audit
+        condition: gate_ready_for_caseworker
 conditions:
-  check_both_complete:
+  gate_ready_for_caseworker:
     plugin: eca_scalar
     configuration:
-      left_value: '[webform_submission:data:parent1_status][webform_submission:data:parent2_status]'
-      operator: '=='
-      right_value: 'completecomplete'
-    successors:
-      - id: check_caseworker_pending
-        condition: 'true'
-  check_caseworker_pending:
-    plugin: eca_scalar
-    configuration:
-      left_value: '[webform_submission:data:caseworker_status]'
-      operator: '=='
-      right_value: 'pending'
-    successors:
-      - id: caseworker_audit
-        condition: 'true'
+      negate: false
+      left: '[webform_submission:values:parent1_status][webform_submission:values:parent2_status][webform_submission:values:caseworker_status]'
+      right: completecompletepending
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   caseworker_audit:
     label: 'Case Worker: Audit Assignment'
     plugin: aabenforms_audit_log
     configuration:
-      event_type_token: caseworker_review
-      user_data_token: 'Both parents approved'
-      metadata_token: 'Assigned to case worker for review'
+      event_type: caseworker_review
+      additional_data_token: 'Both parents approved'
+      message_template: 'Assigned to case worker for review'
     successors:
-      - id: mark_caseworker_assigned
+      -
+        id: mark_caseworker_assigned
         condition: ''
-
   mark_caseworker_assigned:
     label: 'Mark Case Worker Assigned'
     plugin: eca_token_set_value
     configuration:
       token_name: caseworker_status
-      token_value: 'assigned'
+      token_value: assigned
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/config/install/eca.eca.parent1_approval_flow.yml
+++ b/web/modules/custom/aabenforms_workflows/config/install/eca.eca.parent1_approval_flow.yml
@@ -5,66 +5,33 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: parent1_approval_flow
 id: parent1_approval_flow
 weight: null
 template: null
 events:
-  parent1_starts_approval:
-    plugin: 'content_entity:update'
+  on_parent1_approved:
+    plugin: 'content_entity:custom'
     configuration:
-      type: webform_submission
+      event_id: parent1_approved
+      type: 'webform_submission parent_request_form'
     successors:
-      - id: check_parent1_pending
+      -
+        id: parent1_audit
         condition: ''
-conditions:
-  check_parent1_pending:
-    plugin: eca_scalar
-    configuration:
-      left_value: '[webform_submission:data:parent1_status]'
-      operator: '=='
-      right_value: 'pending'
-    successors:
-      - id: parent1_mitid
-        condition: 'true'
+conditions: {  }
 gateways: {  }
 actions:
-  parent1_mitid:
-    label: 'Parent 1: Validate MitID'
-    plugin: aabenforms_mitid_validate
-    configuration:
-      workflow_id_token: workflow_id_parent1
-      result_token: parent1_mitid_valid
-      session_data_token: parent1_session
-    successors:
-      - id: parent1_cpr
-        condition: ''
-
-  parent1_cpr:
-    label: 'Parent 1: CPR Lookup'
-    plugin: aabenforms_cpr_lookup
-    configuration:
-      cpr_token: '[parent1_session:cpr]'
-      result_token: parent1_data
-      use_cache: true
-    successors:
-      - id: parent1_audit
-        condition: ''
-
   parent1_audit:
-    label: 'Parent 1: Audit Log'
+    label: 'Parent 1: Audit approval'
     plugin: aabenforms_audit_log
     configuration:
-      event_type_token: parent1_approval
-      user_data_token: '[parent1_data:name]'
-      metadata_token: 'Parent 1 authenticated and approved'
-    successors:
-      - id: mark_parent1_complete
-        condition: ''
-
-  mark_parent1_complete:
-    label: 'Mark Parent 1 Complete'
-    plugin: eca_token_set_value
-    configuration:
-      token_name: parent1_status
-      token_value: 'complete'
+      event_type: parent1_approval
+      additional_data_token: ''
+      message_template: 'Parent 1 approved (identity and CPR consent verified at submission).'
+      status: success
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/config/install/eca.eca.parent2_approval_flow.yml
+++ b/web/modules/custom/aabenforms_workflows/config/install/eca.eca.parent2_approval_flow.yml
@@ -5,66 +5,33 @@ dependencies:
   module:
     - aabenforms_workflows
     - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: parent2_approval_flow
 id: parent2_approval_flow
 weight: null
 template: null
 events:
-  parent2_starts_approval:
-    plugin: 'content_entity:update'
+  on_parent2_approved:
+    plugin: 'content_entity:custom'
     configuration:
-      type: webform_submission
+      event_id: parent2_approved
+      type: 'webform_submission parent_request_form'
     successors:
-      - id: check_parent2_pending
+      -
+        id: parent2_audit
         condition: ''
-conditions:
-  check_parent2_pending:
-    plugin: eca_scalar
-    configuration:
-      left_value: '[webform_submission:data:parent2_status]'
-      operator: '=='
-      right_value: 'pending'
-    successors:
-      - id: parent2_mitid
-        condition: 'true'
+conditions: {  }
 gateways: {  }
 actions:
-  parent2_mitid:
-    label: 'Parent 2: Validate MitID'
-    plugin: aabenforms_mitid_validate
-    configuration:
-      workflow_id_token: workflow_id_parent2
-      result_token: parent2_mitid_valid
-      session_data_token: parent2_session
-    successors:
-      - id: parent2_cpr
-        condition: ''
-
-  parent2_cpr:
-    label: 'Parent 2: CPR Lookup'
-    plugin: aabenforms_cpr_lookup
-    configuration:
-      cpr_token: '[parent2_session:cpr]'
-      result_token: parent2_data
-      use_cache: true
-    successors:
-      - id: parent2_audit
-        condition: ''
-
   parent2_audit:
-    label: 'Parent 2: Audit Log'
+    label: 'Parent 2: Audit approval'
     plugin: aabenforms_audit_log
     configuration:
-      event_type_token: parent2_approval
-      user_data_token: '[parent2_data:name]'
-      metadata_token: 'Parent 2 authenticated and approved'
-    successors:
-      - id: mark_parent2_complete
-        condition: ''
-
-  mark_parent2_complete:
-    label: 'Mark Parent 2 Complete'
-    plugin: eca_token_set_value
-    configuration:
-      token_name: parent2_status
-      token_value: 'complete'
+      event_type: parent2_approval
+      additional_data_token: ''
+      message_template: 'Parent 2 approved (identity and CPR consent verified at submission).'
+      status: success
     successors: {  }


### PR DESCRIPTION
Recreated after a repo history cleanup (supersedes closed #150). Entity-level lifecycle backstop, holiday-aware FristClock, FVL §19 exemption gate, OpenCase idempotency, CprAccess fail-hard, Digital Post fail-closed test_mode, friplads MitID gate, restored install-config flows. Tests + PHPStan + phpcs green.