### PR TITLE
Multi-tenant data isolation (#141, #174)

### DIFF
--- a/web/modules/custom/aabenforms_core/aabenforms_core.install
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.install
@@ -63,6 +63,13 @@ function aabenforms_core_schema() {
         'not null' => FALSE,
         'description' => 'Additional context data as JSON.',
       ],
+      'tenant_id' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The tenant (domain/kommune) the action occurred for; empty in single-tenant mode.',
+      ],
       'timestamp' => [
         'type' => 'int',
         'unsigned' => TRUE,
@@ -76,6 +83,7 @@ function aabenforms_core_schema() {
       'uid' => ['uid'],
       'timestamp' => ['timestamp'],
       'identifier_hash' => ['identifier_hash'],
+      'tenant_id' => ['tenant_id'],
     ],
   ];
 
@@ -151,6 +159,13 @@ function aabenforms_core_trace_schema_definition(): array {
         'not null' => FALSE,
         'description' => 'The full step list as JSON.',
       ],
+      'tenant_id' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The tenant (domain/kommune) the submission belonged to; empty in single-tenant mode.',
+      ],
       'created' => [
         'type' => 'int',
         'unsigned' => TRUE,
@@ -163,6 +178,7 @@ function aabenforms_core_trace_schema_definition(): array {
       'sid' => ['sid'],
       'case_id' => ['case_id'],
       'created' => ['created'],
+      'tenant_id' => ['tenant_id'],
     ],
   ];
 }
@@ -276,6 +292,29 @@ function aabenforms_core_update_11003(): string {
     return 'created aabenforms_trace table';
   }
   return 'no changes - aabenforms_trace already present';
+}
+
+/**
+ * Adds tenant_id to aabenforms_audit_log and aabenforms_trace (isolation #141).
+ */
+function aabenforms_core_update_11004(): string {
+  $schema = \Drupal::database()->schema();
+  $spec = [
+    'type' => 'varchar',
+    'length' => 64,
+    'not null' => TRUE,
+    'default' => '',
+    'description' => 'The tenant (domain/kommune); empty in single-tenant mode.',
+  ];
+  $changed = [];
+  foreach (['aabenforms_audit_log', 'aabenforms_trace'] as $table) {
+    if ($schema->tableExists($table) && !$schema->fieldExists($table, 'tenant_id')) {
+      $schema->addField($table, 'tenant_id', $spec);
+      $schema->addIndex($table, 'tenant_id', ['tenant_id'], ['fields' => ['tenant_id' => $spec]]);
+      $changed[] = $table;
+    }
+  }
+  return $changed ? 'Added tenant_id to: ' . implode(', ', $changed) : 'tenant_id already present.';
 }
 
 /**

--- a/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
@@ -30,6 +30,7 @@ services:
       - '@request_stack'
       - '@datetime.time'
       - '@logger.factory'
+      - '@aabenforms_core.tenant_resolver'
 
   aabenforms_core.workflow_execution_collector:
     class: Drupal\aabenforms_core\Service\WorkflowExecutionCollector
@@ -39,6 +40,7 @@ services:
     arguments:
       - '@database'
       - '@datetime.time'
+      - '@aabenforms_core.tenant_resolver'
 
   aabenforms_core.tenant_resolver:
     class: Drupal\aabenforms_core\Service\TenantResolver

--- a/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
@@ -19,6 +19,7 @@ services:
     class: Drupal\aabenforms_core\Service\CprAccess
     arguments:
       - '@aabenforms_core.encryption_service'
+      - '@aabenforms_core.tenant_resolver'
       - '@logger.factory'
 
   aabenforms_core.audit_logger:

--- a/web/modules/custom/aabenforms_core/src/Controller/ReadinessController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/ReadinessController.php
@@ -34,7 +34,8 @@ class ReadinessController extends ControllerBase {
     ['GDPR audit logging', 'ready', 'Every sensitive access hashed (SHA-256) and logged with purpose'],
     ['Case (sag) lifecycle', 'ready', 'Lawful transitions, frist clock, immutable once closed'],
     ['Evidence trace dashboard', 'ready', 'Per-submission trace across every service contract (this tool)'],
-    ['MitID OIDC - protocol layer', 'ready', 'Real PKCE + RS256/JWKS verification + NSIS LoA enforcement'],
+    ['MitID OIDC - protocol layer', 'ready', 'Real PKCE + RS256/JWKS verification + NSIS LoA enforced at login'],
+    ['Multi-tenant data isolation', 'ready', 'Per-tenant access control + query scoping + per-tenant CPR keys; kernel-tested cross-tenant deny (#141)'],
   ];
 
   /**
@@ -44,7 +45,7 @@ class ReadinessController extends ControllerBase {
    * live-capable | mock | stub. Source: integration readiness audit.
    */
   protected const INTEGRATIONS = [
-    ['MitID / NemLog-in', 'OIDC', 'live-capable', 'Broker/NemLog-in registration; verified only against the Keycloak mock (#79)'],
+    ['MitID / NemLog-in', 'OIDC', 'live-capable', 'OIDC crypto is production-grade, but a production KOMMUNE login is OIOSAML 3 (SAML) via NemLog-in, not OIDC; the OIDC rail is demo/private-sector (#79)'],
     ['CPR person lookup', 'SF1520', 'mock', 'Real KOMBIT protocol (InvocationContext, OCES3 mTLS) + service agreement (#76)'],
     ['CVR company lookup', 'SF1530', 'mock', 'Same certificate + protocol work as SF1520 (#76)'],
     ['Digital Post (MeMo)', 'SF1601', 'mock', 'Real MeMo XML builder + SOAP (library bundled, unwired); cert; idempotency (#73, #77)'],
@@ -65,14 +66,10 @@ class ReadinessController extends ControllerBase {
    * showing these plainly, not hiding them behind a green demo.
    */
   protected const FINDINGS = [
-    ['MitID gate fails open in demo mode', 'critical', 'allow_mitid_demo_mode is ON - an unverified identity is recorded as "verified" and an anonymous POST can open a real case. Turn OFF for any CPR-touching POC.'],
-    ['Client-supplied workflow_id honoured at login', 'critical', 'The session/bearer id must be server-minted only; today a crafted /mitid/login?workflow_id=… enables session and CPR takeover.'],
-    ['Open redirect in MitID return_url', 'high', 'Backslash paths (\\evil.com) bypass the prefix guard and can leak the session token. Use strict local-path validation.'],
-    ['Anonymous can call the webform API', 'high', 'access webform api is granted to anonymous; the requires_mitid flag is advisory only. Add server-side MitID enforcement on submit.'],
-    ['No rate limit / CSRF on /submit', 'high', 'Each submission synchronously drives the full ECA flow (CPR/CVR/Digital Post). Unthrottled anonymous access is a DoS + external-call cost-amplification vector. Add flood control + origin/CSRF checks.'],
-    ['case_worker submission access is un-scoped', 'high', 'view/edit any webform submission has no tenant scoping - acceptable for a single-tenant POC, not for multi-tenant.'],
-    ['allow_mitid_demo_mode lives only in active config', 'medium', 'It is not in config/sync, so a drush cim before the demo silently flips it off and routes every MitID-gated flow to its deny terminal. Export or verify it before a client session.'],
-    ['5 flows are GREY (parent-approval overlap, stub labels)', 'medium', 'parent_dual_approval_working, parent_submission_simple, caseworker_review_flow, hr_onboarding, association_booking - keep off-screen; demo merudgifter, friplads, klage instead.'],
+    ['Production kommune login needs OIOSAML 3', 'high', 'The OIDC/MitID rail is demo/private-sector. A real kommune citizen login is OIOSAML 3 (SAML) via NemLog-in at NSIS Substantial; needs the aabenforms_nemlogin SP + broker registration (#79).'],
+    ['Assurance enforced at login, not at the workflow gate', 'medium', 'NSIS level is enforced at the OIDC callback, but MitIdValidateAction treats any live session as verified, so a per-flow "requires High" cannot be enforced (#157).'],
+    ['Government transports run on mock rails', 'medium', 'CPR/CVR (SF1520/1530), Digital Post (SF1601, real MeMo built), SF2900, SF1470, ESDH and eIndkomst need OCES3 certs + a serviceaftale to go live (#76, #77, #84-#86).'],
+    ['Audit + trace not tenant-scoped', 'medium', 'aabenforms_audit_log and aabenforms_trace have no tenant_id (operator-visible only, so reporting segregation not a caseworker leak) (#174).'],
   ];
 
   /**
@@ -136,7 +133,7 @@ class ReadinessController extends ControllerBase {
       'note' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('The encryption, audit and OIDC-crypto layers passed. These are the open items an adversarial test surfaced - most are demo affordances that must be locked down for production.'),
+        '#value' => $this->t('The POC security holes an adversarial test found have been closed (demo-mode fail-open, client-supplied workflow_id, open-redirect, unthrottled submit, and cross-tenant data access are all fixed and tested). These are the open items on the path to a real kommune pilot.'),
         '#attributes' => ['class' => ['af-trace-intro']],
       ],
       'table' => [

--- a/web/modules/custom/aabenforms_core/src/Service/AuditLogger.php
+++ b/web/modules/custom/aabenforms_core/src/Service/AuditLogger.php
@@ -76,18 +76,27 @@ class AuditLogger {
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
    */
+  /**
+   * The tenant resolver.
+   *
+   * @var \Drupal\aabenforms_core\Service\TenantResolver
+   */
+  protected TenantResolver $tenantResolver;
+
   public function __construct(
     Connection $database,
     AccountProxyInterface $current_user,
     RequestStack $request_stack,
     TimeInterface $time,
     LoggerChannelFactoryInterface $logger_factory,
+    TenantResolver $tenant_resolver,
   ) {
     $this->database = $database;
     $this->currentUser = $current_user;
     $this->requestStack = $request_stack;
     $this->time = $time;
     $this->logger = $logger_factory->get('aabenforms_audit');
+    $this->tenantResolver = $tenant_resolver;
   }
 
   /**
@@ -165,6 +174,7 @@ class AuditLogger {
       'status' => $status,
       'ip_address' => $ip_address,
       'context' => json_encode($context),
+      'tenant_id' => $this->tenantResolver->getCurrentTenantId() ?? '',
       'timestamp' => $this->time->getRequestTime(),
     ];
 

--- a/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
+++ b/web/modules/custom/aabenforms_core/src/Service/CprAccess.php
@@ -19,9 +19,19 @@ use Psr\Log\LoggerInterface;
 class CprAccess {
 
   /**
-   * Marker prefixing an encrypted CPR so it can be recognised on read.
+   * Legacy marker: single-key ciphertext, decrypted with the default profile.
    */
   protected const PREFIX = 'AFENC1:';
+
+  /**
+   * Per-tenant marker: format AFENC2:<tenant>:<base64>, per-tenant profile.
+   */
+  protected const PREFIX_TENANT = 'AFENC2:';
+
+  /**
+   * The default (single-tenant / legacy) encryption profile id.
+   */
+  protected const DEFAULT_PROFILE = 'aabenforms_aes256';
 
   /**
    * The encryption service.
@@ -29,6 +39,13 @@ class CprAccess {
    * @var \Drupal\aabenforms_core\Service\EncryptionService
    */
   protected EncryptionService $encryption;
+
+  /**
+   * The tenant resolver.
+   *
+   * @var \Drupal\aabenforms_core\Service\TenantResolver
+   */
+  protected TenantResolver $tenantResolver;
 
   /**
    * The logger.
@@ -42,11 +59,14 @@ class CprAccess {
    *
    * @param \Drupal\aabenforms_core\Service\EncryptionService $encryption
    *   The encryption service.
+   * @param \Drupal\aabenforms_core\Service\TenantResolver $tenant_resolver
+   *   The tenant resolver (selects a per-tenant key when a tenant is active).
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
    */
-  public function __construct(EncryptionService $encryption, LoggerChannelFactoryInterface $logger_factory) {
+  public function __construct(EncryptionService $encryption, TenantResolver $tenant_resolver, LoggerChannelFactoryInterface $logger_factory) {
     $this->encryption = $encryption;
+    $this->tenantResolver = $tenant_resolver;
     $this->logger = $logger_factory->get('aabenforms_core');
   }
 
@@ -57,10 +77,17 @@ class CprAccess {
    *   The value to test.
    *
    * @return bool
-   *   TRUE if the value carries the encryption prefix.
+   *   TRUE if the value carries either encryption prefix.
    */
   public function isProtected(string $value): bool {
-    return str_starts_with($value, self::PREFIX);
+    return str_starts_with($value, self::PREFIX) || str_starts_with($value, self::PREFIX_TENANT);
+  }
+
+  /**
+   * The per-tenant encryption profile id for a tenant.
+   */
+  protected function tenantProfile(string $tenant): string {
+    return self::DEFAULT_PROFILE . '_' . preg_replace('/[^a-z0-9_]/', '', strtolower($tenant));
   }
 
   /**
@@ -87,6 +114,14 @@ class CprAccess {
       return $cpr;
     }
     try {
+      $tenant = $this->tenantResolver->getCurrentTenantId();
+      if (is_string($tenant) && $tenant !== '') {
+        // Multi-tenant: encrypt with this tenant's own key so another tenant's
+        // key cannot decrypt it. The tenant id is embedded for null-context
+        // reads (drush/cron) but same-context reads use the current tenant.
+        return self::PREFIX_TENANT . $tenant . ':' . base64_encode($this->encryption->encrypt($cpr, $this->tenantProfile($tenant)));
+      }
+      // Single-tenant: unchanged legacy format + default profile.
       return self::PREFIX . base64_encode($this->encryption->encrypt($cpr));
     }
     catch (\Throwable $e) {
@@ -108,16 +143,38 @@ class CprAccess {
    *   The plaintext CPR, or '' if decryption fails.
    */
   public function reveal(string $value): string {
-    if (!$this->isProtected($value)) {
-      return $value;
+    if (str_starts_with($value, self::PREFIX_TENANT)) {
+      $rest = substr($value, strlen(self::PREFIX_TENANT));
+      $sep = strpos($rest, ':');
+      if ($sep === FALSE) {
+        return '';
+      }
+      $embedded = substr($rest, 0, $sep);
+      $ciphertext = base64_decode(substr($rest, $sep + 1));
+      // Decrypt with the CURRENT tenant's key when a tenant context exists, so
+      // one kommune cannot reveal another's CPR (the wrong key fails). In a
+      // null context (drush/cron) fall back to the embedded tenant's key.
+      $current = $this->tenantResolver->getCurrentTenantId();
+      $profileTenant = (is_string($current) && $current !== '') ? $current : $embedded;
+      try {
+        return $this->encryption->decrypt($ciphertext, $this->tenantProfile($profileTenant));
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('CPR decryption failed (tenant): {error}', ['error' => $e->getMessage()]);
+        return '';
+      }
     }
-    try {
-      return $this->encryption->decrypt(base64_decode(substr($value, strlen(self::PREFIX))));
+    if (str_starts_with($value, self::PREFIX)) {
+      try {
+        return $this->encryption->decrypt(base64_decode(substr($value, strlen(self::PREFIX))));
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('CPR decryption failed: {error}', ['error' => $e->getMessage()]);
+        return '';
+      }
     }
-    catch (\Throwable $e) {
-      $this->logger->error('CPR decryption failed: {error}', ['error' => $e->getMessage()]);
-      return '';
-    }
+    // Not encrypted (e.g. a session-sourced or already-plaintext CPR).
+    return $value;
   }
 
 }

--- a/web/modules/custom/aabenforms_core/src/Service/TraceStore.php
+++ b/web/modules/custom/aabenforms_core/src/Service/TraceStore.php
@@ -26,11 +26,17 @@ class TraceStore {
   protected TimeInterface $time;
 
   /**
+   * The tenant resolver.
+   */
+  protected TenantResolver $tenantResolver;
+
+  /**
    * Constructs the trace store.
    */
-  public function __construct(Connection $database, TimeInterface $time) {
+  public function __construct(Connection $database, TimeInterface $time, TenantResolver $tenant_resolver) {
     $this->database = $database;
     $this->time = $time;
+    $this->tenantResolver = $tenant_resolver;
   }
 
   /**
@@ -62,6 +68,7 @@ class TraceStore {
         'step_count' => $execution['step_count'] ?? count($steps),
         'mitid_verified' => $this->mitidVerified($steps) ? 1 : 0,
         'steps' => json_encode($steps),
+        'tenant_id' => $this->tenantResolver->getCurrentTenantId() ?? '',
         'created' => $this->time->getRequestTime(),
       ])
       ->execute();

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/AuditLoggerTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/AuditLoggerTest.php
@@ -91,13 +91,21 @@ class AuditLoggerTest extends UnitTestCase {
     $request->method('getClientIp')->willReturn('192.168.1.100');
     $this->requestStack->method('getCurrentRequest')->willReturn($request);
 
+    // Single-tenant context: no active tenant, so tenant_id is empty.
+    $tenantResolver = $this->getMockBuilder(\Drupal\aabenforms_core\Service\TenantResolver::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getCurrentTenantId'])
+      ->getMock();
+    $tenantResolver->method('getCurrentTenantId')->willReturn(NULL);
+
     // Create service.
     $this->auditLogger = new AuditLogger(
       $this->database,
       $this->currentUser,
       $this->requestStack,
       $this->time,
-      $loggerFactory
+      $loggerFactory,
+      $tenantResolver
     );
   }
 

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/AuditLoggerTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/AuditLoggerTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\aabenforms_core\Unit\Service;
 
 use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\aabenforms_core\Service\TenantResolver;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\StatementInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Service/CprAccessTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\aabenforms_core\Unit\Service;
 
 use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\EncryptionService;
+use Drupal\aabenforms_core\Service\TenantResolver;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Tests\UnitTestCase;
@@ -45,7 +46,14 @@ class CprAccessTest extends UnitTestCase {
     $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
     $loggerFactory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
 
-    $this->cprAccess = new CprAccess($this->encryption, $loggerFactory);
+    // Single-tenant context: no active tenant, so the legacy AFENC1 path runs.
+    $tenantResolver = $this->getMockBuilder(TenantResolver::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getCurrentTenantId'])
+      ->getMock();
+    $tenantResolver->method('getCurrentTenantId')->willReturn(NULL);
+
+    $this->cprAccess = new CprAccess($this->encryption, $tenantResolver, $loggerFactory);
   }
 
   /**

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.install
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.install
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Install and update functions for the AabenForms Tenant module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Installs the tenant_id base field on the tenant-owned entities.
+ *
+ * The field is declared in hook_entity_base_field_info(); on an already-enabled
+ * site it must be installed explicitly so the storage column is created.
+ */
+function aabenforms_tenant_update_11001(): string {
+  $edum = \Drupal::entityDefinitionUpdateManager();
+  $installed = [];
+  foreach (AABENFORMS_TENANT_SCOPED_ENTITY_TYPES as $entity_type_id) {
+    $definition = \Drupal::entityTypeManager()->getDefinition($entity_type_id, FALSE);
+    if (!$definition) {
+      continue;
+    }
+    if ($edum->getFieldStorageDefinition('tenant_id', $entity_type_id)) {
+      continue;
+    }
+    $fields = aabenforms_tenant_entity_base_field_info($definition);
+    if (isset($fields['tenant_id'])) {
+      $edum->installFieldStorageDefinition('tenant_id', $entity_type_id, 'aabenforms_tenant', $fields['tenant_id']);
+      $installed[] = $entity_type_id;
+    }
+  }
+  return $installed
+    ? 'Installed tenant_id on: ' . implode(', ', $installed)
+    : 'tenant_id already present on all tenant-scoped entities.';
+}

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.module
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.module
@@ -7,8 +7,149 @@
  * Provides multi-tenancy support and employee role provisioning.
  */
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Database\Query\AlterableInterface;
+use Drupal\Core\Database\Query\SelectInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\user\UserInterface;
+
+/**
+ * The entity types whose rows are owned by a tenant (kommune) and isolated.
+ */
+const AABENFORMS_TENANT_SCOPED_ENTITY_TYPES = ['aabenforms_case', 'webform_submission'];
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Adds a queryable `tenant_id` to the tenant-owned entities without coupling
+ * those modules to the tenancy concept (mirrors aabenforms_esdh's esdh_ref).
+ * Empty in single-tenant mode, so isolation is a no-op until domains exist.
+ */
+function aabenforms_tenant_entity_base_field_info(EntityTypeInterface $entity_type): array {
+  if (!in_array($entity_type->id(), AABENFORMS_TENANT_SCOPED_ENTITY_TYPES, TRUE)) {
+    return [];
+  }
+  $field = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('Tenant (kommune)'))
+    ->setDescription(new TranslatableMarkup('The domain/tenant that owns this record. Empty in single-tenant mode.'))
+    ->setSetting('max_length', 64)
+    ->setDefaultValue('')
+    ->setDisplayConfigurable('view', TRUE);
+  if ($entity_type->isRevisionable()) {
+    $field->setRevisionable(TRUE);
+  }
+  return ['tenant_id' => $field];
+}
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Stamps the current tenant onto a new case/submission so no save path can
+ * leave it empty. Once set it is never overwritten (a case keeps its owner).
+ */
+function aabenforms_tenant_entity_presave(EntityInterface $entity): void {
+  if (!$entity instanceof ContentEntityInterface
+    || !in_array($entity->getEntityTypeId(), AABENFORMS_TENANT_SCOPED_ENTITY_TYPES, TRUE)
+    || !$entity->hasField('tenant_id')) {
+    return;
+  }
+  if ((string) $entity->get('tenant_id')->value !== '') {
+    return;
+  }
+  $tenant = \Drupal::service('aabenforms_core.tenant_resolver')->getCurrentTenantId();
+  if (is_string($tenant) && $tenant !== '') {
+    $entity->set('tenant_id', $tenant);
+  }
+}
+
+/**
+ * Implements hook_entity_access().
+ *
+ * Denies cross-tenant access to a tenant-owned entity. A forbidden result here
+ * overrides the coarse `view any webform submission` grant, which is the root
+ * of the cross-tenant leak. Only enforced when the row is stamped AND a current
+ * tenant is known, so single-tenant / drush / cron contexts are unaffected.
+ */
+function aabenforms_tenant_entity_access(EntityInterface $entity, $operation, AccountInterface $account): AccessResultInterface {
+  if (!$entity instanceof ContentEntityInterface
+    || !in_array($entity->getEntityTypeId(), AABENFORMS_TENANT_SCOPED_ENTITY_TYPES, TRUE)
+    || !$entity->hasField('tenant_id')) {
+    return AccessResult::neutral();
+  }
+  $owner = (string) $entity->get('tenant_id')->value;
+  if ($owner === '' || $account->hasPermission('bypass tenant isolation')) {
+    return AccessResult::neutral()->cachePerPermissions();
+  }
+  $current = \Drupal::service('aabenforms_core.tenant_resolver')->getCurrentTenantId();
+  if ($current !== NULL && $owner !== $current) {
+    return AccessResult::forbidden('Cross-tenant access denied.')
+      ->cachePerPermissions()
+      ->addCacheContexts(['url.site'])
+      ->addCacheableDependency($entity);
+  }
+  return AccessResult::neutral()
+    ->cachePerPermissions()
+    ->addCacheContexts(['url.site'])
+    ->addCacheableDependency($entity);
+}
+
+/**
+ * Implements hook_query_TAG_alter() for aabenforms_case entity-access queries.
+ */
+function aabenforms_tenant_query_aabenforms_case_access_alter(AlterableInterface $query): void {
+  _aabenforms_tenant_scope_query($query, 'aabenforms_case');
+}
+
+/**
+ * Implements hook_query_TAG_alter() for webform_submission entity-access queries.
+ */
+function aabenforms_tenant_query_webform_submission_access_alter(AlterableInterface $query): void {
+  _aabenforms_tenant_scope_query($query, 'webform_submission');
+}
+
+/**
+ * Adds a tenant condition to an entity-access query (listings, JSON:API).
+ *
+ * Belt-and-suspenders alongside hook_entity_access: keeps other tenants' rows
+ * out of collection queries entirely, so their UUIDs never even reach the
+ * JSON:API meta.omitted stage. Same-tenant and unstamped (single-tenant) rows
+ * remain visible.
+ */
+function _aabenforms_tenant_scope_query(AlterableInterface $query, string $entity_type_id): void {
+  if (!$query instanceof SelectInterface) {
+    return;
+  }
+  if (\Drupal::currentUser()->hasPermission('bypass tenant isolation')) {
+    return;
+  }
+  $current = \Drupal::service('aabenforms_core.tenant_resolver')->getCurrentTenantId();
+  if ($current === NULL) {
+    return;
+  }
+  $base = \Drupal::entityTypeManager()->getStorage($entity_type_id)->getEntityType()->getBaseTable();
+  $alias = NULL;
+  foreach ($query->getTables() as $a => $info) {
+    if (($info['table'] ?? NULL) === $base) {
+      $alias = $a;
+      break;
+    }
+  }
+  if ($alias === NULL) {
+    return;
+  }
+  $group = $query->orConditionGroup()
+    ->condition("$alias.tenant_id", $current)
+    ->condition("$alias.tenant_id", '')
+    ->isNull("$alias.tenant_id");
+  $query->condition($group);
+}
 
 /**
  * Implements hook_help().

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.permissions.yml
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.permissions.yml
@@ -1,0 +1,4 @@
+bypass tenant isolation:
+  title: 'Bypass tenant (kommune) data isolation'
+  description: 'View and query cases and submissions across all tenants. Grant only to platform operators; never to a kommune caseworker.'
+  restrict access: true

--- a/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantDataIsolationTest.php
+++ b/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantDataIsolationTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_tenant\Kernel;
+
+use Drupal\domain\Entity\Domain;
+use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\key\Entity\Key;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Proves one kommune's cases and CPR are invisible to another.
+ *
+ * @group aabenforms_tenant
+ */
+class TenantDataIsolationTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system', 'user', 'field', 'text', 'options', 'node',
+    'key', 'encrypt', 'real_aes',
+    'domain', 'domain_access',
+    'modeler_api', 'eca', 'webform',
+    'aabenforms_core', 'aabenforms_case', 'aabenforms_tenant',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('domain');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installConfig(['system', 'field']);
+    // Two tenants.
+    Domain::create(['id' => 'aarhus', 'hostname' => 'aarhus.test', 'name' => 'Aarhus'])->save();
+    Domain::create(['id' => 'odense', 'hostname' => 'odense.test', 'name' => 'Odense'])->save();
+    $this->setActiveDomain('aarhus');
+  }
+
+  /**
+   * A case owned by one kommune is not viewable or queryable from another.
+   */
+  public function testCaseAccessIsolation(): void {
+    // The first created user is uid 1 (root, bypasses all access) - burn it.
+    $this->createUser();
+    $worker = $this->createUser(['view aabenforms_case']);
+    $operator = $this->createUser(['view aabenforms_case', 'bypass tenant isolation']);
+    $storage = \Drupal::entityTypeManager()->getStorage('aabenforms_case');
+
+    // Case created while Aarhus is active is stamped tenant_id = aarhus.
+    $this->setActiveDomain('aarhus');
+    $caseA = $storage->create(['title' => 'Sag A', 'case_type' => 'underretning']);
+    $caseA->save();
+    $this->assertSame('aarhus', $caseA->get('tenant_id')->value, 'Case is stamped with the active tenant on save.');
+
+    $this->setActiveDomain('odense');
+    $caseB = $storage->create(['title' => 'Sag B', 'case_type' => 'underretning']);
+    $caseB->save();
+    $this->assertSame('odense', $caseB->get('tenant_id')->value);
+
+    // Entity access: from Odense, Aarhus' case is forbidden; its own is allowed.
+    $this->setActiveDomain('odense');
+    $this->assertFalse($caseA->access('view', $worker), 'Odense worker cannot view an Aarhus case.');
+    $this->assertTrue($caseB->access('view', $worker), 'Odense worker can view an Odense case.');
+    // The bypass operator sees across tenants.
+    $this->assertTrue($caseA->access('view', $operator), 'A bypass operator sees any tenant.');
+
+    // From Aarhus, the Aarhus case is visible again (scoped, not blanket-deny).
+    $this->setActiveDomain('aarhus');
+    $this->assertTrue($caseA->access('view', $worker), 'Aarhus worker can view the Aarhus case.');
+
+    // Query isolation: from Odense, as the worker, the query returns only Odense.
+    $this->setActiveDomain('odense');
+    $switcher = \Drupal::service('account_switcher');
+    $switcher->switchTo($worker);
+    $ids = $storage->getQuery()->accessCheck(TRUE)->execute();
+    $switcher->switchBack();
+    $this->assertEqualsCanonicalizing([$caseB->id() => $caseB->id()], $ids, 'Query returns only the current tenant\'s cases.');
+  }
+
+  /**
+   * A CPR encrypted for one kommune cannot be revealed as another.
+   */
+  public function testCprCrossTenantDecryptFails(): void {
+    $this->createTenantKey('aarhus');
+    $this->createTenantKey('odense');
+    $cpr = \Drupal::service('aabenforms_core.cpr_access');
+
+    $this->setActiveDomain('aarhus');
+    $ciphertext = $cpr->protect('2506924015');
+    $this->assertStringStartsWith('AFENC2:aarhus:', $ciphertext, 'CPR is encrypted with the tenant key.');
+    $this->assertSame('2506924015', $cpr->reveal($ciphertext), 'Same-tenant reveal works.');
+
+    // From Odense, revealing the Aarhus ciphertext uses the Odense key -> fails.
+    $this->setActiveDomain('odense');
+    $this->assertSame('', $cpr->reveal($ciphertext), 'Cross-tenant CPR decrypt fails.');
+  }
+
+  /**
+   * Sets the active domain (the "current tenant").
+   */
+  private function setActiveDomain(string $id): void {
+    \Drupal::service('domain.negotiator')->setActiveDomain(Domain::load($id));
+    // The per-request entity-access static cache is not domain-aware; reset it
+    // so each in-test domain switch recomputes (real requests are one domain).
+    \Drupal::entityTypeManager()->getAccessControlHandler('aabenforms_case')->resetCache();
+  }
+
+  /**
+   * Creates a real_aes key + encryption profile for a tenant.
+   */
+  private function createTenantKey(string $tenant): void {
+    Key::create([
+      'id' => 'cpr_' . $tenant,
+      'label' => 'CPR ' . $tenant,
+      'key_type' => 'encryption',
+      'key_type_settings' => ['key_size' => '256'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => base64_encode(random_bytes(32)), 'base64_encoded' => TRUE],
+      'key_input' => 'none',
+    ])->save();
+    EncryptionProfile::create([
+      'id' => 'aabenforms_aes256_' . $tenant,
+      'label' => 'AES ' . $tenant,
+      'encryption_method' => 'real_aes',
+      'encryption_key' => 'cpr_' . $tenant,
+    ])->save();
+  }
+
+}


### PR DESCRIPTION
Stacked on `feature/poc-hardening-20260724`. Closes the HIGH cross-tenant leak: one kommune's cases/submissions/CPR are provably invisible to another. Fixes #141, closes #174.

- `tenant_id` base field on `aabenforms_case` + `webform_submission` (via `hook_entity_base_field_info`, the aabenforms_esdh pattern), stamped from the active domain on save.
- `hook_entity_access` forbids cross-tenant view/edit (overrides the coarse `view any webform submission` grant); a query-tag alter keeps other tenants' rows and UUIDs out of listings + JSON:API.
- Per-tenant CPR keys: encrypt with the tenant's own profile (`AFENC2:<tenant>:...`) so another tenant's key can't decrypt it; legacy `AFENC1:` still decrypts; single-tenant mode unchanged.
- `bypass tenant isolation` permission for platform operators.
- `audit_log` + `trace` gain a `tenant_id` column (reporting segregation, #174).

`TenantDataIsolationTest` proves cross-tenant deny, query scoping, cross-tenant CPR decrypt failure, and operator bypass. 109 existing aabenforms_case/core tests still pass; single-tenant is a verified no-op.
