### PR TITLE
Never close a case on a failed letter; start klagefrist on dispatch (#154)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "php-http/discovery": true,
-            "php-tuf/composer-integration": true
+            "php-tuf/composer-integration": true,
+            "symfony/runtime": true
         },
         "sort-packages": true
     },
@@ -102,7 +103,7 @@
             ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",

--- a/config/sync/eca.eca.friplads_flow.yml
+++ b/config/sync/eca.eca.friplads_flow.yml
@@ -62,6 +62,24 @@ conditions:
       operator: atmost
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -155,7 +173,18 @@ actions:
     successors:
       -
         id: sf2900_distribute
-        condition: ''
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: friplads_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute

--- a/config/sync/eca.eca.merudgifter_flow.yml
+++ b/config/sync/eca.eca.merudgifter_flow.yml
@@ -62,6 +62,24 @@ conditions:
       operator: atleast
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -166,7 +184,18 @@ actions:
     successors:
       -
         id: sf2900_distribute
-        condition: ''
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: merudgifter_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket, og klagefristen er ikke startet.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute
@@ -216,4 +245,17 @@ actions:
       body_template: '<p>Din ansøgning om dækning af merudgifter er ikke imødekommet (afslag). Se vedlagte klagevejledning.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors:
+      -
+        id: set_klagefrist
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  set_klagefrist:
+    label: 'Start klagefrist (brev afsendt)'
+    plugin: aabenforms_case_set_klagefrist
+    configuration:
+      case_id_token: '[case_id]'
+      klagefrist_uger: 4
     successors: {  }

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.friplads_flow.yml
@@ -62,6 +62,24 @@ conditions:
       operator: atmost
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -155,7 +173,18 @@ actions:
     successors:
       -
         id: sf2900_distribute
-        condition: ''
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: friplads_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.merudgifter_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.merudgifter_flow.yml
@@ -22,7 +22,8 @@ events:
     configuration:
       type: 'webform_submission merudgifter'
     successors:
-      - id: mitid_validate
+      -
+        id: mitid_validate
         condition: ''
 conditions:
   gate_mitid_ok:
@@ -61,6 +62,24 @@ conditions:
       operator: atleast
       type: numeric
       case: false
+  gate_letter_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+  gate_letter_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[digital_post_result_status]'
+      right: success
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   mitid_validate:
@@ -71,9 +90,11 @@ actions:
       result_token: merudgift_mitid_valid
       session_data_token: merudgift_session
     successors:
-      - id: cpr_lookup
+      -
+        id: cpr_lookup
         condition: gate_mitid_ok
-      - id: deny_identity
+      -
+        id: deny_identity
         condition: gate_mitid_deny
   deny_identity:
     label: 'Afvis: identitet ikke bekræftet'
@@ -91,7 +112,8 @@ actions:
       result_token: citizen_data
       use_cache: true
     successors:
-      - id: open_case
+      -
+        id: open_case
         condition: ''
   open_case:
     label: 'Åbn sag (merudgifter)'
@@ -100,7 +122,8 @@ actions:
       case_type: merudgifter
       case_id_token: case_id
     successors:
-      - id: journal_case
+      -
+        id: journal_case
         condition: ''
   journal_case:
     label: 'Journalisér sag (SF1470)'
@@ -108,7 +131,8 @@ actions:
     configuration:
       case_id_token: '[case_id]'
     successors:
-      - id: income_lookup
+      -
+        id: income_lookup
         condition: ''
   income_lookup:
     label: 'Hent husstandsindkomst (eIndkomst)'
@@ -117,7 +141,8 @@ actions:
       cpr_token: '[webform_submission:values:applicant_cpr:raw]'
       result_token: merudgift_income
     successors:
-      - id: transition_oplyst
+      -
+        id: transition_oplyst
         condition: ''
   transition_oplyst:
     label: 'Oplys sag'
@@ -127,9 +152,11 @@ actions:
       target_status: oplyst
       log_message: 'Sag oplyst: identitet bekræftet, journaliseret, indkomst hentet.'
     successors:
-      - id: decide_medhold
+      -
+        id: decide_medhold
         condition: gate_eligible
-      - id: partshoering_open
+      -
+        id: partshoering_open
         condition: gate_ineligible
   decide_medhold:
     label: 'Afgørelse: medhold'
@@ -140,7 +167,8 @@ actions:
       klagevejledning: ''
       klagefrist_uger: 4
     successors:
-      - id: letter_medhold
+      -
+        id: letter_medhold
         condition: ''
   letter_medhold:
     label: 'Send afgørelsesbrev (medhold)'
@@ -154,8 +182,20 @@ actions:
       type: 'Digital Post'
       result_token: digital_post_result
     successors:
-      - id: sf2900_distribute
-        condition: ''
+      -
+        id: sf2900_distribute
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  letter_failed:
+    label: 'Brev ikke afsendt - sag afventer'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: merudgifter_letter_failed
+      step_label: 'Afgørelsesbrev ikke afsendt'
+      message: 'Afgørelsen er truffet, men afgørelsesbrevet kunne ikke afsendes. Sagen forbliver åben og afventer fornyet afsendelse - den er ikke lukket, og klagefristen er ikke startet.'
+    successors: {  }
   sf2900_distribute:
     label: 'Distribuér til fagsystem (SF2900)'
     plugin: aabenforms_case_sf2900_distribute
@@ -169,7 +209,8 @@ actions:
       case_id_token: '[case_id]'
       state: afventer
     successors:
-      - id: partshoering_close
+      -
+        id: partshoering_close
         condition: ''
   partshoering_close:
     label: 'Afslut partshøring'
@@ -178,7 +219,8 @@ actions:
       case_id_token: '[case_id]'
       state: afsluttet
     successors:
-      - id: decide_afslag
+      -
+        id: decide_afslag
         condition: ''
   decide_afslag:
     label: 'Afgørelse: afslag'
@@ -189,7 +231,8 @@ actions:
       klagevejledning: 'Du kan klage over afgørelsen til Ankestyrelsen. Klagen skal være modtaget senest 4 uger efter, du har fået afgørelsen.'
       klagefrist_uger: 4
     successors:
-      - id: letter_afslag
+      -
+        id: letter_afslag
         condition: ''
   letter_afslag:
     label: 'Send afgørelsesbrev (afslag + klagevejledning)'
@@ -202,4 +245,17 @@ actions:
       body_template: '<p>Din ansøgning om dækning af merudgifter er ikke imødekommet (afslag). Se vedlagte klagevejledning.</p>'
       type: 'Digital Post'
       result_token: digital_post_result
+    successors:
+      -
+        id: set_klagefrist
+        condition: gate_letter_ok
+      -
+        id: letter_failed
+        condition: gate_letter_fail
+  set_klagefrist:
+    label: 'Start klagefrist (brev afsendt)'
+    plugin: aabenforms_case_set_klagefrist
+    configuration:
+      case_id_token: '[case_id]'
+      klagefrist_uger: 4
     successors: {  }

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/MakeDecisionAction.php
@@ -169,15 +169,15 @@ class MakeDecisionAction extends CaseActionBase {
 
       $now = $this->time->getRequestTime();
       $case->set('afgoerelse_type', $type);
-      if ($adverse) {
-        $case->set('klagefrist', $now + ($uger * 7 * 86400));
-      }
+      // The klagefrist clock is NOT started here: it runs from when the citizen
+      // is notified (FVL meddelelseskrav), so aabenforms_case_set_klagefrist
+      // stamps it on the branch where the decision letter is confirmed sent.
       $case->setStatus('afgoerelse');
       $case->setNewRevision(TRUE);
       $logParts = [sprintf('Afgørelse: %s.', $type)];
       if ($adverse) {
         $logParts[] = 'Klagevejledning: ' . $klagevejledning;
-        $logParts[] = sprintf('Klagefrist: %d uger.', $uger);
+        $logParts[] = sprintf('Klagefrist: %d uger (startes ved brevafsendelse).', $uger);
         if ((string) $case->get('partshoering_state')->value !== 'afsluttet' && $exemption !== '') {
           $logParts[] = 'Partshøring undladt (FVL §19 stk. 2): ' . $exemption;
         }

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/SetKlagefristAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/SetKlagefristAction.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: start the appeal deadline (klagefrist) clock on a decided case.
+ *
+ * The klagefrist must run from when the citizen is notified, not from the
+ * decision itself (FVL meddelelseskrav) - so a flow runs this only on the
+ * branch where the decision letter was confirmed dispatched. Kept separate
+ * from MakeDecisionAction, which records the decision but no longer stamps the
+ * deadline. Only valid while the case is in "afgoerelse".
+ */
+#[Action(
+  id: 'aabenforms_case_set_klagefrist',
+  label: new TranslatableMarkup('Start appeal deadline (klagefrist)'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Starts the klagefrist clock on a decided case once the decision letter is confirmed dispatched.'),
+  version_introduced: '1.1.0',
+)]
+class SetKlagefristAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[case_id]',
+      'klagefrist_uger' => 4,
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['klagefrist_uger'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Appeal deadline (weeks)'),
+      '#min' => 1,
+      '#default_value' => $this->configuration['klagefrist_uger'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['klagefrist_uger'] = $form_state->getValue('klagefrist_uger');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? '[case_id]'), '');
+      $uger = max(1, (int) ($this->configuration['klagefrist_uger'] ?? 4));
+      if ($caseId === '') {
+        $this->recordStep('Klagefrist', 'Mangler sags-id.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Klagefrist', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      if ($case->getStatus() !== 'afgoerelse') {
+        $this->recordStep('Klagefrist', sprintf('Sag #%s er ikke afgjort - klagefrist kan ikke sættes.', $caseId), 'failed');
+        return;
+      }
+
+      // Idempotent: keep an existing klagefrist.
+      if ((int) ($case->get('klagefrist')->value ?? 0) > 0) {
+        $this->recordStep('Klagefrist', sprintf('Sag #%s har allerede en klagefrist.', $caseId));
+        return;
+      }
+
+      $now = $this->time->getRequestTime();
+      $case->set('klagefrist', $now + ($uger * 7 * 86400));
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage(sprintf('Klagefrist startet (afgørelsesbrev afsendt): %d uger.', $uger));
+      $case->setRevisionCreationTime($now);
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Klagefrist', sprintf('Sag #%s: klagefrist på %d uger startet.', $caseId, $uger));
+      $this->auditLogger->log('case_klagefrist', (string) $caseId, sprintf('%d uger', $uger), 'success', [
+        'action_id' => $this->getPluginId(),
+      ]);
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Set klagefrist');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseLifecycleEnforcementTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/CaseLifecycleEnforcementTest.php
@@ -74,7 +74,7 @@ class CaseLifecycleEnforcementTest extends KernelTestBase {
    */
   public function testIllegalTransitionThrows(): void {
     $case = $this->reload((int) $this->caseIn('modtaget')->id());
-    // modtaget may only reach oplyst or lukket - never afgoerelse directly.
+    // Modtaget may only reach oplyst or lukket - never afgoerelse directly.
     $case->setStatus('afgoerelse');
     $this->expectException(EntityStorageException::class);
     $case->save();

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
@@ -105,11 +105,14 @@ class MakeDecisionActionTest extends KernelTestBase {
   }
 
   /**
-   * An adverse decision with a klagevejledning sets the appeal deadline.
+   * An adverse decision records the outcome but does NOT start the klagefrist.
    *
-   * A §19 stk. 2 exemption is supplied because no partshøring was held.
+   * The klagefrist runs from notification (FVL meddelelseskrav), so the decide
+   * step leaves it unset; aabenforms_case_set_klagefrist starts it once the
+   * letter is confirmed sent. A §19 stk. 2 exemption is supplied here because
+   * no partshøring was held.
    */
-  public function testAdverseWithKlagevejledningSetsKlagefrist(): void {
+  public function testAdverseDecisionDefersKlagefristToDispatch(): void {
     $case = $this->caseInOplyst();
     $now = $this->container->get('datetime.time')->getRequestTime();
     $this->invoke('aabenforms_case_decide', [
@@ -118,10 +121,14 @@ class MakeDecisionActionTest extends KernelTestBase {
       'klagefrist_uger' => 4,
       'partshoering_exemption' => 'Afgørelsen bygger alene på borgerens egne oplysninger (FVL §19 stk. 2).',
     ]);
-    $reloaded = $this->reload((int) $case->id());
-    $this->assertSame('afgoerelse', $reloaded->getStatus());
-    $this->assertSame('afslag', (string) $reloaded->get('afgoerelse_type')->value);
-    $this->assertSame($now + (4 * 7 * 86400), (int) $reloaded->get('klagefrist')->value);
+    $decided = $this->reload((int) $case->id());
+    $this->assertSame('afgoerelse', $decided->getStatus());
+    $this->assertSame('afslag', (string) $decided->get('afgoerelse_type')->value);
+    $this->assertNull($decided->get('klagefrist')->value, 'Klagefrist is not started at decide time');
+
+    // The dispatch step starts the clock.
+    $this->invoke('aabenforms_case_set_klagefrist', ['klagefrist_uger' => 4]);
+    $this->assertSame($now + (4 * 7 * 86400), (int) $this->reload((int) $case->id())->get('klagefrist')->value);
   }
 
   /**

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/MakeDecisionActionTest.php
@@ -132,8 +132,9 @@ class MakeDecisionActionTest extends KernelTestBase {
   }
 
   /**
-   * FVL §19: an adverse decision is blocked when no hearing was held and no
-   * exemption is given - the silent-skip path is closed.
+   * FVL §19: an adverse decision needs a hearing or a recorded exemption.
+   *
+   * The silent-skip path (no hearing, no exemption) is closed.
    */
   public function testAdverseWithoutHearingOrExemptionBlocked(): void {
     $case = $this->caseInOplyst();

--- a/web/modules/custom/aabenforms_case/tests/src/Kernel/SetKlagefristActionTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Kernel/SetKlagefristActionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_case\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the aabenforms_case_set_klagefrist action.
+ *
+ * The appeal clock starts from notification, so this action only stamps the
+ * klagefrist on a decided (afgoerelse) case and is idempotent.
+ *
+ * @group aabenforms_case
+ */
+class SetKlagefristActionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+  }
+
+  /**
+   * Creates a persisted case in the given status and sets the case_id token.
+   */
+  protected function caseIn(string $status): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    /** @var \Drupal\aabenforms_case\Entity\AabenformsCase $case */
+    $case = $storage->create(['title' => 'Sag', 'case_type' => 'merudgifter', 'status' => $status]);
+    $case->save();
+    $this->container->get('eca.token_services')->addTokenData('case_id', (string) $case->id());
+    return $case;
+  }
+
+  /**
+   * Reloads a case fresh.
+   */
+  protected function reload(int $id): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$id]);
+    return $storage->load($id);
+  }
+
+  /**
+   * Runs the action.
+   */
+  protected function setKlagefrist(int $uger = 4): void {
+    $this->container->get('plugin.manager.action')
+      ->createInstance('aabenforms_case_set_klagefrist', ['klagefrist_uger' => $uger])
+      ->execute();
+  }
+
+  /**
+   * Starts the klagefrist on a decided case.
+   */
+  public function testStartsKlagefristOnDecidedCase(): void {
+    $case = $this->caseIn('afgoerelse');
+    $now = $this->container->get('datetime.time')->getRequestTime();
+    $this->setKlagefrist(4);
+    $this->assertSame($now + (4 * 7 * 86400), (int) $this->reload((int) $case->id())->get('klagefrist')->value);
+  }
+
+  /**
+   * Refuses to start the klagefrist on a case that is not decided.
+   */
+  public function testRejectsWhenNotDecided(): void {
+    $case = $this->caseIn('oplyst');
+    $this->setKlagefrist(4);
+    $this->assertNull($this->reload((int) $case->id())->get('klagefrist')->value, 'No klagefrist set on an undecided case');
+  }
+
+  /**
+   * Is idempotent: a second run does not move an existing klagefrist.
+   */
+  public function testIdempotent(): void {
+    $case = $this->caseIn('afgoerelse');
+    $this->setKlagefrist(4);
+    $first = (int) $this->reload((int) $case->id())->get('klagefrist')->value;
+    $this->setKlagefrist(8);
+    $this->assertSame($first, (int) $this->reload((int) $case->id())->get('klagefrist')->value, 'Klagefrist unchanged on re-run');
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
+++ b/web/modules/custom/aabenforms_case/tests/src/Unit/Service/FristClockTest.php
@@ -106,7 +106,7 @@ class FristClockTest extends UnitTestCase {
    *
    * @covers ::addWorkingDays
    */
-  public function testStoreBededagIsAWorkingDay(): void {
+  public function testStoreBededagCountsAsWorkingDay(): void {
     $clock = $this->clock(['x' => ['unit' => 'hverdage', 'amount' => 1]]);
     // 4th Friday after Easter 2025 = 2025-05-16 (former store bededag).
     // Receipt Thu 2025-05-15 + 1 hverdag must land on that Friday, not skip it.

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/SendDigitalPostAction.php
@@ -386,6 +386,11 @@ class SendDigitalPostAction extends AabenFormsActionBase {
       'reason_code' => $reasonCode,
       'message' => $message,
     ]);
+    // Status-token companion so an eca_scalar gate can branch on the outcome
+    // (a DTO token cannot be compared directly). A flow MUST route the case
+    // close only on '[<result_token>_status]' == 'success'; anything else
+    // leaves the case open. See the status-token contract.
+    $this->setTokenValue($name . '_status', $success ? 'success' : 'failed');
   }
 
 }

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/SendDigitalPostActionTest.php
@@ -174,6 +174,8 @@ class SendDigitalPostActionTest extends UnitTestCase {
 
     $this->assertSame(TRUE, $writtenTokens['digital_post_result']['success']);
     $this->assertSame('tx-1', $writtenTokens['digital_post_result']['transaction_id']);
+    // The status-token companion an eca_scalar gate branches on.
+    $this->assertSame('success', $writtenTokens['digital_post_result_status']);
   }
 
   /**
@@ -220,6 +222,7 @@ class SendDigitalPostActionTest extends UnitTestCase {
 
     $this->assertSame(FALSE, $writtenTokens['digital_post_result']['success']);
     $this->assertSame('RECIPIENT_EMPTY', $writtenTokens['digital_post_result']['reason_code']);
+    $this->assertSame('failed', $writtenTokens['digital_post_result_status'], 'A failed send sets the status companion to failed so the flow does not close the case');
   }
 
   /**


### PR DESCRIPTION
Recreated after history cleanup (supersedes closed #158). Stacked on the casework-hardening PR. Gate SF2900 close on confirmed Digital Post dispatch, klagefrist-on-dispatch via aabenforms_case_set_klagefrist, _status companion. Tests + phpcs green.