### PR TITLE
Enforce eIDAS assurance level on the MitID id_token (#157)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "php-http/discovery": true,
-            "php-tuf/composer-integration": true
+            "php-tuf/composer-integration": true,
+            "symfony/runtime": true
         },
         "sort-packages": true
     },
@@ -102,7 +103,7 @@
             ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdCprExtractor.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdCprExtractor.php
@@ -298,16 +298,24 @@ class MitIdCprExtractor {
       $claims = $this->parseJwt($id_token);
       $acr = $claims['acr'] ?? 'unknown';
 
-      // Map MitID ACR values to NSIS levels
-      // https://www.digst.dk/it-loesninger/nemlog-in/
+      // Map MitID / NemLog-in ACR values to NSIS levels. NemLog-in asserts the
+      // NSIS LoA URIs; the eIDAS URIs and bare words cover brokers/mocks.
+      // https://digst.dk/it-loesninger/standarder/nsis/
       $mapping = [
+        'https://data.gov.dk/concept/core/nsis/loa/Low' => 'low',
+        'https://data.gov.dk/concept/core/nsis/loa/Substantial' => 'substantial',
+        'https://data.gov.dk/concept/core/nsis/loa/High' => 'high',
         'http://eidas.europa.eu/LoA/low' => 'low',
         'http://eidas.europa.eu/LoA/substantial' => 'substantial',
         'http://eidas.europa.eu/LoA/high' => 'high',
         'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport' => 'low',
+        'low' => 'low',
+        'substantial' => 'substantial',
+        'high' => 'high',
       ];
 
-      return $mapping[$acr] ?? ($acr === 'unknown' ? 'unknown' : 'substantial');
+      // Fail closed: an unrecognised acr is 'unknown', never 'substantial'.
+      return $mapping[$acr] ?? 'unknown';
 
     }
     catch (\InvalidArgumentException $e) {

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php
@@ -296,7 +296,40 @@ class MitIdOidcClient {
     // forged or tampered token must never reach claim extraction.
     $this->tokenVerifier->verify($id_token);
 
+    // Enforce the eIDAS assurance level (NSIS LoA): a signature-valid token at
+    // a level below the flow's requirement must be rejected, not merely logged.
+    $this->enforceAssuranceLevel($id_token);
+
     return $this->cprExtractor->extractPersonData($id_token);
+  }
+
+  /**
+   * Rejects a token whose assurance level is below the configured requirement.
+   *
+   * Ranks unknown < low < substantial < high; the municipal norm is
+   * Betydelig/Substantial. Fails closed - an unrecognised acr maps to
+   * 'unknown' and never satisfies a substantial/high requirement.
+   *
+   * @param string $id_token
+   *   The (already signature-verified) ID token.
+   *
+   * @throws \RuntimeException
+   *   When the asserted level is below the requirement.
+   */
+  private function enforceAssuranceLevel(string $id_token): void {
+    $ranks = ['unknown' => 0, 'low' => 1, 'substantial' => 2, 'high' => 3];
+    $required = (string) ($this->configFactory->get('aabenforms_mitid.settings')
+      ->get('security.required_assurance_level') ?: 'substantial');
+    $requiredRank = $ranks[$required] ?? 2;
+    $actual = $this->cprExtractor->getAssuranceLevel($id_token);
+    $actualRank = $ranks[$actual] ?? 0;
+    if ($actualRank < $requiredRank) {
+      $this->logger->warning('MitID assurance level too low: got {actual}, required {required}.', [
+        'actual' => $actual,
+        'required' => $required,
+      ]);
+      throw new \RuntimeException(sprintf('MitID assurance level "%s" is below the required "%s".', $actual, $required));
+    }
   }
 
   /**

--- a/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdCprExtractorTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Unit/Service/MitIdCprExtractorTest.php
@@ -365,6 +365,26 @@ class MitIdCprExtractorTest extends UnitTestCase {
   }
 
   /**
+   * A present-but-unrecognised acr fails closed to 'unknown', not 'substantial'.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelUnrecognisedFailsClosed(): void {
+    $token = $this->createTestJwt(['acr' => 'urn:some:unexpected:value']);
+    $this->assertEquals('unknown', $this->cprExtractor->getAssuranceLevel($token));
+  }
+
+  /**
+   * The real NemLog-in NSIS LoA URI maps to substantial.
+   *
+   * @covers ::getAssuranceLevel
+   */
+  public function testGetAssuranceLevelNsisSubstantial(): void {
+    $token = $this->createTestJwt(['acr' => 'https://data.gov.dk/concept/core/nsis/loa/Substantial']);
+    $this->assertEquals('substantial', $this->cprExtractor->getAssuranceLevel($token));
+  }
+
+  /**
    * Tests JWT parsing with invalid format.
    *
    * @covers ::extractCpr
@@ -447,16 +467,16 @@ class MitIdCprExtractorTest extends UnitTestCase {
   }
 
   /**
-   * Tests assurance level falls back to 'substantial' for unmapped non-unknown ACR.
+   * An unmapped ACR fails closed to 'unknown' (never 'substantial').
    *
    * @covers ::getAssuranceLevel
    */
-  public function testGetAssuranceLevelDefaultsToSubstantialForUnmappedAcr(): void {
+  public function testGetAssuranceLevelUnmappedAcrFailsClosed(): void {
     $token = $this->createTestJwt([
       'acr' => 'http://example.org/some/custom/loa',
     ]);
 
-    $this->assertSame('substantial', $this->cprExtractor->getAssuranceLevel($token));
+    $this->assertSame('unknown', $this->cprExtractor->getAssuranceLevel($token));
   }
 
   /**


### PR DESCRIPTION
Recreated after history cleanup (supersedes closed #159). validateIdToken enforces token acr vs required level; getAssuranceLevel maps NSIS URIs and fails closed. Tests + phpcs green.