### PR TITLE
Bind klage_flow to case ownership; only a party may appeal (#153)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "php-http/discovery": true,
-            "php-tuf/composer-integration": true
+            "php-tuf/composer-integration": true,
+            "symfony/runtime": true
         },
         "sort-packages": true
     },
@@ -102,7 +103,7 @@
             ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",

--- a/config/sync/eca.eca.klage_flow.yml
+++ b/config/sync/eca.eca.klage_flow.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - aabenforms_case
+    - aabenforms_workflows
     - eca_content
     - modeler_api
 third_party_settings:
@@ -20,15 +21,95 @@ events:
       type: 'webform_submission klage'
     successors:
       -
-        id: appeal_case
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[klage_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[klage_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_owner_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[appeal_ownership_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_owner_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[appeal_ownership_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validér MitID-session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_klage
+      result_token: klage_mitid_valid
+      session_data_token: klage_session
+    successors:
+      -
+        id: verify_ownership
+        condition: gate_mitid_ok
+      -
+        id: deny_identity
+        condition: gate_mitid_deny
+  verify_ownership:
+    label: 'Verificér klageberettigelse'
+    plugin: aabenforms_verify_appeal_ownership
+    configuration:
+      case_id_token: '[webform_submission:values:case_id]'
+      workflow_id_token: workflow_id_klage
+      result_token: appeal_ownership
+    successors:
+      -
+        id: appeal_case
+        condition: gate_owner_ok
+      -
+        id: deny_ownership
+        condition: gate_owner_deny
   appeal_case:
     label: 'Registrér klage (genvurdering)'
     plugin: aabenforms_case_appeal
     configuration:
       case_id_token: '[webform_submission:values:case_id]'
       grounds_token: '[webform_submission:values:klage_begrundelse]'
+    successors: {  }
+  deny_identity:
+    label: 'Afvis: identitet ikke bekræftet'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: klage_denied_identity
+      step_label: 'Identitet ikke bekræftet'
+      message: 'Klagen blev ikke behandlet, fordi din identitet ikke kunne bekræftes med MitID. Log ind med MitID og prøv igen.'
+    successors: {  }
+  deny_ownership:
+    label: 'Afvis: ikke klageberettiget'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: klage_denied_ownership
+      step_label: 'Ikke part i sagen'
+      message: 'Klagen blev ikke behandlet, fordi du ikke er part i den angivne sag. Kun sagens part kan klage over afgørelsen.'
     successors: {  }

--- a/web/modules/custom/aabenforms_case/config/install/eca.eca.klage_flow.yml
+++ b/web/modules/custom/aabenforms_case/config/install/eca.eca.klage_flow.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - aabenforms_case
+    - aabenforms_workflows
     - eca_content
     - modeler_api
 third_party_settings:
@@ -19,15 +20,96 @@ events:
     configuration:
       type: 'webform_submission klage'
     successors:
-      - id: appeal_case
+      -
+        id: mitid_validate
         condition: ''
-conditions: {  }
+conditions:
+  gate_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[klage_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[klage_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_owner_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[appeal_ownership_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_owner_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[appeal_ownership_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
+  mitid_validate:
+    label: 'Validér MitID-session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_klage
+      result_token: klage_mitid_valid
+      session_data_token: klage_session
+    successors:
+      -
+        id: verify_ownership
+        condition: gate_mitid_ok
+      -
+        id: deny_identity
+        condition: gate_mitid_deny
+  verify_ownership:
+    label: 'Verificér klageberettigelse'
+    plugin: aabenforms_verify_appeal_ownership
+    configuration:
+      case_id_token: '[webform_submission:values:case_id]'
+      workflow_id_token: workflow_id_klage
+      result_token: appeal_ownership
+    successors:
+      -
+        id: appeal_case
+        condition: gate_owner_ok
+      -
+        id: deny_ownership
+        condition: gate_owner_deny
   appeal_case:
     label: 'Registrér klage (genvurdering)'
     plugin: aabenforms_case_appeal
     configuration:
       case_id_token: '[webform_submission:values:case_id]'
       grounds_token: '[webform_submission:values:klage_begrundelse]'
+    successors: {  }
+  deny_identity:
+    label: 'Afvis: identitet ikke bekræftet'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: klage_denied_identity
+      step_label: 'Identitet ikke bekræftet'
+      message: 'Klagen blev ikke behandlet, fordi din identitet ikke kunne bekræftes med MitID. Log ind med MitID og prøv igen.'
+    successors: {  }
+  deny_ownership:
+    label: 'Afvis: ikke klageberettiget'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: klage_denied_ownership
+      step_label: 'Ikke part i sagen'
+      message: 'Klagen blev ikke behandlet, fordi du ikke er part i den angivne sag. Kun sagens part kan klage over afgørelsen.'
     successors: {  }

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -40,6 +40,15 @@ services:
       - '@logger.factory'
       - '@aabenforms_core.cpr_access'
 
+  aabenforms_workflows.appeal_ownership_verifier:
+    class: Drupal\aabenforms_workflows\Service\AppealOwnershipVerifier
+    arguments:
+      - '@aabenforms_mitid.session_manager'
+      - '@aabenforms_core.audit_logger'
+      - '@logger.factory'
+      - '@aabenforms_core.cpr_access'
+      - '@entity_type.manager'
+
   aabenforms_workflows.payment_service:
     class: Drupal\aabenforms_workflows\Service\PaymentService
     arguments:

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/VerifyAppealOwnershipAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/VerifyAppealOwnershipAction.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_workflows\Service\AppealOwnershipVerifier;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * ECA Action: verify that the MitID appellant is a party to the case.
+ *
+ * Gate a klage (appeal) flow on this before aabenforms_case_appeal: it compares
+ * the verified MitID session CPR against the case's original applicant CPR and
+ * writes a `<result_token>_status` scalar (`verified`/`failed`) to gate on.
+ * Fails closed - a missing session, an unresolved case, or a mismatch all
+ * produce `failed` so an attacker cannot appeal a stranger's case by id.
+ */
+#[Action(
+  id: 'aabenforms_verify_appeal_ownership',
+  label: new TranslatableMarkup('Verify appeal ownership'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Verifies the MitID appellant is a party to the case before an appeal is lodged.'),
+  version_introduced: '1.1.0',
+)]
+class VerifyAppealOwnershipAction extends AabenFormsActionBase {
+
+  /**
+   * The request-attribute key the SPA rides the workflow id on.
+   */
+  protected const REQUEST_WORKFLOW_ATTR = 'aabenforms_workflow_id';
+
+  /**
+   * The browser-session key a same-origin login binds the workflow id to.
+   */
+  protected const SESSION_WORKFLOW_KEY = 'mitid_workflow_id';
+
+  /**
+   * The ownership verifier.
+   */
+  protected AppealOwnershipVerifier $verifier;
+
+  /**
+   * The request stack.
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->verifier = $container->get('aabenforms_workflows.appeal_ownership_verifier');
+    $instance->requestStack = $container->get('request_stack');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => '[webform_submission:values:case_id]',
+      'workflow_id_token' => 'workflow_id_klage',
+      'result_token' => 'appeal_ownership',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['workflow_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Workflow id token'),
+      '#default_value' => $this->configuration['workflow_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['workflow_id_token'] = $form_state->getValue('workflow_id_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? 'appeal_ownership');
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? ''), '');
+      $workflowId = $this->resolveWorkflowId();
+
+      if ($caseId === '') {
+        $this->denied($resultToken, 'Mangler sags-id.');
+        return;
+      }
+
+      $result = $this->verifier->verify($caseId, $workflowId);
+      if ($result === AppealOwnershipVerifier::RESULT_MATCH) {
+        $this->setTokenValue($resultToken, TRUE);
+        $this->setTokenValue($resultToken . '_status', 'verified');
+        $this->recordStep('Klageberettigelse', 'Klager er part i sagen (MitID-verificeret).');
+        return;
+      }
+      $this->denied($resultToken, sprintf('Klager er ikke part i sagen (%s).', $result));
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Verify appeal ownership');
+      $this->setTokenValue($resultToken, FALSE);
+      $this->setTokenValue($resultToken . '_status', 'failed');
+    }
+  }
+
+  /**
+   * Records a fail-closed denial.
+   */
+  protected function denied(string $resultToken, string $message): void {
+    $this->setTokenValue($resultToken, FALSE);
+    $this->setTokenValue($resultToken . '_status', 'failed');
+    $this->recordStep('Klageberettigelse afvist', $message, 'failed');
+  }
+
+  /**
+   * Resolves the workflow id (configured token, then SPA payload, then session).
+   */
+  protected function resolveWorkflowId(): string {
+    $workflowId = $this->getTokenValue((string) ($this->configuration['workflow_id_token'] ?? 'workflow_id'), '');
+    if ($workflowId !== '') {
+      return $workflowId;
+    }
+    $request = $this->requestStack->getCurrentRequest();
+    if ($request) {
+      $fromRequest = $request->attributes->get(self::REQUEST_WORKFLOW_ATTR)
+        ?? $request->query->get('workflow_id');
+      if (is_string($fromRequest) && $fromRequest !== '') {
+        return $fromRequest;
+      }
+      $session = $request->getSession();
+      if ($session && $session->isStarted()) {
+        $bound = $session->get(self::SESSION_WORKFLOW_KEY);
+        if (is_string($bound) && $bound !== '') {
+          return $bound;
+        }
+      }
+    }
+    return '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Service/AppealOwnershipVerifier.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/AppealOwnershipVerifier.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Verifies that the MitID-authenticated appellant is a party to the case.
+ *
+ * A klage (appeal) must only be lodgeable by someone who is party to the case.
+ * The authoritative applicant CPR is the one on the case's ORIGINAL submission
+ * (encrypted at rest) - never the self-reported CPR on the klage form. This
+ * compares the verified MitID session CPR against that, constant-time, and
+ * fails closed on any doubt. Mirrors ParentCprVerifier.
+ */
+class AppealOwnershipVerifier {
+
+  /**
+   * The appellant's MitID CPR matches the case applicant.
+   */
+  public const RESULT_MATCH = 'match';
+
+  /**
+   * The appellant's MitID CPR does not match the case applicant.
+   */
+  public const RESULT_MISMATCH = 'mismatch';
+
+  /**
+   * The MitID session carries no CPR (upstream IdP failure / no session).
+   */
+  public const RESULT_MISSING_MITID_CPR = 'missing_mitid_cpr';
+
+  /**
+   * The case (or its submission's applicant CPR) could not be resolved.
+   */
+  public const RESULT_MISSING_EXPECTED_CPR = 'missing_expected_cpr';
+
+  public function __construct(
+    protected MitIdSessionManager $sessionManager,
+    protected AuditLogger $auditLogger,
+    LoggerChannelFactoryInterface $logger_factory,
+    protected CprAccess $cprAccess,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    $this->logger = $logger_factory->get('aabenforms_workflows');
+  }
+
+  /**
+   * The logger channel.
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Verifies appeal ownership.
+   *
+   * @param string $case_id
+   *   The case being appealed.
+   * @param string $workflow_id
+   *   The MitID workflow id; used to read the asserted CPR from the session.
+   *
+   * @return string
+   *   One of the RESULT_* constants.
+   */
+  public function verify(string $case_id, string $workflow_id): string {
+    $asserted = $this->normaliseCpr((string) ($this->sessionManager->getCprFromSession($workflow_id) ?? ''));
+    if ($asserted === '') {
+      $this->logger->warning('Appeal blocked: MitID session lacks a CPR claim (case @cid, workflow @wid).', [
+        '@cid' => $case_id,
+        '@wid' => $workflow_id,
+      ]);
+      $this->auditLogger->logWorkflowAccess($workflow_id, 'appeal_cpr_missing', 'failure', ['case_id' => $case_id]);
+      return self::RESULT_MISSING_MITID_CPR;
+    }
+
+    $expected = $this->normaliseCpr($this->caseApplicantCpr($case_id));
+    if ($expected === '') {
+      $this->logger->error('Appeal blocked: case @cid has no resolvable applicant CPR.', ['@cid' => $case_id]);
+      $this->auditLogger->logCprLookup($asserted, 'appeal_expected_cpr_missing', 'failure', [
+        'case_id' => $case_id,
+        'workflow_id' => $workflow_id,
+      ]);
+      return self::RESULT_MISSING_EXPECTED_CPR;
+    }
+
+    if (!hash_equals($expected, $asserted)) {
+      $this->logger->warning('Appeal blocked: MitID CPR does not match the case applicant (case @cid).', ['@cid' => $case_id]);
+      $this->auditLogger->logCprLookup($asserted, 'appeal_ownership_mismatch', 'failure', [
+        'case_id' => $case_id,
+        'workflow_id' => $workflow_id,
+      ]);
+      return self::RESULT_MISMATCH;
+    }
+
+    $this->auditLogger->logCprLookup($asserted, 'appeal_ownership_verified', 'success', [
+      'case_id' => $case_id,
+      'workflow_id' => $workflow_id,
+    ]);
+    return self::RESULT_MATCH;
+  }
+
+  /**
+   * Reads and decrypts the applicant CPR from the case's original submission.
+   */
+  protected function caseApplicantCpr(string $case_id): string {
+    $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($case_id);
+    if ($case === NULL || !method_exists($case, 'getSubmissionId')) {
+      return '';
+    }
+    $submissionId = $case->getSubmissionId();
+    if ($submissionId === NULL) {
+      return '';
+    }
+    $submission = $this->entityTypeManager->getStorage('webform_submission')->load($submissionId);
+    if ($submission === NULL || !method_exists($submission, 'getElementData')) {
+      return '';
+    }
+    // The application forms store the citizen CPR as applicant_cpr (or cpr),
+    // encrypted at rest.
+    $raw = (string) ($submission->getElementData('applicant_cpr') ?? $submission->getElementData('cpr') ?? '');
+    return $this->cprAccess->reveal($raw);
+  }
+
+  /**
+   * Strips non-digits so encrypted vs session CPRs compare cleanly.
+   */
+  protected function normaliseCpr(string $cpr): string {
+    return preg_replace('/[^0-9]/', '', $cpr) ?? '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/AppealOwnershipVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/AppealOwnershipVerifierTest.php
@@ -24,8 +24,10 @@ use Psr\Log\LoggerInterface;
 class AppealOwnershipVerifierTest extends UnitTestCase {
 
   /**
-   * Builds a verifier where the session returns $sessionCpr and the case's
-   * submission holds $caseCpr (already "decrypted" by the CprAccess stub).
+   * Builds a verifier with a stubbed session CPR and case applicant CPR.
+   *
+   * The session returns $sessionCpr; the case's submission holds $caseCpr
+   * (already "decrypted" by the CprAccess stub).
    *
    * @param string|null $sessionCpr
    *   CPR the MitID session returns (NULL = no session).

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/AppealOwnershipVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/AppealOwnershipVerifierTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\aabenforms_workflows\Service\AppealOwnershipVerifier;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\webform\WebformSubmissionInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Service\AppealOwnershipVerifier
+ *
+ * @group aabenforms_workflows
+ */
+class AppealOwnershipVerifierTest extends UnitTestCase {
+
+  /**
+   * Builds a verifier where the session returns $sessionCpr and the case's
+   * submission holds $caseCpr (already "decrypted" by the CprAccess stub).
+   *
+   * @param string|null $sessionCpr
+   *   CPR the MitID session returns (NULL = no session).
+   * @param string|null $caseCpr
+   *   Applicant CPR on the case's submission (NULL = no submission/case).
+   */
+  protected function verifier(?string $sessionCpr, ?string $caseCpr): AppealOwnershipVerifier {
+    $session = $this->createMock(MitIdSessionManager::class);
+    $session->method('getCprFromSession')->willReturn($sessionCpr);
+
+    $cprAccess = $this->createMock(CprAccess::class);
+    // reveal() is a pass-through here: the stored value already IS the cpr.
+    $cprAccess->method('reveal')->willReturnArgument(0);
+
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    if ($caseCpr === NULL) {
+      $caseStorage = $this->createMock(EntityStorageInterface::class);
+      $caseStorage->method('load')->willReturn(NULL);
+      $etm->method('getStorage')->willReturn($caseStorage);
+    }
+    else {
+      $submission = $this->createMock(WebformSubmissionInterface::class);
+      $submission->method('getElementData')->willReturnMap([
+        ['applicant_cpr', $caseCpr],
+        ['cpr', NULL],
+      ]);
+      $case = $this->createMock(AabenformsCase::class);
+      $case->method('getSubmissionId')->willReturn('7');
+      $caseStorage = $this->createMock(EntityStorageInterface::class);
+      $caseStorage->method('load')->willReturn($case);
+      $submissionStorage = $this->createMock(EntityStorageInterface::class);
+      $submissionStorage->method('load')->willReturn($submission);
+      $etm->method('getStorage')->willReturnMap([
+        ['aabenforms_case', $caseStorage],
+        ['webform_submission', $submissionStorage],
+      ]);
+    }
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->createMock(LoggerInterface::class));
+
+    return new AppealOwnershipVerifier(
+      $session,
+      $this->createMock(AuditLogger::class),
+      $loggerFactory,
+      $cprAccess,
+      $etm,
+    );
+  }
+
+  /**
+   * @covers ::verify
+   */
+  public function testMatch(): void {
+    $this->assertSame(
+      AppealOwnershipVerifier::RESULT_MATCH,
+      $this->verifier('0101901234', '0101901234')->verify('1', 'wf_abc'),
+    );
+  }
+
+  /**
+   * A different session CPR is a mismatch (the core bypass is closed).
+   *
+   * @covers ::verify
+   */
+  public function testMismatch(): void {
+    $this->assertSame(
+      AppealOwnershipVerifier::RESULT_MISMATCH,
+      $this->verifier('0101901234', '2202800000')->verify('1', 'wf_abc'),
+    );
+  }
+
+  /**
+   * A hyphenated session CPR still matches the digit-only stored CPR.
+   *
+   * @covers ::verify
+   */
+  public function testNormalisedMatch(): void {
+    $this->assertSame(
+      AppealOwnershipVerifier::RESULT_MATCH,
+      $this->verifier('010190-1234', '0101901234')->verify('1', 'wf_abc'),
+    );
+  }
+
+  /**
+   * No MitID session CPR fails closed.
+   *
+   * @covers ::verify
+   */
+  public function testMissingSessionFailsClosed(): void {
+    $this->assertSame(
+      AppealOwnershipVerifier::RESULT_MISSING_MITID_CPR,
+      $this->verifier(NULL, '0101901234')->verify('1', 'wf_abc'),
+    );
+  }
+
+  /**
+   * An unresolvable case fails closed.
+   *
+   * @covers ::verify
+   */
+  public function testMissingCaseFailsClosed(): void {
+    $this->assertSame(
+      AppealOwnershipVerifier::RESULT_MISSING_EXPECTED_CPR,
+      $this->verifier('0101901234', NULL)->verify('999', 'wf_abc'),
+    );
+  }
+
+}


### PR DESCRIPTION
Recreated after history cleanup (supersedes closed #160). AppealOwnershipVerifier (session CPR vs case applicant CPR), aabenforms_verify_appeal_ownership action, klage_flow MitID+ownership gates. Tests + phpcs green.