### PR TITLE
ci: allow symfony/runtime composer plugin (unblocks Validate Composer)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "php-http/discovery": true,
-            "php-tuf/composer-integration": true
+            "php-tuf/composer-integration": true,
+            "symfony/runtime": true
         },
         "sort-packages": true
     },
@@ -102,7 +103,7 @@
             ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",


### PR DESCRIPTION
The `Validate Composer` CI job runs `composer update --prefer-stable`, which (due to upstream dependency drift) now pulls in `symfony/runtime` — a Composer plugin not in `allow-plugins`, so it exits 1 on **every** open PR (and would on a `main` re-run; the last green `main` run predates the drift). This adds `symfony/runtime: true` to `config.allow-plugins`. Safe (trusted Symfony component). Merge this first to green the other PRs after they retarget/rebase onto main.