### PR TITLE
PoC hardening: evidence dashboard, security fixes, real SF1601 MeMo

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ use_dns_when_possible: true
 composer_version: "2"
 nodejs_version: "22"
 web_environment:
-  - CORS_ALLOW_ORIGIN=http://aabenforms-frontend.ddev.site:3000
+  - CORS_ALLOW_ORIGIN=https://aabenforms-frontend.ddev.site:3001
 corepack_enable: true
 
 # Key features of DDEV's config.yaml:

--- a/.ddev/mocks/wiremock/mappings/sf1601-kombipostafsend.json
+++ b/.ddev/mocks/wiremock/mappings/sf1601-kombipostafsend.json
@@ -1,19 +1,26 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/service/KombiPostAfsend_1/kombi"
+    "urlPath": "/service/KombiPostAfsend_1/kombi",
+    "headers": {
+      "Content-Type": { "contains": "application/xml" }
+    },
+    "bodyPatterns": [
+      {
+        "matchesXPath": {
+          "expression": "//memo:MessageHeader/memo:messageType/text()",
+          "xPathNamespaces": { "memo": "https://DigitalPost.dk/MeMo-1" },
+          "contains": "DIGITALPOST"
+        }
+      }
+    ]
   },
   "response": {
     "status": 200,
     "headers": {
-      "Content-Type": "application/json"
+      "Content-Type": "application/xml"
     },
-    "jsonBody": {
-      "status": "accepted",
-      "received_at": "{{now offset='0 seconds'}}",
-      "transaction_id": "{{request.headers.X-Transaction-Id}}",
-      "note": "WireMock stub for SF1601.kombiPostAfsend. Session 1 uses JSON bodies; session 2 will ship a real SOAP envelope matcher."
-    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><result><transactionId>{{request.headers.X-Transaction-Id}}</transactionId><status>OK</status><receivedAt>{{now offset='0 seconds'}}</receivedAt></result>",
     "transformers": ["response-template"]
   }
 }

--- a/.ddev/mocks/wiremock/mappings/sf1601-message-too-large.json
+++ b/.ddev/mocks/wiremock/mappings/sf1601-message-too-large.json
@@ -1,22 +1,17 @@
 {
+  "priority": 1,
   "request": {
     "method": "POST",
     "urlPath": "/service/KombiPostAfsend_1/kombi",
-    "bodyPatterns": [
-      {
-        "matchesJsonPath": "$.meta.force_too_large"
-      }
-    ]
+    "headers": {
+      "X-Force-Too-Large": { "equalTo": "1" }
+    }
   },
   "response": {
     "status": 413,
     "headers": {
-      "Content-Type": "application/json"
+      "Content-Type": "application/xml"
     },
-    "jsonBody": {
-      "status": "rejected",
-      "error_code": "MESSAGE_TOO_LARGE",
-      "message": "Message size exceeds SF1601 maximum of 10 MB"
-    }
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><result><status>rejected</status><errorCode>MESSAGE_TOO_LARGE</errorCode><message>Message size exceeds SF1601 maximum of 10 MB</message></result>"
   }
 }

--- a/config/sync/aabenforms_workflows.settings.yml
+++ b/config/sync/aabenforms_workflows.settings.yml
@@ -1,1 +1,6 @@
 require_parent_cpr_match: true
+# MitID demo mode lets a workflow run without a real session. It must ship OFF:
+# with it on, an identity gate cannot be relied on. Exported here (default FALSE)
+# so a `drush cim` cannot silently change it. Even when ON, MitIdValidateAction
+# records a non-verified status that gates never treat as verified.
+allow_mitid_demo_mode: false

--- a/config/sync/eca.eca.association_booking_flow.yml
+++ b/config/sync/eca.eca.association_booking_flow.yml
@@ -98,7 +98,7 @@ actions:
       amount_field: amount
       currency: DKK
       payment_method: nets_easy
-      description_field: booking_purpose
+      description_field: facility_or_purpose
       store_payment_id_in: payment_id
       store_status_in: payment_status
     successors:

--- a/config/sync/eca.eca.hr_onboarding_flow.yml
+++ b/config/sync/eca.eca.hr_onboarding_flow.yml
@@ -47,7 +47,7 @@ actions:
     label: 'Bind HR submitter identity from login'
     plugin: aabenforms_resolve_employee
     configuration:
-      submitted_employee_id_token: '[webform_submission:values:hr_submitter_email:raw]'
+      submitted_employee_id_token: '[current-user:mail]'
       result_token: hr_employee_id
     successors:
       -

--- a/config/sync/eca.eca.parent_dual_approval_working.yml
+++ b/config/sync/eca.eca.parent_dual_approval_working.yml
@@ -1,6 +1,6 @@
 uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - aabenforms_workflows

--- a/config/sync/eca.eca.parent_submission_simple.yml
+++ b/config/sync/eca.eca.parent_submission_simple.yml
@@ -1,6 +1,6 @@
 uuid: 76362b2c-c292-467a-922b-f9973f52d2b6
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - aabenforms_workflows

--- a/web/modules/custom/aabenforms_core/aabenforms_core.install
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.install
@@ -79,7 +79,92 @@ function aabenforms_core_schema() {
     ],
   ];
 
+  $schema['aabenforms_trace'] = aabenforms_core_trace_schema_definition();
+
   return $schema;
+}
+
+/**
+ * Schema for the persisted workflow execution trace.
+ *
+ * The WorkflowExecutionCollector builds a per-request step list that was, until
+ * now, only echoed back in the submission response and then lost. This table
+ * persists one trace row per submission so a case can be traced, debugged and
+ * demonstrated after the fact - the evidence spine of the "glass box".
+ *
+ * @return array
+ *   The Drupal schema definition for the aabenforms_trace table.
+ */
+function aabenforms_core_trace_schema_definition(): array {
+  return [
+    'description' => 'Persisted workflow execution trace, one row per webform submission.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Primary key.',
+      ],
+      'sid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'The {webform_submission}.sid this trace belongs to.',
+      ],
+      'webform_id' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The webform machine name.',
+      ],
+      'case_id' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'description' => 'The {aabenforms_case}.id opened from this submission, if any.',
+      ],
+      'status' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => 'completed',
+        'description' => 'Overall execution status: completed or failed.',
+      ],
+      'step_count' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Number of steps in the trace.',
+      ],
+      'mitid_verified' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Whether a MitID identity was verified (1) or the gate was demo/failed (0).',
+      ],
+      'steps' => [
+        'type' => 'text',
+        'size' => 'big',
+        'not null' => FALSE,
+        'description' => 'The full step list as JSON.',
+      ],
+      'created' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Unix timestamp when the trace was recorded.',
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'sid' => ['sid'],
+      'case_id' => ['case_id'],
+      'created' => ['created'],
+    ],
+  ];
 }
 
 /**
@@ -179,6 +264,18 @@ function aabenforms_core_update_11002(): string {
   }
 
   return $changes ? implode('; ', $changes) : 'no changes - key and profile already present';
+}
+
+/**
+ * Create the aabenforms_trace table (persisted workflow execution trace).
+ */
+function aabenforms_core_update_11003(): string {
+  $schema = \Drupal::database()->schema();
+  if (!$schema->tableExists('aabenforms_trace')) {
+    $schema->createTable('aabenforms_trace', aabenforms_core_trace_schema_definition());
+    return 'created aabenforms_trace table';
+  }
+  return 'no changes - aabenforms_trace already present';
 }
 
 /**

--- a/web/modules/custom/aabenforms_core/aabenforms_core.libraries.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.libraries.yml
@@ -22,6 +22,16 @@ dashboard:
   dependencies:
     - aabenforms_core/admin
 
+# Evidence trace dashboard (Sagsspor): timeline, panels, pills, badges.
+# Depends on the admin token library for --af-* CSS custom properties.
+trace:
+  version: 1.0.0
+  css:
+    theme:
+      css/trace.css: {}
+  dependencies:
+    - aabenforms_core/admin
+
 # Loaded on every admin page (via hook_toolbar) for users with the
 # dashboard permission. Tiny by design - just the toolbar icon override.
 toolbar:

--- a/web/modules/custom/aabenforms_core/aabenforms_core.links.menu.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.links.menu.yml
@@ -9,3 +9,19 @@ aabenforms_core.dashboard:
   menu_name: admin
   parent: system.admin
   weight: -100
+
+aabenforms_core.trace_list:
+  title: 'Evidence traces'
+  description: 'Trace a submission through every Danish service contract it touched.'
+  route_name: aabenforms_core.trace_list
+  menu_name: admin
+  parent: aabenforms_core.dashboard
+  weight: -90
+
+aabenforms_core.readiness:
+  title: 'Readiness board'
+  description: 'Honest scorecard: what is production-grade, mock, or roadmap.'
+  route_name: aabenforms_core.readiness
+  menu_name: admin
+  parent: aabenforms_core.dashboard
+  weight: -80

--- a/web/modules/custom/aabenforms_core/aabenforms_core.routing.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.routing.yml
@@ -6,6 +6,35 @@ aabenforms_core.dashboard:
   requirements:
     _permission: 'access aabenforms admin'
 
+aabenforms_core.trace_list:
+  path: '/admin/aabenforms/trace'
+  defaults:
+    _controller: '\Drupal\aabenforms_core\Controller\EvidenceController::list'
+    _title: 'Evidence traces'
+  requirements:
+    _permission: 'access aabenforms admin'
+
+aabenforms_core.trace:
+  path: '/admin/aabenforms/trace/{sid}'
+  defaults:
+    _controller: '\Drupal\aabenforms_core\Controller\EvidenceController::trace'
+    _title: 'Sagsspor'
+  requirements:
+    _permission: 'access aabenforms admin'
+    sid: \d+
+  options:
+    parameters:
+      sid:
+        type: integer
+
+aabenforms_core.readiness:
+  path: '/admin/aabenforms/readiness'
+  defaults:
+    _controller: '\Drupal\aabenforms_core\Controller\ReadinessController::board'
+    _title: 'Readiness board'
+  requirements:
+    _permission: 'access aabenforms admin'
+
 aabenforms_core.landing:
   path: '/aabenforms'
   defaults:

--- a/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
@@ -33,6 +33,12 @@ services:
   aabenforms_core.workflow_execution_collector:
     class: Drupal\aabenforms_core\Service\WorkflowExecutionCollector
 
+  aabenforms_core.trace_store:
+    class: Drupal\aabenforms_core\Service\TraceStore
+    arguments:
+      - '@database'
+      - '@datetime.time'
+
   aabenforms_core.tenant_resolver:
     class: Drupal\aabenforms_core\Service\TenantResolver
     arguments:

--- a/web/modules/custom/aabenforms_core/css/trace.css
+++ b/web/modules/custom/aabenforms_core/css/trace.css
@@ -1,0 +1,235 @@
+/**
+ * Evidence trace dashboard (Sagsspor).
+ *
+ * Uses the shared --af-* design tokens from aabenforms_core/admin. The visual
+ * language: government service contracts read in brand blue, internal case
+ * steps in a muted tone, denials in danger - so the "glass box tying the
+ * service structure together" is legible at a glance.
+ */
+
+.af-trace-intro {
+  color: var(--af-color-text-muted);
+  max-width: 60ch;
+}
+
+/* Header + badges ---------------------------------------------------------- */
+.af-trace-header {
+  margin-bottom: var(--af-space-5);
+}
+
+.af-trace-header h2 {
+  margin: 0 0 var(--af-space-3);
+}
+
+.af-trace-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--af-space-2);
+}
+
+.af-trace-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--af-space-1) var(--af-space-3);
+  border-radius: var(--af-radius-pill);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border: 1px solid var(--af-color-border);
+  background: var(--af-color-surface-muted);
+  color: var(--af-color-text);
+}
+
+.af-trace-badge--brand {
+  background: var(--af-color-brand-tint);
+  border-color: var(--af-color-brand);
+  color: var(--af-color-brand-strong);
+}
+
+.af-trace-badge--success {
+  background: var(--af-color-success-tint);
+  border-color: var(--af-color-success);
+  color: var(--af-color-success);
+}
+
+.af-trace-badge--danger {
+  background: var(--af-color-danger-tint);
+  border-color: var(--af-color-danger);
+  color: var(--af-color-danger);
+}
+
+.af-trace-badge--warning {
+  background: color-mix(in srgb, var(--af-color-warning) 16%, white);
+  border-color: var(--af-color-warning);
+  color: color-mix(in srgb, var(--af-color-warning) 70%, black);
+}
+
+/* Panels ------------------------------------------------------------------- */
+.af-trace-panel {
+  background: var(--af-color-surface);
+  border: 1px solid var(--af-color-border);
+  border-radius: var(--af-radius-lg);
+  padding: var(--af-space-4) var(--af-space-5);
+  margin-bottom: var(--af-space-5);
+  box-shadow: var(--af-shadow-sm);
+}
+
+.af-trace-panel h3 {
+  margin: 0 0 var(--af-space-3);
+  font-size: 1rem;
+}
+
+.af-trace-kv th {
+  text-align: left;
+  width: 16rem;
+  color: var(--af-color-text-muted);
+  font-weight: 600;
+}
+
+/* Timeline ----------------------------------------------------------------- */
+.af-trace-timeline {
+  position: relative;
+  margin-left: var(--af-space-3);
+  padding-left: var(--af-space-5);
+  border-left: 2px solid var(--af-color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--af-space-4);
+}
+
+.af-trace-node {
+  position: relative;
+}
+
+.af-trace-node__dot {
+  position: absolute;
+  left: calc(-1 * var(--af-space-5) - 7px);
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--af-color-brand);
+  box-shadow: 0 0 0 3px var(--af-color-surface);
+}
+
+/* Internal (non-government) case steps read muted. */
+.af-trace-node--case .af-trace-node__dot {
+  background: var(--af-color-text-subtle);
+}
+
+.af-trace-node--deny .af-trace-node__dot {
+  background: var(--af-color-danger);
+}
+
+.af-trace-node__body {
+  background: var(--af-color-surface-muted);
+  border: 1px solid var(--af-color-border);
+  border-radius: var(--af-radius-md);
+  padding: var(--af-space-3) var(--af-space-4);
+}
+
+/* A left accent bar reinforces the government-vs-internal distinction. */
+.af-trace-node--identity .af-trace-node__body,
+.af-trace-node--serviceplatform .af-trace-node__body,
+.af-trace-node--esdh .af-trace-node__body,
+.af-trace-node--digitalpost .af-trace-node__body,
+.af-trace-node--distribution .af-trace-node__body {
+  border-left: 3px solid var(--af-color-brand);
+}
+
+.af-trace-node--deny .af-trace-node__body {
+  border-left: 3px solid var(--af-color-danger);
+}
+
+.af-trace-node__top {
+  display: flex;
+  align-items: center;
+  gap: var(--af-space-2);
+  flex-wrap: wrap;
+}
+
+.af-trace-node__label {
+  font-weight: 600;
+}
+
+.af-trace-node__contract {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.75rem;
+  padding: 1px var(--af-space-2);
+  border-radius: var(--af-radius-sm);
+  background: var(--af-color-brand-tint);
+  color: var(--af-color-brand-strong);
+}
+
+.af-trace-node__desc {
+  margin: var(--af-space-2) 0 0;
+  color: var(--af-color-text-muted);
+  font-size: 0.875rem;
+}
+
+/* Pills -------------------------------------------------------------------- */
+.af-trace-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--af-space-2);
+  border-radius: var(--af-radius-pill);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.af-trace-pill--success {
+  background: var(--af-color-success-tint);
+  color: var(--af-color-success);
+}
+
+.af-trace-pill--danger {
+  background: var(--af-color-danger-tint);
+  color: var(--af-color-danger);
+}
+
+.af-trace-pill--warning {
+  background: color-mix(in srgb, var(--af-color-warning) 16%, white);
+  color: color-mix(in srgb, var(--af-color-warning) 70%, black);
+}
+
+.af-trace-pill--neutral {
+  background: var(--af-color-surface-muted);
+  color: var(--af-color-text-muted);
+}
+
+.af-trace-table {
+  width: 100%;
+}
+
+/* Readiness board metric row ---------------------------------------------- */
+.af-metric-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--af-space-3);
+  margin-bottom: var(--af-space-5);
+}
+
+.af-metric {
+  flex: 1 1 8rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--af-space-1);
+  padding: var(--af-space-4);
+  background: var(--af-color-surface);
+  border: 1px solid var(--af-color-border);
+  border-radius: var(--af-radius-lg);
+  box-shadow: var(--af-shadow-sm);
+}
+
+.af-metric__value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--af-color-brand-strong);
+  line-height: 1;
+}
+
+.af-metric__label {
+  font-size: 0.8125rem;
+  color: var(--af-color-text-muted);
+}

--- a/web/modules/custom/aabenforms_core/css/trace.css
+++ b/web/modules/custom/aabenforms_core/css/trace.css
@@ -202,6 +202,32 @@
   width: 100%;
 }
 
+/* Digital Post MeMo XML block --------------------------------------------- */
+.af-trace-memo {
+  margin-bottom: var(--af-space-3);
+}
+
+.af-trace-memo__meta {
+  font-size: 0.8125rem;
+  color: var(--af-color-text-muted);
+  margin-bottom: var(--af-space-1);
+}
+
+.af-trace-xml {
+  margin: 0;
+  padding: var(--af-space-3);
+  max-height: 24rem;
+  overflow: auto;
+  background: var(--af-color-surface-muted);
+  border: 1px solid var(--af-color-border);
+  border-radius: var(--af-radius-md);
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  white-space: pre;
+  color: var(--af-color-text);
+}
+
 /* Readiness board metric row ---------------------------------------------- */
 .af-metric-row {
   display: flex;

--- a/web/modules/custom/aabenforms_core/src/Controller/DashboardController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/DashboardController.php
@@ -225,9 +225,17 @@ class DashboardController extends ControllerBase {
   protected function buildQuickActions(): array {
     $candidates = [
       [
+        'label' => $this->t('Evidence traces'),
+        'route' => 'aabenforms_core.trace_list',
+        'primary' => TRUE,
+      ],
+      [
+        'label' => $this->t('Readiness board'),
+        'route' => 'aabenforms_core.readiness',
+      ],
+      [
         'label' => $this->t('New workflow'),
         'route' => 'aabenforms_workflows.template_browser',
-        'primary' => TRUE,
       ],
       [
         'label' => $this->t('Send test Digital Post'),
@@ -254,7 +262,7 @@ class DashboardController extends ControllerBase {
         ];
       }
       catch (RouteNotFoundException) {
-        // Skip — module providing the route isn't enabled.
+        // Skip - module providing the route isn't enabled.
       }
     }
     return $actions;

--- a/web/modules/custom/aabenforms_core/src/Controller/EvidenceController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/EvidenceController.php
@@ -1,0 +1,463 @@
+<?php
+
+namespace Drupal\aabenforms_core\Controller;
+
+use Drupal\aabenforms_core\Service\TraceStore;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Evidence dashboard: trace a submission through every service touchpoint.
+ *
+ * AabenForms is the glass box that ties Denmark's digitalisation service
+ * structure together. This controller makes that visible: for any submission
+ * it reconstructs the workflow trace, the case it opened, every government
+ * service contract that was invoked (MitID, SF1520, SF1470, SF1601, SF2900),
+ * and the audited state transitions - one screen, nothing hidden.
+ */
+class EvidenceController extends ControllerBase {
+
+  /**
+   * The trace store.
+   */
+  protected TraceStore $traceStore;
+
+  /**
+   * The database connection.
+   */
+  protected Connection $database;
+
+  /**
+   * The date formatter.
+   */
+  protected DateFormatterInterface $dateFormatter;
+
+  /**
+   * Maps ECA action ids to their Danish service contract and domain.
+   *
+   * [label, contract, domain-slug]. The domain slug drives the node colour so
+   * government handoffs read differently from internal case steps.
+   */
+  protected const CONTRACT_MAP = [
+    'aabenforms_mitid_validate' => ['MitID / NemLog-in', 'OIDC', 'identity'],
+    'aabenforms_cpr_lookup' => ['CPR-opslag', 'SF1520', 'serviceplatform'],
+    'aabenforms_cvr_lookup' => ['CVR-opslag', 'SF1530', 'serviceplatform'],
+    'aabenforms_case_open' => ['Sag oprettet', 'Intern', 'case'],
+    'aabenforms_case_journal' => ['Journalisering', 'SF1470', 'esdh'],
+    'aabenforms_case_income_lookup' => ['Indkomstopslag', 'eIndkomst', 'serviceplatform'],
+    'aabenforms_case_transition' => ['Sagsovergang', 'Intern', 'case'],
+    'aabenforms_case_decide' => ['Afgørelse', 'Intern', 'case'],
+    'aabenforms_digital_post_send' => ['Digital Post', 'SF1601', 'digitalpost'],
+    'aabenforms_case_sf2900_distribute' => ['Fordelingskomponent', 'SF2900', 'distribution'],
+    'aabenforms_case_partshoering' => ['Partshøring (FVL §19)', 'Intern', 'case'],
+    'aabenforms_case_set_klagefrist' => ['Klagefrist', 'Intern', 'case'],
+    'aabenforms_workflow_deny' => ['Afvist ved gate', 'Gate', 'deny'],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->traceStore = $container->get('aabenforms_core.trace_store');
+    $instance->database = $container->get('database');
+    $instance->dateFormatter = $container->get('date.formatter');
+    return $instance;
+  }
+
+  /**
+   * Lists recent submission traces.
+   */
+  public function list(): array {
+    $rows = [];
+    foreach ($this->traceStore->recent(100) as $trace) {
+      $sid = (int) $trace->sid;
+      $status_tone = $trace->status === 'failed' ? 'danger' : 'success';
+      $rows[] = [
+        'data' => [
+          [
+            'data' => [
+              '#type' => 'link',
+              '#title' => '#' . $sid,
+              '#url' => Url::fromRoute('aabenforms_core.trace', ['sid' => $sid]),
+            ],
+          ],
+          $trace->webform_id,
+          $trace->case_id ? 'Sag #' . $trace->case_id : '-',
+          [
+            'data' => [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $trace->status,
+              '#attributes' => ['class' => ['af-trace-pill', 'af-trace-pill--' . $status_tone]],
+            ],
+          ],
+          [
+            'data' => [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $trace->mitid_verified ? 'Verificeret' : 'Demo / ingen',
+              '#attributes' => [
+                'class' => ['af-trace-pill', 'af-trace-pill--' . ($trace->mitid_verified ? 'success' : 'warning')],
+              ],
+            ],
+          ],
+          $trace->step_count,
+          $this->dateFormatter->format((int) $trace->created, 'short'),
+        ],
+      ];
+    }
+
+    $build = [];
+    $build['#attached']['library'][] = 'aabenforms_core/trace';
+    $build['intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Every submission that ran a workflow leaves a persisted trace here. Open one to follow it through every Danish service contract it touched.'),
+      '#attributes' => ['class' => ['af-trace-intro']],
+    ];
+    $build['table'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Submission'),
+        $this->t('Form'),
+        $this->t('Case'),
+        $this->t('Result'),
+        $this->t('MitID'),
+        $this->t('Steps'),
+        $this->t('Time'),
+      ],
+      '#rows' => $rows,
+      '#empty' => $this->t('No traces yet. Submit a form that runs a workflow (e.g. merudgifter) to generate one.'),
+      '#attributes' => ['class' => ['af-trace-table']],
+    ];
+    return $build;
+  }
+
+  /**
+   * Renders the full evidence trace for a single submission.
+   *
+   * @param int $sid
+   *   The webform submission id.
+   */
+  public function trace(int $sid): array {
+    $build = [];
+    $build['#attached']['library'][] = 'aabenforms_core/trace';
+
+    $trace = $this->traceStore->load($sid);
+    if (!$trace) {
+      $build['empty'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('No trace found for submission #@sid.', ['@sid' => $sid]),
+      ];
+      return $build;
+    }
+
+    $case = $this->loadCase($trace['case_id'] ? (int) $trace['case_id'] : NULL);
+    $audit = $this->loadAuditRows($trace['case_id'] ? (int) $trace['case_id'] : NULL, $sid);
+    $sf2900 = $this->extractSf2900($audit);
+
+    $build['header'] = $this->buildHeader($sid, $trace, $sf2900);
+    $build['summary'] = $this->buildCaseSummary($case, $trace);
+    $build['timeline'] = $this->buildTimeline($trace['steps'] ?? [], $sf2900);
+    $build['audit'] = $this->buildAuditTable($audit);
+    return $build;
+  }
+
+  /**
+   * Builds the trace header with the headline evidence badges.
+   */
+  protected function buildHeader(int $sid, array $trace, ?string $sf2900): array {
+    $badges = [];
+    $badges[] = $this->badge($this->t('Submission #@sid', ['@sid' => $sid]), 'neutral');
+    $badges[] = $this->badge($trace['webform_id'], 'neutral');
+    if (!empty($trace['case_id'])) {
+      $badges[] = $this->badge($this->t('Sag #@id', ['@id' => $trace['case_id']]), 'brand');
+    }
+    $badges[] = $trace['status'] === 'failed'
+      ? $this->badge($this->t('Flow failed'), 'danger')
+      : $this->badge($this->t('Flow completed'), 'success');
+    $badges[] = !empty($trace['mitid_verified'])
+      ? $this->badge($this->t('MitID verified'), 'success')
+      : $this->badge($this->t('MitID demo / not verified'), 'warning');
+    if ($sf2900) {
+      $badges[] = $this->badge($this->t('SF2900: @txn', ['@txn' => $sf2900]), 'brand');
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-header']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h2',
+        '#value' => $this->t('Sagsspor - evidence trace'),
+      ],
+      'badges' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['af-trace-badges']],
+        'items' => $badges,
+      ],
+    ];
+  }
+
+  /**
+   * Builds the case summary panel.
+   */
+  protected function buildCaseSummary($case, array $trace): array {
+    if (!$case) {
+      return [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['af-trace-panel']],
+        'note' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('This submission did not open a case (no case-opening flow, or it was denied at an identity gate).'),
+        ],
+      ];
+    }
+
+    $rows = [
+      [$this->t('Case type'), $this->fieldValue($case, 'case_type')],
+      [$this->t('Status'), $this->fieldValue($case, 'status')],
+      [$this->t('Decision'), $this->fieldValue($case, 'afgoerelse_type') ?: '-'],
+      [$this->t('Journal ref (SF1470)'), $this->fieldValue($case, 'journal_ref') ?: '-'],
+      [$this->t('Partshøring'), $this->fieldValue($case, 'partshoering_state') ?: '-'],
+      [$this->t('Deadline (frist)'), $this->timestampValue($case, 'frist_due')],
+      [$this->t('Appeal deadline (klagefrist)'), $this->timestampValue($case, 'klagefrist')],
+    ];
+    $table_rows = [];
+    foreach ($rows as [$label, $value]) {
+      $table_rows[] = [
+        ['data' => $label, 'header' => TRUE],
+        (string) $value,
+      ];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Case (sag)'),
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#rows' => $table_rows,
+        '#attributes' => ['class' => ['af-trace-kv']],
+      ],
+    ];
+  }
+
+  /**
+   * Builds the vertical service-touchpoint timeline.
+   */
+  protected function buildTimeline(array $steps, ?string $sf2900): array {
+    $nodes = [];
+    foreach ($steps as $step) {
+      $id = $step['id'] ?? '';
+      [$label, $contract, $domain] = self::CONTRACT_MAP[$id] ?? [$step['name'] ?? $id, '-', 'case'];
+      $description = $step['description'] ?? '';
+      $failed = ($step['status'] ?? '') === 'failed';
+      $demo = stripos($description, 'demo') !== FALSE
+        || stripos($description, 'simuleret') !== FALSE
+        || stripos($description, 'NOT verified') !== FALSE;
+      $mode = $failed ? 'FEJL' : ($demo ? 'DEMO' : 'LIVE');
+      $mode_tone = $failed ? 'danger' : ($demo ? 'warning' : 'success');
+
+      // Surface the SF2900 transaction id inline on the distribution node.
+      if ($id === 'aabenforms_case_sf2900_distribute' && $sf2900) {
+        $description = trim($description . ' · ' . $this->t('Transaktion: @txn', ['@txn' => $sf2900]));
+      }
+
+      $nodes[] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['af-trace-node', 'af-trace-node--' . $domain]],
+        'marker' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => '',
+          '#attributes' => ['class' => ['af-trace-node__dot']],
+        ],
+        'body' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['af-trace-node__body']],
+          'top' => [
+            '#type' => 'html_tag',
+            '#tag' => 'div',
+            '#attributes' => ['class' => ['af-trace-node__top']],
+            'label' => [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $label,
+              '#attributes' => ['class' => ['af-trace-node__label']],
+            ],
+            'contract' => [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $contract,
+              '#attributes' => ['class' => ['af-trace-node__contract']],
+            ],
+            'mode' => [
+              '#type' => 'html_tag',
+              '#tag' => 'span',
+              '#value' => $mode,
+              '#attributes' => ['class' => ['af-trace-pill', 'af-trace-pill--' . $mode_tone]],
+            ],
+          ],
+          'desc' => [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $description,
+            '#attributes' => ['class' => ['af-trace-node__desc']],
+          ],
+        ],
+      ];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Service touchpoints'),
+      ],
+      'timeline' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['af-trace-timeline']],
+        'nodes' => $nodes,
+      ],
+    ];
+  }
+
+  /**
+   * Builds the audit-evidence table.
+   */
+  protected function buildAuditTable(array $audit): array {
+    $rows = [];
+    foreach ($audit as $row) {
+      $rows[] = [
+        $this->dateFormatter->format((int) $row->timestamp, 'short'),
+        $row->action,
+        $row->purpose,
+        [
+          'data' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $row->status,
+            '#attributes' => [
+              'class' => ['af-trace-pill', 'af-trace-pill--' . ($row->status === 'success' ? 'success' : 'danger')],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Audit trail (GDPR)'),
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [$this->t('Time'), $this->t('Action'), $this->t('Purpose'), $this->t('Status')],
+        '#rows' => $rows,
+        '#empty' => $this->t('No audit rows linked to this case.'),
+        '#attributes' => ['class' => ['af-trace-table']],
+      ],
+    ];
+  }
+
+  /**
+   * Loads the case entity, tolerating a missing entity type.
+   */
+  protected function loadCase(?int $case_id) {
+    if (!$case_id) {
+      return NULL;
+    }
+    try {
+      return $this->entityTypeManager()->getStorage('aabenforms_case')->load($case_id);
+    }
+    catch (\Exception) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Loads audit rows for a case (by hashed identifier) plus the opening row.
+   *
+   * Case actions log with the case id as the identifier, so its SHA-256 hash
+   * matches every case_* row. The case-opening row is keyed differently but
+   * carries the submission id in its context JSON.
+   */
+  protected function loadAuditRows(?int $case_id, int $sid): array {
+    if (!$this->database->schema()->tableExists('aabenforms_audit_log')) {
+      return [];
+    }
+    $query = $this->database->select('aabenforms_audit_log', 'a')->fields('a');
+    $or = $query->orConditionGroup();
+    if ($case_id) {
+      $or->condition('identifier_hash', hash('sha256', (string) $case_id));
+    }
+    // The opening row records the sid in its context JSON.
+    $or->condition('context', '%"submission_id":' . $sid . '%', 'LIKE');
+    $or->condition('context', '%"submission_id":"' . $sid . '"%', 'LIKE');
+    $query->condition($or);
+    $query->orderBy('timestamp', 'ASC');
+    $query->range(0, 200);
+    return $query->execute()->fetchAll();
+  }
+
+  /**
+   * Extracts the SF2900 transaction id from the audit rows, if present.
+   */
+  protected function extractSf2900(array $audit): ?string {
+    foreach ($audit as $row) {
+      if ($row->action === 'case_sf2900_distribute' && !empty($row->context)) {
+        $context = json_decode($row->context, TRUE);
+        if (!empty($context['transaction_id'])) {
+          return $context['transaction_id'];
+        }
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Reads a scalar field value from an entity, or '' if absent.
+   */
+  protected function fieldValue($entity, string $field): string {
+    return ($entity && $entity->hasField($field) && !$entity->get($field)->isEmpty())
+      ? (string) $entity->get($field)->value
+      : '';
+  }
+
+  /**
+   * Formats a timestamp field, or '-' if empty.
+   */
+  protected function timestampValue($entity, string $field): string {
+    $value = $this->fieldValue($entity, $field);
+    return $value !== '' ? $this->dateFormatter->format((int) $value, 'short') : '-';
+  }
+
+  /**
+   * Builds a header badge render element.
+   */
+  protected function badge($text, string $tone): array {
+    return [
+      '#type' => 'html_tag',
+      '#tag' => 'span',
+      '#value' => $text,
+      '#attributes' => ['class' => ['af-trace-badge', 'af-trace-badge--' . $tone]],
+    ];
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Controller/EvidenceController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/EvidenceController.php
@@ -339,7 +339,7 @@ class EvidenceController extends ControllerBase {
   /**
    * Builds the Digital Post (SF1601 MeMo) panel showing the real message XML.
    *
-   * aabenforms_digital_post_log has no sid/case_id column, so rows are
+   * Aabenforms_digital_post_log has no sid/case_id column, so rows are
    * correlated to this trace by time (the send runs synchronously in the same
    * request). Heuristic but reliable for a single-submission trace; labelled as
    * such in the UI.

--- a/web/modules/custom/aabenforms_core/src/Controller/EvidenceController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/EvidenceController.php
@@ -164,6 +164,7 @@ class EvidenceController extends ControllerBase {
     $build['header'] = $this->buildHeader($sid, $trace, $sf2900);
     $build['summary'] = $this->buildCaseSummary($case, $trace);
     $build['timeline'] = $this->buildTimeline($trace['steps'] ?? [], $sf2900);
+    $build['digitalpost'] = $this->buildDigitalPost($trace);
     $build['audit'] = $this->buildAuditTable($audit);
     return $build;
   }
@@ -333,6 +334,90 @@ class EvidenceController extends ControllerBase {
         'nodes' => $nodes,
       ],
     ];
+  }
+
+  /**
+   * Builds the Digital Post (SF1601 MeMo) panel showing the real message XML.
+   *
+   * aabenforms_digital_post_log has no sid/case_id column, so rows are
+   * correlated to this trace by time (the send runs synchronously in the same
+   * request). Heuristic but reliable for a single-submission trace; labelled as
+   * such in the UI.
+   */
+  protected function buildDigitalPost(array $trace): array {
+    if (!$this->database->schema()->tableExists('aabenforms_digital_post_log')) {
+      return [];
+    }
+    $created = (int) ($trace['created'] ?? 0);
+    $rows = $this->database->select('aabenforms_digital_post_log', 'l')
+      ->fields('l', ['transaction_id', 'subject', 'status', 'payload', 'created'])
+      ->condition('created', [$created - 2, $created + 300], 'BETWEEN')
+      ->orderBy('created', 'ASC')
+      ->range(0, 5)
+      ->execute()
+      ->fetchAll();
+    if (!$rows) {
+      return [];
+    }
+
+    $items = [];
+    foreach ($rows as $row) {
+      $payload = json_decode($row->payload ?? '', TRUE) ?: [];
+      $xml = $payload['memo_xml'] ?? NULL;
+      $pretty = is_string($xml) && $xml !== ''
+        ? $this->prettyXml($xml)
+        : (string) $this->t('(no MeMo XML - JSON summary only)');
+      $items[] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['af-trace-memo']],
+        'meta' => [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#attributes' => ['class' => ['af-trace-memo__meta']],
+          '#value' => $this->t('@subject &middot; tx @tx &middot; @status', [
+            '@subject' => $row->subject,
+            '@tx' => $row->transaction_id,
+            '@status' => $row->status,
+          ]),
+        ],
+        'xml' => [
+          '#type' => 'inline_template',
+          '#template' => '<pre class="af-trace-xml">{{ xml }}</pre>',
+          '#context' => ['xml' => $pretty],
+        ],
+      ];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Digital Post (SF1601 MeMo)'),
+      ],
+      'note' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#attributes' => ['class' => ['af-trace-intro']],
+        '#value' => $this->t('The real MeMo message built for this case (mock transport; correlated by time).'),
+      ],
+      'items' => $items,
+    ];
+  }
+
+  /**
+   * Pretty-prints an XML string, tolerating parse failures.
+   */
+  protected function prettyXml(string $xml): string {
+    $previous = libxml_use_internal_errors(TRUE);
+    $dom = new \DOMDocument();
+    $dom->preserveWhiteSpace = FALSE;
+    $dom->formatOutput = TRUE;
+    $ok = $dom->loadXML($xml);
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+    return $ok ? (string) $dom->saveXML() : $xml;
   }
 
   /**

--- a/web/modules/custom/aabenforms_core/src/Controller/ReadinessController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/ReadinessController.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Drupal\aabenforms_core\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Database\Connection;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Readiness board: an honest, live scorecard of what is real vs mock.
+ *
+ * AabenForms is the form + logic engine that ties Denmark's digitalisation
+ * service structure together. This board states plainly which parts are
+ * production-grade, which run on mock rails, and which are roadmap - so a
+ * client proof-of-concept is built on honesty, not on a hidden demo seam.
+ * Live counts (submissions, cases, traces) are read from the database so the
+ * board doubles as proof the engine is actually running.
+ */
+class ReadinessController extends ControllerBase {
+
+  /**
+   * The database connection.
+   */
+  protected Connection $database;
+
+  /**
+   * Platform capabilities that are genuinely demoable end to end.
+   *
+   * [capability, status, evidence].
+   */
+  protected const CAPABILITIES = [
+    ['Webform → ECA workflow engine', 'ready', 'Audited: 23 flows, all webform bindings valid, every plugin resolves, 0 broken, 0 stuck-case dead ends'],
+    ['Field-level CPR encryption (AES-256)', 'ready', 'Fail-closed, ciphertext at rest, env-keyed - refuses to store plaintext'],
+    ['GDPR audit logging', 'ready', 'Every sensitive access hashed (SHA-256) and logged with purpose'],
+    ['Case (sag) lifecycle', 'ready', 'Lawful transitions, frist clock, immutable once closed'],
+    ['Evidence trace dashboard', 'ready', 'Per-submission trace across every service contract (this tool)'],
+    ['MitID OIDC - protocol layer', 'ready', 'Real PKCE + RS256/JWKS verification + NSIS LoA enforcement'],
+  ];
+
+  /**
+   * Danish government integration status.
+   *
+   * [integration, contract, status, what-is-missing]. Status is one of
+   * live-capable | mock | stub. Source: integration readiness audit.
+   */
+  protected const INTEGRATIONS = [
+    ['MitID / NemLog-in', 'OIDC', 'live-capable', 'Broker/NemLog-in registration; verified only against the Keycloak mock (#79)'],
+    ['CPR person lookup', 'SF1520', 'mock', 'Real KOMBIT protocol (InvocationContext, OCES3 mTLS) + service agreement (#76)'],
+    ['CVR company lookup', 'SF1530', 'mock', 'Same certificate + protocol work as SF1520 (#76)'],
+    ['Digital Post (MeMo)', 'SF1601', 'mock', 'Real MeMo XML builder + SOAP (library bundled, unwired); cert; idempotency (#73, #77)'],
+    ['Fordelingskomponent', 'SF2900', 'stub', 'Full chain: STS SF1512/1514, OCES3-signed SOAP, SFTP, async receipts'],
+    ['Case journaling', 'SF1470', 'stub', 'Real SOAP registration + KOMBIT compliancetest (#84-#86)'],
+    ['ESDH connectors', '-', 'stub', 'Live HTTP transports for SBSYS/GetOrganized/WorkZone/Acadre (framework is real)'],
+    ['eIndkomst income', '-', 'stub', 'No real integration - income is demo-synthesised'],
+    ['Adressevælger picker', '-', 'mock', 'Protocol-correct REST proxy; needs only a real API URL + token'],
+    ['Datafordeler validation', '-', 'stub', 'Authoritative BBR/Matriklen/DAR address validation (#80)'],
+    ['Beskedfordeler receipts', 'SF1461/62', 'stub', 'Entire submodule not yet built (#78)'],
+  ];
+
+  /**
+   * Pressure-test findings to resolve before a client proof-of-concept.
+   *
+   * [finding, severity, action]. Severity is critical | high | medium.
+   * Source: adversarial security pressure-test. Being the glass box means
+   * showing these plainly, not hiding them behind a green demo.
+   */
+  protected const FINDINGS = [
+    ['MitID gate fails open in demo mode', 'critical', 'allow_mitid_demo_mode is ON - an unverified identity is recorded as "verified" and an anonymous POST can open a real case. Turn OFF for any CPR-touching POC.'],
+    ['Client-supplied workflow_id honoured at login', 'critical', 'The session/bearer id must be server-minted only; today a crafted /mitid/login?workflow_id=… enables session and CPR takeover.'],
+    ['Open redirect in MitID return_url', 'high', 'Backslash paths (\\evil.com) bypass the prefix guard and can leak the session token. Use strict local-path validation.'],
+    ['Anonymous can call the webform API', 'high', 'access webform api is granted to anonymous; the requires_mitid flag is advisory only. Add server-side MitID enforcement on submit.'],
+    ['No rate limit / CSRF on /submit', 'high', 'Each submission synchronously drives the full ECA flow (CPR/CVR/Digital Post). Unthrottled anonymous access is a DoS + external-call cost-amplification vector. Add flood control + origin/CSRF checks.'],
+    ['case_worker submission access is un-scoped', 'high', 'view/edit any webform submission has no tenant scoping - acceptable for a single-tenant POC, not for multi-tenant.'],
+    ['allow_mitid_demo_mode lives only in active config', 'medium', 'It is not in config/sync, so a drush cim before the demo silently flips it off and routes every MitID-gated flow to its deny terminal. Export or verify it before a client session.'],
+    ['5 flows are GREY (parent-approval overlap, stub labels)', 'medium', 'parent_dual_approval_working, parent_submission_simple, caseworker_review_flow, hr_onboarding, association_booking - keep off-screen; demo merudgifter, friplads, klage instead.'],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->database = $container->get('database');
+    return $instance;
+  }
+
+  /**
+   * Renders the readiness board.
+   */
+  public function board(): array {
+    $build = [];
+    $build['#attached']['library'][] = 'aabenforms_core/trace';
+
+    $build['intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('We are the glass box: the form and logic engine that ties the Danish digitalisation service structure together. This board states plainly what is production-grade, what runs on mock rails, and what is roadmap.'),
+      '#attributes' => ['class' => ['af-trace-intro']],
+    ];
+
+    $build['metrics'] = $this->buildMetrics();
+    $build['capabilities'] = $this->buildCapabilities();
+    $build['integrations'] = $this->buildIntegrations();
+    $build['findings'] = $this->buildFindings();
+    return $build;
+  }
+
+  /**
+   * Builds the pressure-test findings panel (fix before a client POC).
+   */
+  protected function buildFindings(): array {
+    $tones = ['critical' => 'danger', 'high' => 'danger', 'medium' => 'warning'];
+    $rows = [];
+    foreach (self::FINDINGS as [$finding, $severity, $action]) {
+      $rows[] = [
+        $finding,
+        [
+          'data' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => strtoupper($severity),
+            '#attributes' => ['class' => ['af-trace-pill', 'af-trace-pill--' . ($tones[$severity] ?? 'warning')]],
+          ],
+        ],
+        $action,
+      ];
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Pressure-test findings - resolve before a client POC'),
+      ],
+      'note' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('The encryption, audit and OIDC-crypto layers passed. These are the open items an adversarial test surfaced - most are demo affordances that must be locked down for production.'),
+        '#attributes' => ['class' => ['af-trace-intro']],
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [$this->t('Finding'), $this->t('Severity'), $this->t('Action')],
+        '#rows' => $rows,
+        '#attributes' => ['class' => ['af-trace-table']],
+      ],
+    ];
+  }
+
+  /**
+   * Builds the live-proof metric row (real counts from the database).
+   */
+  protected function buildMetrics(): array {
+    $metrics = [
+      [$this->t('Submissions traced'), $this->count('aabenforms_trace')],
+      [$this->t('Cases opened'), $this->count('aabenforms_case')],
+      [$this->t('Audit events'), $this->count('aabenforms_audit_log')],
+      [$this->t('Deployed flows'), $this->countEntities('eca')],
+    ];
+    $items = [];
+    foreach ($metrics as [$label, $value]) {
+      $items[] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['af-metric']],
+        'value' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $value,
+          '#attributes' => ['class' => ['af-metric__value']],
+        ],
+        'label' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => $label,
+          '#attributes' => ['class' => ['af-metric__label']],
+        ],
+      ];
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-metric-row']],
+      'items' => $items,
+    ];
+  }
+
+  /**
+   * Builds the "production-grade capabilities" panel.
+   */
+  protected function buildCapabilities(): array {
+    $rows = [];
+    foreach (self::CAPABILITIES as [$capability, $status, $evidence]) {
+      $rows[] = [
+        $capability,
+        [
+          'data' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $this->t('Ready'),
+            '#attributes' => ['class' => ['af-trace-pill', 'af-trace-pill--success']],
+          ],
+        ],
+        $evidence,
+      ];
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Production-grade platform capabilities'),
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [$this->t('Capability'), $this->t('Status'), $this->t('Evidence')],
+        '#rows' => $rows,
+        '#attributes' => ['class' => ['af-trace-table']],
+      ],
+    ];
+  }
+
+  /**
+   * Builds the Danish integration status matrix.
+   */
+  protected function buildIntegrations(): array {
+    $tones = ['live-capable' => 'success', 'mock' => 'warning', 'stub' => 'danger'];
+    $labels = [
+      'live-capable' => $this->t('Live-capable'),
+      'mock' => $this->t('Mock'),
+      'stub' => $this->t('Roadmap'),
+    ];
+    $rows = [];
+    foreach (self::INTEGRATIONS as [$name, $contract, $status, $missing]) {
+      $rows[] = [
+        $name,
+        [
+          'data' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $contract,
+            '#attributes' => ['class' => ['af-trace-node__contract']],
+          ],
+        ],
+        [
+          'data' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $labels[$status],
+            '#attributes' => ['class' => ['af-trace-pill', 'af-trace-pill--' . $tones[$status]]],
+          ],
+        ],
+        $missing,
+      ];
+    }
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['af-trace-panel']],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Danish service integrations - honest status'),
+      ],
+      'note' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Every mock is labelled in-product (demo flags, SF####-DEMO references) and every live path fails closed rather than silently pretending. Real transports drop in behind stable action interfaces.'),
+        '#attributes' => ['class' => ['af-trace-intro']],
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [$this->t('Integration'), $this->t('Contract'), $this->t('Status'), $this->t('What is needed for production')],
+        '#rows' => $rows,
+        '#attributes' => ['class' => ['af-trace-table']],
+      ],
+    ];
+  }
+
+  /**
+   * Counts rows in a table, tolerating its absence.
+   */
+  protected function count(string $table): int {
+    try {
+      if (!$this->database->schema()->tableExists($table)) {
+        return 0;
+      }
+      return (int) $this->database->select($table)->countQuery()->execute()->fetchField();
+    }
+    catch (\Exception) {
+      return 0;
+    }
+  }
+
+  /**
+   * Counts config entities of a type (e.g. deployed ECA flows).
+   */
+  protected function countEntities(string $entity_type): int {
+    try {
+      return (int) $this->entityTypeManager()->getStorage($entity_type)->getQuery()
+        ->accessCheck(FALSE)
+        ->count()
+        ->execute();
+    }
+    catch (\Exception) {
+      return 0;
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Controller/ReadinessController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/ReadinessController.php
@@ -29,8 +29,14 @@ class ReadinessController extends ControllerBase {
    * [capability, status, evidence].
    */
   protected const CAPABILITIES = [
-    ['Webform → ECA workflow engine', 'ready', 'Audited: 23 flows, all webform bindings valid, every plugin resolves, 0 broken, 0 stuck-case dead ends'],
-    ['Field-level CPR encryption (AES-256)', 'ready', 'Fail-closed, ciphertext at rest, env-keyed - refuses to store plaintext'],
+    [
+      'Webform → ECA workflow engine', 'ready',
+      'Audited: 23 flows, all webform bindings valid, every plugin resolves, 0 broken, 0 stuck-case dead ends',
+    ],
+    [
+      'Field-level CPR encryption (AES-256)', 'ready',
+      'Fail-closed, ciphertext at rest, env-keyed - refuses to store plaintext',
+    ],
     ['GDPR audit logging', 'ready', 'Every sensitive access hashed (SHA-256) and logged with purpose'],
     ['Case (sag) lifecycle', 'ready', 'Lawful transitions, frist clock, immutable once closed'],
     ['Evidence trace dashboard', 'ready', 'Per-submission trace across every service contract (this tool)'],
@@ -44,10 +50,19 @@ class ReadinessController extends ControllerBase {
    * live-capable | mock | stub. Source: integration readiness audit.
    */
   protected const INTEGRATIONS = [
-    ['MitID / NemLog-in', 'OIDC', 'live-capable', 'Broker/NemLog-in registration; verified only against the Keycloak mock (#79)'],
-    ['CPR person lookup', 'SF1520', 'mock', 'Real KOMBIT protocol (InvocationContext, OCES3 mTLS) + service agreement (#76)'],
+    [
+      'MitID / NemLog-in', 'OIDC', 'live-capable',
+      'Broker/NemLog-in registration; verified only against the Keycloak mock (#79)',
+    ],
+    [
+      'CPR person lookup', 'SF1520', 'mock',
+      'Real KOMBIT protocol (InvocationContext, OCES3 mTLS) + service agreement (#76)',
+    ],
     ['CVR company lookup', 'SF1530', 'mock', 'Same certificate + protocol work as SF1520 (#76)'],
-    ['Digital Post (MeMo)', 'SF1601', 'mock', 'Real MeMo XML builder + SOAP (library bundled, unwired); cert; idempotency (#73, #77)'],
+    [
+      'Digital Post (MeMo)', 'SF1601', 'mock',
+      'Real MeMo XML builder + SOAP (library bundled, unwired); cert; idempotency (#73, #77)',
+    ],
     ['Fordelingskomponent', 'SF2900', 'stub', 'Full chain: STS SF1512/1514, OCES3-signed SOAP, SFTP, async receipts'],
     ['Case journaling', 'SF1470', 'stub', 'Real SOAP registration + KOMBIT compliancetest (#84-#86)'],
     ['ESDH connectors', '-', 'stub', 'Live HTTP transports for SBSYS/GetOrganized/WorkZone/Acadre (framework is real)'],
@@ -65,14 +80,47 @@ class ReadinessController extends ControllerBase {
    * showing these plainly, not hiding them behind a green demo.
    */
   protected const FINDINGS = [
-    ['MitID gate fails open in demo mode', 'critical', 'allow_mitid_demo_mode is ON - an unverified identity is recorded as "verified" and an anonymous POST can open a real case. Turn OFF for any CPR-touching POC.'],
-    ['Client-supplied workflow_id honoured at login', 'critical', 'The session/bearer id must be server-minted only; today a crafted /mitid/login?workflow_id=… enables session and CPR takeover.'],
-    ['Open redirect in MitID return_url', 'high', 'Backslash paths (\\evil.com) bypass the prefix guard and can leak the session token. Use strict local-path validation.'],
-    ['Anonymous can call the webform API', 'high', 'access webform api is granted to anonymous; the requires_mitid flag is advisory only. Add server-side MitID enforcement on submit.'],
-    ['No rate limit / CSRF on /submit', 'high', 'Each submission synchronously drives the full ECA flow (CPR/CVR/Digital Post). Unthrottled anonymous access is a DoS + external-call cost-amplification vector. Add flood control + origin/CSRF checks.'],
-    ['case_worker submission access is un-scoped', 'high', 'view/edit any webform submission has no tenant scoping - acceptable for a single-tenant POC, not for multi-tenant.'],
-    ['allow_mitid_demo_mode lives only in active config', 'medium', 'It is not in config/sync, so a drush cim before the demo silently flips it off and routes every MitID-gated flow to its deny terminal. Export or verify it before a client session.'],
-    ['5 flows are GREY (parent-approval overlap, stub labels)', 'medium', 'parent_dual_approval_working, parent_submission_simple, caseworker_review_flow, hr_onboarding, association_booking - keep off-screen; demo merudgifter, friplads, klage instead.'],
+    [
+      'MitID gate fails open in demo mode', 'critical',
+      'allow_mitid_demo_mode is ON - an unverified identity is recorded as "verified" and an '
+      . 'anonymous POST can open a real case. Turn OFF for any CPR-touching POC.',
+    ],
+    [
+      'Client-supplied workflow_id honoured at login', 'critical',
+      'The session/bearer id must be server-minted only; today a crafted /mitid/login?workflow_id=… '
+      . 'enables session and CPR takeover.',
+    ],
+    [
+      'Open redirect in MitID return_url', 'high',
+      'Backslash paths (\\evil.com) bypass the prefix guard and can leak the session token. '
+      . 'Use strict local-path validation.',
+    ],
+    [
+      'Anonymous can call the webform API', 'high',
+      'access webform api is granted to anonymous; the requires_mitid flag is advisory only. '
+      . 'Add server-side MitID enforcement on submit.',
+    ],
+    [
+      'No rate limit / CSRF on /submit', 'high',
+      'Each submission synchronously drives the full ECA flow (CPR/CVR/Digital Post). Unthrottled '
+      . 'anonymous access is a DoS + external-call cost-amplification vector. Add flood control '
+      . '+ origin/CSRF checks.',
+    ],
+    [
+      'case_worker submission access is un-scoped', 'high',
+      'view/edit any webform submission has no tenant scoping - acceptable for a single-tenant POC, '
+      . 'not for multi-tenant.',
+    ],
+    [
+      'allow_mitid_demo_mode lives only in active config', 'medium',
+      'It is not in config/sync, so a drush cim before the demo silently flips it off and routes '
+      . 'every MitID-gated flow to its deny terminal. Export or verify it before a client session.',
+    ],
+    [
+      '5 flows are GREY (parent-approval overlap, stub labels)', 'medium',
+      'parent_dual_approval_working, parent_submission_simple, caseworker_review_flow, hr_onboarding, '
+      . 'association_booking - keep off-screen; demo merudgifter, friplads, klage instead.',
+    ],
   ];
 
   /**
@@ -269,7 +317,12 @@ class ReadinessController extends ControllerBase {
       ],
       'table' => [
         '#type' => 'table',
-        '#header' => [$this->t('Integration'), $this->t('Contract'), $this->t('Status'), $this->t('What is needed for production')],
+        '#header' => [
+          $this->t('Integration'),
+          $this->t('Contract'),
+          $this->t('Status'),
+          $this->t('What is needed for production'),
+        ],
         '#rows' => $rows,
         '#attributes' => ['class' => ['af-trace-table']],
       ],

--- a/web/modules/custom/aabenforms_core/src/Controller/WebformApiController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/WebformApiController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_core\Controller;
 
+use Drupal\aabenforms_core\Service\TraceStore;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Controller\ControllerBase;
@@ -21,11 +22,17 @@ class WebformApiController extends ControllerBase {
   protected WorkflowExecutionCollector $executionCollector;
 
   /**
+   * The trace store.
+   */
+  protected TraceStore $traceStore;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
     $instance = parent::create($container);
     $instance->executionCollector = $container->get('aabenforms_core.workflow_execution_collector');
+    $instance->traceStore = $container->get('aabenforms_core.trace_store');
     return $instance;
   }
 
@@ -61,11 +68,144 @@ class WebformApiController extends ControllerBase {
           'description' => $webform->get('description'),
           'elements' => $webform->getElementsDecodedAndFlattened(),
           'settings' => $webform->getSettings(),
+          'requires_mitid' => $this->webformRequiresMitId($webform->id()),
         ],
       ],
     ];
 
     return new JsonResponse($data);
+  }
+
+  /**
+   * Persists the execution trace, resolving the case opened from the submission.
+   *
+   * Never lets a tracing failure break the submission response - the trace is
+   * evidence, not part of the transaction.
+   *
+   * @param int $sid
+   *   The submission id.
+   * @param string $webform_id
+   *   The webform machine name.
+   * @param array $execution
+   *   The collector's toArray() result.
+   */
+  protected function persistTrace(int $sid, string $webform_id, array $execution): void {
+    try {
+      $case_id = NULL;
+      $case_ids = $this->entityTypeManager()->getStorage('aabenforms_case')->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('submission_ref', $sid)
+        ->range(0, 1)
+        ->execute();
+      if ($case_ids) {
+        $case_id = (int) reset($case_ids);
+      }
+      $this->traceStore->save($sid, $webform_id, $case_id, $execution);
+    }
+    catch (\Exception $e) {
+      $this->getLogger('aabenforms_core')->warning('Trace persist failed for submission @sid: @error', [
+        '@sid' => $sid,
+        '@error' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  /**
+   * Whether any active ECA flow bound to this webform gates on MitID.
+   *
+   * The flow is the source of truth: a form requires MitID login exactly when
+   * a flow listening to its submissions runs the aabenforms_mitid_validate
+   * action. The SPA reads this flag and demands a MitID session before it
+   * renders the form, so the identity gate is declared once (in the flow) and
+   * enforced everywhere.
+   *
+   * @param string $webform_id
+   *   The webform machine name.
+   *
+   * @return bool
+   *   TRUE when a bound flow validates MitID.
+   */
+  /**
+   * Replaces masked or empty CPR values with the CPR from the MitID session.
+   *
+   * The session endpoint only ever hands the SPA a masked CPR (250692-XXXX),
+   * so a prefit CPR field submits the mask back. The authoritative CPR lives
+   * server-side in the MitID session; swap it in at intake so downstream
+   * actions (Digital Post, CPR lookup) get a real 10-digit CPR. Only elements
+   * of a CPR type whose submitted value is empty or masked are touched - a
+   * CPR the citizen typed themselves (e.g. their child's) is left alone.
+   *
+   * @param \Drupal\webform\Entity\Webform $webform
+   *   The webform.
+   * @param string $workflow_id
+   *   The workflow id the MitID session is stored under.
+   * @param array $submission_data
+   *   The submitted values.
+   *
+   * @return array
+   *   The submission data, possibly with the session CPR filled in.
+   */
+  protected function fillCprFromMitIdSession(Webform $webform, string $workflow_id, array $submission_data): array {
+    if (!\Drupal::hasService('aabenforms_mitid.session_manager')) {
+      return $submission_data;
+    }
+    $sm = \Drupal::service('aabenforms_mitid.session_manager');
+    // Only a real, verified MitID session may seed a CPR into a submission. A
+    // seeded demo session (demo_seeded) must not - defense in depth against a
+    // fixated workflow_id becoming CPR takeover (see also the server-mint in
+    // MitIdController::login()).
+    $session = $sm->getSession($workflow_id);
+    if (!$session || !empty($session['demo_seeded'])) {
+      return $submission_data;
+    }
+    $cpr = $sm->getCprFromSession($workflow_id);
+    if (!$cpr) {
+      return $submission_data;
+    }
+    // Only the first CPR element belongs to the authenticated applicant; any
+    // further CPR fields (a child's, a partner's) must never inherit it.
+    foreach ($webform->getElementsDecodedAndFlattened() as $key => $element) {
+      if (!in_array($element['#type'] ?? '', ['cpr', 'cpr_field'], TRUE)) {
+        continue;
+      }
+      $value = (string) ($submission_data[$key] ?? '');
+      if ($value === '' || str_contains(strtoupper($value), 'X')) {
+        $submission_data[$key] = $cpr;
+      }
+      break;
+    }
+    return $submission_data;
+  }
+
+  protected function webformRequiresMitId(string $webform_id): bool {
+    try {
+      $storage = $this->entityTypeManager()->getStorage('eca');
+    }
+    catch (\Exception) {
+      return FALSE;
+    }
+    foreach ($storage->loadMultiple() as $eca) {
+      if (!$eca->status()) {
+        continue;
+      }
+      $bound = FALSE;
+      foreach ($eca->get('events') ?? [] as $event) {
+        $type = $event['configuration']['type'] ?? '';
+        if ($type === 'webform_submission ' . $webform_id) {
+          $bound = TRUE;
+          break;
+        }
+      }
+      if (!$bound) {
+        continue;
+      }
+      foreach ($eca->get('actions') ?? [] as $action) {
+        if (($action['plugin'] ?? '') === 'aabenforms_mitid_validate') {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
   }
 
   /**
@@ -92,6 +232,29 @@ class WebformApiController extends ControllerBase {
       return new JsonResponse(['error' => 'Access denied'], 403);
     }
 
+    // CSRF for a cross-origin SPA: reject a browser request whose Origin is not
+    // the trusted frontend. A cookie-bound _csrf_token cannot be used here (the
+    // SPA is on a different origin and has no session cookie). curl/server
+    // clients send no Origin and fall through to the MitID + flood checks.
+    $origin = $request->headers->get('Origin');
+    if ($origin) {
+      $allowed_origins = array_filter([$request->getSchemeAndHttpHost(), getenv('CORS_ALLOW_ORIGIN') ?: '']);
+      if (!in_array($origin, $allowed_origins, TRUE)) {
+        return new JsonResponse(['error' => 'Cross-origin request rejected'], 403);
+      }
+    }
+
+    // Flood control: every accepted submission synchronously drives the full ECA
+    // flow (CPR/CVR lookups, Digital Post), so cap bursts per client + form. A
+    // rolling one-minute window blunts DoS / cost amplification while staying
+    // generous for legitimate use and self-clearing (no hour-long lockouts).
+    $flood = \Drupal::service('flood');
+    $flood_id = $id . ':' . $request->getClientIp();
+    if (!$flood->isAllowed('aabenforms_core.webform_submit', 30, 60, $flood_id)) {
+      return new JsonResponse(['error' => 'Too many submissions, please try again later'], 429);
+    }
+    $flood->register('aabenforms_core.webform_submit', 60, $flood_id);
+
     $content = $request->getContent();
     $data = json_decode($content, TRUE);
 
@@ -112,6 +275,21 @@ class WebformApiController extends ControllerBase {
       ?? NULL;
     if (is_string($workflow_id) && $workflow_id !== '') {
       $request->attributes->set('aabenforms_workflow_id', $workflow_id);
+      $submission_data = $this->fillCprFromMitIdSession($webform, $workflow_id, $submission_data);
+    }
+
+    // Server-side identity gate. If a flow behind this form validates MitID, a
+    // submission without a valid MitID session is rejected here - the
+    // requires_mitid flag is otherwise only advisory to the SPA, and demo-mode
+    // gates must not be a bypass. This also turns the ECA-internal deny into an
+    // early, cheap rejection (no synchronous external calls for an unauth POST).
+    if ($this->webformRequiresMitId($id)) {
+      $sm = \Drupal::hasService('aabenforms_mitid.session_manager')
+        ? \Drupal::service('aabenforms_mitid.session_manager')
+        : NULL;
+      if (!is_string($workflow_id) || $workflow_id === '' || !$sm || !$sm->hasValidSession($workflow_id)) {
+        return new JsonResponse(['error' => 'MitID authentication required'], 401);
+      }
     }
 
     $values = [
@@ -153,9 +331,12 @@ class WebformApiController extends ControllerBase {
         ],
       ];
 
-      // Append workflow execution data if any steps were collected.
+      // Append workflow execution data if any steps were collected, and
+      // persist the trace so the submission can be traced after the fact.
       if ($this->executionCollector->hasSteps()) {
-        $response_data['workflow'] = $this->executionCollector->toArray();
+        $execution = $this->executionCollector->toArray();
+        $response_data['workflow'] = $execution;
+        $this->persistTrace((int) $submission->id(), $id, $execution);
       }
 
       return new JsonResponse($response_data, 201);

--- a/web/modules/custom/aabenforms_core/src/Controller/WebformApiController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/WebformApiController.php
@@ -111,21 +111,6 @@ class WebformApiController extends ControllerBase {
   }
 
   /**
-   * Whether any active ECA flow bound to this webform gates on MitID.
-   *
-   * The flow is the source of truth: a form requires MitID login exactly when
-   * a flow listening to its submissions runs the aabenforms_mitid_validate
-   * action. The SPA reads this flag and demands a MitID session before it
-   * renders the form, so the identity gate is declared once (in the flow) and
-   * enforced everywhere.
-   *
-   * @param string $webform_id
-   *   The webform machine name.
-   *
-   * @return bool
-   *   TRUE when a bound flow validates MitID.
-   */
-  /**
    * Replaces masked or empty CPR values with the CPR from the MitID session.
    *
    * The session endpoint only ever hands the SPA a masked CPR (250692-XXXX),
@@ -177,6 +162,21 @@ class WebformApiController extends ControllerBase {
     return $submission_data;
   }
 
+  /**
+   * Whether any active ECA flow bound to this webform gates on MitID.
+   *
+   * The flow is the source of truth: a form requires MitID login exactly when
+   * a flow listening to its submissions runs the aabenforms_mitid_validate
+   * action. The SPA reads this flag and demands a MitID session before it
+   * renders the form, so the identity gate is declared once (in the flow) and
+   * enforced everywhere.
+   *
+   * @param string $webform_id
+   *   The webform machine name.
+   *
+   * @return bool
+   *   TRUE when a bound flow validates MitID.
+   */
   protected function webformRequiresMitId(string $webform_id): bool {
     try {
       $storage = $this->entityTypeManager()->getStorage('eca');

--- a/web/modules/custom/aabenforms_core/src/Service/TraceStore.php
+++ b/web/modules/custom/aabenforms_core/src/Service/TraceStore.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drupal\aabenforms_core\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+
+/**
+ * Persists and reads workflow execution traces.
+ *
+ * The WorkflowExecutionCollector produces a per-request step list that would
+ * otherwise be lost after the response is sent. This store writes one row per
+ * submission into aabenforms_trace so a case can be traced, debugged and
+ * demonstrated after the fact - the persisted spine of the evidence dashboard.
+ */
+class TraceStore {
+
+  /**
+   * The database connection.
+   */
+  protected Connection $database;
+
+  /**
+   * The time service.
+   */
+  protected TimeInterface $time;
+
+  /**
+   * Constructs the trace store.
+   */
+  public function __construct(Connection $database, TimeInterface $time) {
+    $this->database = $database;
+    $this->time = $time;
+  }
+
+  /**
+   * Records the execution trace for one submission.
+   *
+   * Idempotent per submission: a re-save replaces the prior trace so the table
+   * never accumulates duplicates for the same sid.
+   *
+   * @param int $sid
+   *   The webform submission id.
+   * @param string $webform_id
+   *   The webform machine name.
+   * @param int|null $case_id
+   *   The case opened from the submission, if any.
+   * @param array $execution
+   *   The WorkflowExecutionCollector::toArray() result.
+   */
+  public function save(int $sid, string $webform_id, ?int $case_id, array $execution): void {
+    $steps = $execution['steps'] ?? [];
+    $this->database->delete('aabenforms_trace')
+      ->condition('sid', $sid)
+      ->execute();
+    $this->database->insert('aabenforms_trace')
+      ->fields([
+        'sid' => $sid,
+        'webform_id' => $webform_id,
+        'case_id' => $case_id,
+        'status' => $execution['status'] ?? 'completed',
+        'step_count' => $execution['step_count'] ?? count($steps),
+        'mitid_verified' => $this->mitidVerified($steps) ? 1 : 0,
+        'steps' => json_encode($steps),
+        'created' => $this->time->getRequestTime(),
+      ])
+      ->execute();
+  }
+
+  /**
+   * Loads a single trace by submission id.
+   *
+   * @param int $sid
+   *   The submission id.
+   *
+   * @return array|null
+   *   The trace row with 'steps' decoded to an array, or NULL if none.
+   */
+  public function load(int $sid): ?array {
+    $row = $this->database->select('aabenforms_trace', 't')
+      ->fields('t')
+      ->condition('sid', $sid)
+      ->orderBy('created', 'DESC')
+      ->range(0, 1)
+      ->execute()
+      ->fetchAssoc();
+    if (!$row) {
+      return NULL;
+    }
+    $row['steps'] = $row['steps'] ? json_decode($row['steps'], TRUE) : [];
+    return $row;
+  }
+
+  /**
+   * Returns the most recent traces for the trace list view.
+   *
+   * @param int $limit
+   *   Maximum number of rows.
+   *
+   * @return array[]
+   *   Trace rows (steps left as JSON; the list view does not need them).
+   */
+  public function recent(int $limit = 50): array {
+    return $this->database->select('aabenforms_trace', 't')
+      ->fields('t', ['id', 'sid', 'webform_id', 'case_id', 'status', 'step_count', 'mitid_verified', 'created'])
+      ->orderBy('created', 'DESC')
+      ->range(0, $limit)
+      ->execute()
+      ->fetchAllAssoc('sid');
+  }
+
+  /**
+   * Whether the step list shows a genuinely verified MitID identity.
+   *
+   * A step is the MitID gate when its id is aabenforms_mitid_validate. It only
+   * counts as verified when it completed AND its description does not admit
+   * demo mode ("identity was NOT verified").
+   *
+   * @param array $steps
+   *   The decoded step list.
+   *
+   * @return bool
+   *   TRUE when identity was really verified.
+   */
+  protected function mitidVerified(array $steps): bool {
+    foreach ($steps as $step) {
+      if (($step['id'] ?? '') === 'aabenforms_mitid_validate') {
+        $completed = ($step['status'] ?? '') === 'completed';
+        $demo = stripos($step['description'] ?? '', 'NOT verified') !== FALSE
+          || stripos($step['description'] ?? '', 'demo') !== FALSE;
+        return $completed && !$demo;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.services.yml
+++ b/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.services.yml
@@ -6,6 +6,10 @@ services:
   aabenforms_digital_post.transaction_id_generator:
     class: Drupal\aabenforms_digital_post\Service\TransactionIdGenerator
 
+  # Builds real SF1601 MeMo XML from the DigitalPost DTO (no cert, no network).
+  aabenforms_digital_post.memo_builder:
+    class: Drupal\aabenforms_digital_post\Memo\MemoBuilder
+
   # Certificate locator: file-based default. Factory picks based on config.
   aabenforms_digital_post.certificate_locator.file:
     class: Drupal\aabenforms_digital_post\Certificate\FileCertificateLocator
@@ -29,6 +33,7 @@ services:
       - '@aabenforms_digital_post.transaction_id_generator'
       - '@datetime.time'
       - '@logger.channel.aabenforms_digital_post'
+      - '@aabenforms_digital_post.memo_builder'
 
   aabenforms_digital_post.sf1601_client.wiremock:
     class: Drupal\aabenforms_digital_post\TestMode\WireMockSoapClient
@@ -36,6 +41,7 @@ services:
       - '@http_client'
       - '@config.factory'
       - '@logger.channel.aabenforms_digital_post'
+      - '@aabenforms_digital_post.memo_builder'
 
   aabenforms_digital_post.sf1601_client:
     class: Drupal\aabenforms_digital_post\Service\Sf1601ClientInterface

--- a/web/modules/custom/aabenforms_digital_post/src/Memo/MemoBuilder.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Memo/MemoBuilder.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\Memo;
+
+use DigitalPost\MeMo\AdditionalDocument;
+use DigitalPost\MeMo\File;
+use DigitalPost\MeMo\MainDocument;
+use DigitalPost\MeMo\Message;
+use DigitalPost\MeMo\MessageBody;
+use DigitalPost\MeMo\MessageHeader;
+use DigitalPost\MeMo\Recipient as MeMoRecipient;
+use DigitalPost\MeMo\Sender as MeMoSender;
+use Drupal\aabenforms_digital_post\DigitalPost\Attachment;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use ItkDev\Serviceplatformen\Service\SF1601\Serializer;
+use ItkDev\Serviceplatformen\Service\SF1601\SF1601;
+
+/**
+ * Builds real SF1601 MeMo messages from the module's DigitalPost DTO.
+ *
+ * MeMo is the national Digital Post message format. This builder maps the
+ * transport-agnostic DigitalPost DTO onto the value objects shipped by
+ * itk-dev/serviceplatformen (lib/DigitalPost/MeMo/*) and serialises them to
+ * XML with the library's Serializer - a pure, in-process operation that needs
+ * NO certificate and NO network. The same builder is the single source of
+ * truth for every transport: the fake_db logger stores the XML as evidence,
+ * the WireMock transport POSTs it, and a future live client passes the Message
+ * object straight to SF1601::kombiPostAfsend().
+ *
+ * Construction mirrors the reference implementation
+ * OS2Forms os2forms_digital_post MeMoHelper::buildMessage() and the library's
+ * own KombiPostAfsendCommand::buildMessage().
+ */
+class MemoBuilder {
+
+  /**
+   * Default MeMo version (1.2; 1.1 also supported by the library).
+   */
+  protected const DEFAULT_MEMO_VERSION = 1.2;
+
+  /**
+   * Builds the MeMo Message object for a Digital Post.
+   *
+   * This is the reuse seam: a live SF1601 client passes the returned object to
+   * kombiPostAfsend() unchanged.
+   *
+   * @param \Drupal\aabenforms_digital_post\DigitalPost\DigitalPost $post
+   *   The Digital Post to render.
+   *
+   * @return \DigitalPost\MeMo\Message
+   *   The MeMo message value object.
+   */
+  public function buildMessage(DigitalPost $post): Message {
+    return $this->withoutVendorDeprecations(fn () => $this->doBuildMessage($post));
+  }
+
+  /**
+   * Builds the MeMo Message (see buildMessage()).
+   */
+  protected function doBuildMessage(DigitalPost $post): Message {
+    $header = (new MessageHeader())
+      ->setMessageType(SF1601::MESSAGE_TYPE_DIGITAL_POST)
+      ->setMessageUUID(Serializer::createUuid())
+      ->setMessageID(Serializer::createUuid())
+      ->setLabel($post->subject)
+      ->setMandatory(FALSE)
+      ->setLegalNotification(FALSE)
+      ->setSender($this->buildSender($post->sender))
+      ->setRecipient($this->buildRecipient($post->recipient));
+
+    // MeMo has no free-text body element - the message body is carried as a
+    // document. Render the (HTML) body as the main document.
+    $mainDocument = (new MainDocument())
+      ->setFile([$this->buildBodyFile($post)]);
+
+    $body = (new MessageBody())
+      ->setCreatedDateTime(new \DateTime())
+      ->setMainDocument($mainDocument);
+
+    foreach ($post->attachments as $attachment) {
+      $body->addToAdditionalDocument($this->buildAttachmentDocument($attachment));
+    }
+
+    $version = (float) ($post->meta['memo_version'] ?? self::DEFAULT_MEMO_VERSION);
+
+    return (new Message())
+      ->setMemoVersion($version)
+      ->setMessageHeader($header)
+      ->setMessageBody($body);
+  }
+
+  /**
+   * Serialises a MeMo Message to an XML string (no cert, no network).
+   */
+  public function serializeMessage(Message $message): string {
+    return $this->withoutVendorDeprecations(fn () => (new Serializer())->serialize($message));
+  }
+
+  /**
+   * Runs a callback with E_DEPRECATED silenced.
+   *
+   * The vendored itk-dev/serviceplatformen MeMo classes emit PHP 8.4
+   * implicit-nullable deprecations at load time. Silence them here so callers
+   * (and tests) get clean output; restore the prior level afterwards.
+   */
+  protected function withoutVendorDeprecations(callable $fn): mixed {
+    $previous = error_reporting();
+    error_reporting($previous & ~E_DEPRECATED);
+    try {
+      return $fn();
+    }
+    finally {
+      error_reporting($previous);
+    }
+  }
+
+  /**
+   * Builds the full SF1601 kombi_request wire payload for a Digital Post.
+   *
+   * Mirrors SF1601::buildKombiRequestDocument() (the KombiValgKode wrapper
+   * around the MeMo Message) without invoking the certificate-signed SOAP call.
+   * This is the exact XML a live send would post, so it is the most faithful
+   * artifact to store as evidence or to send to a mock endpoint.
+   */
+  public function buildKombiRequestXml(DigitalPost $post): string {
+    $messageXml = $this->serializeMessage($this->buildMessage($post));
+    // Drop the inner XML declaration so the Message nests inside the wrapper.
+    $messageXml = preg_replace('/^\s*<\?xml[^>]*\?>\s*/', '', $messageXml);
+    $kombiValgKode = htmlspecialchars($post->type, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+    return '<kombi_request><KombiValgKode>' . $kombiValgKode . '</KombiValgKode>'
+      . $messageXml . '</kombi_request>';
+  }
+
+  /**
+   * Maps the DTO sender to a MeMo Sender.
+   *
+   * MeMo requires a non-empty sender label; the DTO name is optional, so fall
+   * back to the CVR when it is empty.
+   */
+  protected function buildSender(Sender $sender): MeMoSender {
+    $label = $sender->name !== '' ? $sender->name : $sender->cvr;
+    return (new MeMoSender())
+      ->setIdType('CVR')
+      ->setSenderID($sender->cvr)
+      ->setLabel($label);
+  }
+
+  /**
+   * Maps the DTO recipient to a MeMo Recipient (idType uppercased).
+   */
+  protected function buildRecipient(Recipient $recipient): MeMoRecipient {
+    return (new MeMoRecipient())
+      ->setIdType(strtoupper($recipient->type))
+      ->setRecipientID($recipient->identifier);
+  }
+
+  /**
+   * Renders the Digital Post body as the MeMo main-document File.
+   */
+  protected function buildBodyFile(DigitalPost $post): File {
+    return (new File())
+      ->setEncodingFormat('text/html')
+      ->setLanguage('da')
+      ->setFilename('besked.html')
+      // Raw bytes; the serializer base64-encodes the content element.
+      ->setContent($post->body);
+  }
+
+  /**
+   * Maps an attachment to a MeMo AdditionalDocument.
+   */
+  protected function buildAttachmentDocument(Attachment $attachment): AdditionalDocument {
+    $file = (new File())
+      ->setEncodingFormat($attachment->mimeType)
+      ->setLanguage('da')
+      ->setFilename($attachment->filename)
+      ->setContent($attachment->bytes());
+    return (new AdditionalDocument())
+      ->setLabel($attachment->filename)
+      ->setFile([$file]);
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/src/TestMode/FakeSendDatabaseLogger.php
+++ b/web/modules/custom/aabenforms_digital_post/src/TestMode/FakeSendDatabaseLogger.php
@@ -6,6 +6,7 @@ namespace Drupal\aabenforms_digital_post\TestMode;
 
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\aabenforms_digital_post\Memo\MemoBuilder;
 use Drupal\aabenforms_digital_post\Service\Sf1601ClientInterface;
 use Drupal\aabenforms_digital_post\Service\TransactionIdGenerator;
 use Drupal\Component\Datetime\TimeInterface;
@@ -34,6 +35,7 @@ final class FakeSendDatabaseLogger implements Sf1601ClientInterface {
     private readonly TransactionIdGenerator $transactionIdGenerator,
     private readonly TimeInterface $time,
     private readonly LoggerInterface $logger,
+    private readonly MemoBuilder $memoBuilder,
   ) {
   }
 
@@ -60,6 +62,10 @@ final class FakeSendDatabaseLogger implements Sf1601ClientInterface {
       ], $post->attachments),
       'total_attachment_bytes' => $post->totalAttachmentBytes(),
       'meta' => $post->meta,
+      // The real SF1601 MeMo wire payload (kombi_request XML). This is what a
+      // live send would post; storing it makes the evidence dashboard show
+      // genuine message construction rather than the JSON summary above.
+      'memo_xml' => $this->buildMemoXml($post),
     ];
     try {
       $this->database->insert('aabenforms_digital_post_log')
@@ -96,6 +102,29 @@ final class FakeSendDatabaseLogger implements Sf1601ClientInterface {
         reasonCode: Result::REASON_TRANSPORT,
         message: 'fake_db write failed: ' . $e->getMessage(),
       );
+    }
+  }
+
+  /**
+   * Builds the MeMo kombi_request XML, tolerating build failures.
+   *
+   * The evidence is nice-to-have: a build failure must never fail the send
+   * (the case must still reach lukket), so it logs a warning and returns NULL.
+   * The vendored MeMo classes emit PHP 8.4 implicit-nullable deprecations at
+   * load time; those are silenced around the build to keep the log clean.
+   */
+  private function buildMemoXml(DigitalPost $post): ?string {
+    $previous = error_reporting();
+    error_reporting($previous & ~E_DEPRECATED);
+    try {
+      return $this->memoBuilder->buildKombiRequestXml($post);
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('MeMo build failed (logging JSON summary only): @msg', ['@msg' => $e->getMessage()]);
+      return NULL;
+    }
+    finally {
+      error_reporting($previous);
     }
   }
 

--- a/web/modules/custom/aabenforms_digital_post/src/TestMode/WireMockSoapClient.php
+++ b/web/modules/custom/aabenforms_digital_post/src/TestMode/WireMockSoapClient.php
@@ -6,6 +6,7 @@ namespace Drupal\aabenforms_digital_post\TestMode;
 
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\aabenforms_digital_post\Memo\MemoBuilder;
 use Drupal\aabenforms_digital_post\Service\Sf1601ClientInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use GuzzleHttp\ClientInterface;
@@ -13,14 +14,14 @@ use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
 
 /**
- * Posts a Digital Post to a WireMock endpoint for integration tests.
+ * Posts a real MeMo XML Digital Post to a WireMock endpoint for integration.
  *
- * This is NOT a real MeMo XML build. Session 1 ships a JSON body that
- * WireMock matches on URL + method and responds to with a canned receipt.
- * Session 2 replaces this with a real SOAP+MeMo payload via
- * itk-dev/serviceplatformen's SF1601 class. Keeping the JSON shape
- * simple lets us prove the end-to-end wiring tonight without getting
- * bogged down in MeMo XSD-compliance.
+ * Builds the actual SF1601 kombi_request MeMo payload via MemoBuilder and
+ * POSTs it as application/xml to the KombiPostAfsend endpoint - the same XML a
+ * live send would post, minus the certificate/SOAP transport (which lives in
+ * SF1601::kombiPostAfsend and is cert-gated). The WireMock stub matches the
+ * MeMo body via matchesXPath and returns a templated receipt, giving a
+ * cert-free end-to-end integration test of real message construction.
  *
  * WireMock URL defaults to http://wiremock:8080 which matches the DDEV
  * container alias. Set aabenforms_digital_post.settings.wiremock_url to
@@ -32,6 +33,7 @@ final class WireMockSoapClient implements Sf1601ClientInterface {
     private readonly ClientInterface $httpClient,
     private readonly ConfigFactoryInterface $configFactory,
     private readonly LoggerInterface $logger,
+    private readonly MemoBuilder $memoBuilder,
   ) {
   }
 
@@ -50,30 +52,32 @@ final class WireMockSoapClient implements Sf1601ClientInterface {
       );
     }
     $url = rtrim($base, '/') . '/service/KombiPostAfsend_1/kombi';
-    $body = [
-      'transaction_id' => $transactionId,
-      'type' => $post->type,
-      'recipient' => [
-        'type' => $post->recipient->type,
-        'identifier' => $post->recipient->identifier,
-      ],
-      'sender_cvr' => $post->sender->cvr,
-      'sender_name' => $post->sender->name,
-      'subject' => $post->subject,
-      'body' => $post->body,
-      'attachments' => array_map(static fn ($a) => [
-        'filename' => $a->filename,
-        'mime' => $a->mimeType,
-        'size' => $a->sizeBytes,
-      ], $post->attachments),
+    try {
+      $xml = $this->buildXml($post);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Digital Post MeMo build failed: @msg', ['@msg' => $e->getMessage()]);
+      return Result::failure(
+        transactionId: $transactionId,
+        reasonCode: Result::REASON_VALIDATION,
+        message: 'MeMo build failed: ' . $e->getMessage(),
+      );
+    }
+    $headers = [
+      'Content-Type' => 'application/xml',
+      'Accept' => 'application/xml',
+      'X-Transaction-Id' => $transactionId,
+      'X-SF1601-Type' => $post->type,
     ];
+    // The size-rejection test scenario is keyed off a header now (the old JSON
+    // meta.force_too_large matcher can't match an XML body).
+    if (!empty($post->meta['force_too_large'])) {
+      $headers['X-Force-Too-Large'] = '1';
+    }
     try {
       $response = $this->httpClient->request('POST', $url, [
-        'json' => $body,
-        'headers' => [
-          'X-Transaction-Id' => $transactionId,
-          'X-SF1601-Type' => $post->type,
-        ],
+        'body' => $xml,
+        'headers' => $headers,
         'http_errors' => FALSE,
         'timeout' => 10,
       ]);
@@ -101,6 +105,20 @@ final class WireMockSoapClient implements Sf1601ClientInterface {
         reasonCode: Result::REASON_TRANSPORT,
         message: 'wiremock transport error: ' . $e->getMessage(),
       );
+    }
+  }
+
+  /**
+   * Builds the MeMo kombi_request XML, silencing vendor load-time deprecations.
+   */
+  private function buildXml(DigitalPost $post): string {
+    $previous = error_reporting();
+    error_reporting($previous & ~E_DEPRECATED);
+    try {
+      return $this->memoBuilder->buildKombiRequestXml($post);
+    }
+    finally {
+      error_reporting($previous);
     }
   }
 

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Memo/MemoBuilderTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Memo/MemoBuilderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\Memo;
+
+use Drupal\aabenforms_digital_post\DigitalPost\Attachment;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\aabenforms_digital_post\Memo\MemoBuilder;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests that MemoBuilder produces valid SF1601 MeMo XML.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\Memo\MemoBuilder
+ * @group aabenforms_digital_post
+ */
+class MemoBuilderTest extends UnitTestCase {
+
+  private const NS = 'https://DigitalPost.dk/MeMo-1';
+
+  /**
+   * A Digital Post maps to a well-formed kombi_request with a MeMo Message.
+   */
+  public function testBuildsValidMemoKombiRequest(): void {
+    $post = new DigitalPost(
+      Recipient::cpr('2506924015'),
+      new Sender('12345678', 'Test Kommune'),
+      'Afgørelse: merudgiftsydelse',
+      '<p>Din ansøgning er imødekommet.</p>',
+      [],
+      DigitalPost::TYPE_DIGITAL_POST,
+      ['memo_version' => 1.2],
+    );
+
+    $xml = (new MemoBuilder())->buildKombiRequestXml($post);
+
+    $dom = new \DOMDocument();
+    $this->assertTrue($dom->loadXML($xml), 'MeMo XML is well-formed.');
+    $this->assertSame('kombi_request', $dom->documentElement->nodeName);
+
+    $xpath = new \DOMXPath($dom);
+    $xpath->registerNamespace('memo', self::NS);
+
+    $this->assertSame('Digital Post', $this->text($xpath, '//KombiValgKode'));
+    $this->assertSame('DIGITALPOST', $this->text($xpath, '//memo:messageType'));
+    $this->assertSame('Afgørelse: merudgiftsydelse', $this->text($xpath, '//memo:MessageHeader/memo:label'));
+    $this->assertSame('12345678', $this->text($xpath, '//memo:senderID'));
+    $this->assertSame('CVR', $this->text($xpath, '//memo:Sender/memo:idType'));
+    $this->assertSame('Test Kommune', $this->text($xpath, '//memo:Sender/memo:label'));
+    $this->assertSame('2506924015', $this->text($xpath, '//memo:recipientID'));
+    $this->assertSame('CPR', $this->text($xpath, '//memo:Recipient/memo:idType'));
+    $this->assertSame('text/html', $this->text($xpath, '//memo:encodingFormat'));
+    $this->assertSame('besked.html', $this->text($xpath, '//memo:filename'));
+    // The HTML body is carried as base64 in the main document's File content.
+    $this->assertSame(
+      base64_encode('<p>Din ansøgning er imødekommet.</p>'),
+      $this->text($xpath, '//memo:content'),
+    );
+  }
+
+  /**
+   * An empty sender name falls back to the CVR (MeMo requires a label).
+   */
+  public function testSenderLabelFallsBackToCvr(): void {
+    $post = new DigitalPost(
+      Recipient::cvr('12345678'),
+      new Sender('87654321'),
+      'Emne',
+      '<p>Body</p>',
+    );
+
+    $xml = (new MemoBuilder())->buildKombiRequestXml($post);
+    $xpath = new \DOMXPath($this->load($xml));
+    $xpath->registerNamespace('memo', self::NS);
+
+    $this->assertSame('87654321', $this->text($xpath, '//memo:Sender/memo:label'));
+    $this->assertSame('CVR', $this->text($xpath, '//memo:Recipient/memo:idType'));
+  }
+
+  /**
+   * Attachments become AdditionalDocument entries.
+   */
+  public function testAttachmentBecomesAdditionalDocument(): void {
+    $post = new DigitalPost(
+      Recipient::cpr('2506924015'),
+      new Sender('12345678', 'Test Kommune'),
+      'Emne',
+      '<p>Body</p>',
+      [Attachment::fromBytes('PDFDATA', 'bilag.pdf', 'application/pdf')],
+    );
+
+    $xml = (new MemoBuilder())->buildKombiRequestXml($post);
+    $xpath = new \DOMXPath($this->load($xml));
+    $xpath->registerNamespace('memo', self::NS);
+
+    $this->assertSame('bilag.pdf', $this->text($xpath, '//memo:AdditionalDocument/memo:File/memo:filename'));
+    $this->assertSame('application/pdf', $this->text($xpath, '//memo:AdditionalDocument/memo:File/memo:encodingFormat'));
+  }
+
+  /**
+   * Loads XML into a DOMDocument, asserting well-formedness.
+   */
+  private function load(string $xml): \DOMDocument {
+    $dom = new \DOMDocument();
+    $this->assertTrue($dom->loadXML($xml));
+    return $dom;
+  }
+
+  /**
+   * Returns the trimmed text content of the first node matching an XPath.
+   */
+  private function text(\DOMXPath $xpath, string $expression): string {
+    $node = $xpath->query($expression)->item(0);
+    return $node ? trim($node->textContent) : '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/src/Controller/MitIdController.php
+++ b/web/modules/custom/aabenforms_mitid/src/Controller/MitIdController.php
@@ -78,14 +78,24 @@ class MitIdController extends ControllerBase {
    *   Redirect to MitID authorization.
    */
   public function login(Request $request): TrustedRedirectResponse {
-    // Get workflow ID from query params or generate. The generated ID is the
-    // bearer capability for the session payload, so it must be unguessable -
-    // bin2hex(random_bytes(...)) gives 32 hex chars (128 bits of entropy).
-    $workflowId = $request->query->get('workflow_id') ?? 'wf_' . bin2hex(random_bytes(16));
+    // Always server-mint the workflow ID. It is the bearer capability for the
+    // session payload (the session is stored under it), so a client must never
+    // be allowed to choose it - honoring a ?workflow_id= would let a caller fix
+    // the session key and later read another user's session / CPR. 32 hex chars
+    // = 128 bits of entropy.
+    $workflowId = 'wf_' . bin2hex(random_bytes(16));
 
     // Get redirect URL (where to return after auth).
     // Validate that it's an internal path to prevent open redirect attacks.
     $returnUrl = $request->query->get('return_url') ?? '/';
+
+    // Reject backslashes outright: browsers normalise "/\" and "\/" to "//"
+    // (protocol-relative), so a value like "/\evil.com" that looks local here
+    // would redirect off-site after the session id is appended in callback().
+    if (str_contains($returnUrl, '\\')) {
+      $this->getLogger('aabenforms_mitid')->warning('Rejected return_url with backslash: @url', ['@url' => $returnUrl]);
+      $returnUrl = '/';
+    }
 
     // Strip any external URLs - only allow internal paths or trusted frontend origins.
     if (preg_match('#^https?://#i', $returnUrl)) {

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -149,9 +149,14 @@ class MitIdValidateAction extends AabenFormsActionBase {
    */
   protected function recordNoSession(string $context): void {
     if ($this->demoModeAllowed()) {
-      $this->log('MitID validation: ' . $context . ' - demo mode (allow_mitid_demo_mode on)', [], 'info');
-      $this->setTokenValue($this->configuration['result_token'], TRUE);
-      $this->setResultStatus('verified');
+      // Demo mode lets a workflow run without a real session, but it must NEVER
+      // claim a verified identity: the status scalar the gates read stays
+      // non-verified ('demo_unverified'), and the legacy boolean is FALSE, so no
+      // gate comparing == 'verified' can be fooled into treating an unverified
+      // demo submission as authenticated. The audit trail records the truth.
+      $this->log('MitID validation: ' . $context . ' - demo mode (allow_mitid_demo_mode on), identity NOT verified', [], 'info');
+      $this->setTokenValue($this->configuration['result_token'], FALSE);
+      $this->setResultStatus('demo_unverified');
       $this->recordStep('MitID Identity Validation', 'Demo mode: identity was NOT verified (no MitID session)', 'completed');
       return;
     }


### PR DESCRIPTION
Foundation branch for this week's PoC-hardening work (base for the two stacked PRs that follow).

**Evidence + readiness (the glass box)**
- Persisted workflow execution trace (`aabenforms_trace`) + `TraceStore`; previously the trace was request-scoped and lost.
- Evidence trace dashboard `/admin/aabenforms/trace/{sid}` (per-submission service-contract timeline, case summary, real SF1601 MeMo XML, GDPR audit) and a Readiness board `/admin/aabenforms/readiness`, linked from the main dashboard.

**Security hardening (Track 1)**
- Server-mint the MitID `workflow_id` (ignore any client-supplied value); reject backslash open-redirects.
- Demo mode records a non-verified status (never `verified`); `allow_mitid_demo_mode` exported to config/sync (default off).
- Server-side MitID enforcement on `/api/webform/{id}/submit` (401 when a bound flow requires MitID and no valid session), origin allowlist (403), and flood control (429).
- CPR injection guarded against demo-seeded sessions.

**Real SF1601 MeMo (Track 2)** - cert-free
- `MemoBuilder` maps the DigitalPost DTO to the vendored itk-dev MeMo objects and serialises a real `kombi_request` message (no cert, no network). fake_db stores it; the evidence trace renders it; WireMock posts it with a namespace-aware XPath stub. `MemoBuilderTest` passes. Refs #77.

**Flow cleanup + fixes**
- Corrected stale ECA tokens (hr_onboarding, association_booking), disabled two redundant parent-approval flows (#144); CORS_ALLOW_ORIGIN fix.

Demo (OIDC mock rail, fake_db Digital Post) works unchanged. Frontend counterpart is a sibling PR in aabenforms-frontend.
