### PR TITLE
Enforce per-flow NSIS assurance at the MitID gate (#157)

### DIFF
--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/MitIdValidateAction.php
@@ -192,8 +192,21 @@ class MitIdValidateAction extends AabenFormsActionBase {
       'workflow_id_token' => 'workflow_id',
       'result_token' => 'mitid_valid',
       'session_data_token' => 'mitid_session',
+      // Per-flow minimum NSIS assurance level ('low'|'substantial'|'high').
+      // Empty means no per-flow requirement (any valid session passes); a flow
+      // handling sensitive data sets 'substantial' or 'high'. Login already
+      // enforces the global minimum; this enforces it again at the gate.
+      'required_assurance_level' => '',
     ] + parent::defaultConfiguration();
   }
+
+  /**
+   * NSIS assurance ranking (unknown < low < substantial < high, fail-closed).
+   *
+   * Mirrors MitIdOidcClient::enforceAssuranceLevel so the gate applies the same
+   * ordering the login does.
+   */
+  protected const ASSURANCE_RANKS = ['unknown' => 0, 'low' => 1, 'substantial' => 2, 'high' => 3];
 
   /**
    * {@inheritdoc}
@@ -266,6 +279,28 @@ class MitIdValidateAction extends AabenFormsActionBase {
         $this->setResultStatus('failed');
         $this->recordStep('MitID Identity Validation', 'Session expired - re-authentication required', 'failed');
         return;
+      }
+
+      // Per-flow assurance gate: a live session is not enough if this flow
+      // demands a higher NSIS level than the citizen authenticated at. Login
+      // enforces the global minimum; this re-asserts a per-flow minimum so a
+      // 'substantial' session cannot satisfy a flow that requires 'high'.
+      $requiredLevel = strtolower((string) ($this->configuration['required_assurance_level'] ?? ''));
+      if ($requiredLevel !== '') {
+        $sessionLevel = strtolower((string) ($sessionData['assurance_level'] ?? 'unknown'));
+        $have = self::ASSURANCE_RANKS[$sessionLevel] ?? 0;
+        $need = self::ASSURANCE_RANKS[$requiredLevel] ?? 2;
+        if ($have < $need) {
+          $this->log('MitID validation failed: assurance {have} below required {need} for {wf}', [
+            'have' => $sessionLevel,
+            'need' => $requiredLevel,
+            'wf' => $workflowId,
+          ], 'warning');
+          $this->setTokenValue($this->configuration['result_token'], FALSE);
+          $this->setResultStatus('failed');
+          $this->recordStep('MitID Identity Validation', sprintf('Sikringsniveau "%s" er lavere end det krævede "%s"', $sessionLevel, $requiredLevel), 'failed');
+          return;
+        }
       }
 
       // Session is valid.

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/MitIdValidateActionTest.php
@@ -561,6 +561,61 @@ class MitIdValidateActionTest extends UnitTestCase {
 
     $this->assertArrayHasKey('session_data_token', $defaults);
     $this->assertEquals('mitid_session', $defaults['session_data_token']);
+
+    $this->assertArrayHasKey('required_assurance_level', $defaults);
+    $this->assertSame('', $defaults['required_assurance_level'], 'No per-flow assurance requirement by default.');
+  }
+
+  /**
+   * A session below the flow's required assurance level is denied at the gate.
+   *
+   * @covers ::execute
+   */
+  public function testAssuranceBelowRequiredIsDenied(): void {
+    $workflowId = 'wf_low_assurance';
+    $this->tokenStorage['workflow_id'] = $workflowId;
+    $this->sessionManager->method('getSession')->with($workflowId)->willReturn([
+      'cpr' => '0101001234',
+      'assurance_level' => 'substantial',
+      'expires_at' => time() + 600,
+    ]);
+    $this->setActionConfig('required_assurance_level', 'high');
+
+    $this->logger->expects($this->once())->method('warning');
+    $this->action->execute();
+
+    $this->assertFalse($this->tokenStorage['mitid_valid'], 'A substantial session must not satisfy a high-assurance flow.');
+  }
+
+  /**
+   * A session at or above the required assurance level passes the gate.
+   *
+   * @covers ::execute
+   */
+  public function testAssuranceMeetsRequirement(): void {
+    $workflowId = 'wf_high_assurance';
+    $this->tokenStorage['workflow_id'] = $workflowId;
+    $this->sessionManager->method('getSession')->with($workflowId)->willReturn([
+      'cpr' => '0101001234',
+      'assurance_level' => 'high',
+      'expires_at' => time() + 600,
+    ]);
+    $this->setActionConfig('required_assurance_level', 'substantial');
+
+    $this->action->execute();
+
+    $this->assertTrue($this->tokenStorage['mitid_valid'], 'A high session satisfies a substantial-assurance flow.');
+  }
+
+  /**
+   * Sets a single configuration value on the action under test.
+   */
+  private function setActionConfig(string $key, $value): void {
+    $property = (new \ReflectionClass($this->action))->getProperty('configuration');
+    $property->setAccessible(TRUE);
+    $config = $property->getValue($this->action);
+    $config[$key] = $value;
+    $property->setValue($this->action, $config);
   }
 
 }


### PR DESCRIPTION
Stacked on `feature/tenant-isolation`. Closes the residual identity gap in #157.

NSIS assurance was enforced at the OIDC callback but not at the ECA workflow gate, so a per-flow "requires High" could not be enforced. `MitIdValidateAction` now reads the session `assurance_level` and, when a flow sets `required_assurance_level` (low|substantial|high), denies a session below it - reusing the same `unknown<low<substantial<high` ranking the login uses (fail-closed).

Non-breaking: default `''` (no per-flow requirement), so existing flows and the demo are unchanged. Two unit tests cover below-required deny + at/above pass; all 13 MitIdValidateAction tests pass.
