### PR TITLE
chore: gitignore the local-only workflow-builder skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ Thumbs.db
 data/*
 !data/private/
 !data/private/.gitkeep
+
+# Proprietary workflow-builder skill kept local-only (not distributed)
+.claude/skills/aabenforms-workflow-builder/SKILL.md

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "php-http/discovery": true,
-            "php-tuf/composer-integration": true
+            "php-tuf/composer-integration": true,
+            "symfony/runtime": true
         },
         "sort-packages": true
     },
@@ -102,7 +103,7 @@
             ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",


### PR DESCRIPTION
Keeps .claude/skills/aabenforms-workflow-builder/SKILL.md ignored so the local-only proprietary skill is never re-added. (The file was removed from history via a repo cleanup.)