### PR TITLE
Session B: identity abstraction + NemLog-in OIOSAML 3 SP (aabenforms_nemlogin)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "drupal/smtp": "^1.4",
         "drupal/webform": "^6.3@dev",
         "drush/drush": "^13.7",
-        "itk-dev/serviceplatformen": "^1.8"
+        "itk-dev/serviceplatformen": "^1.8",
+        "onelogin/php-saml": "^4"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1e0090021870f46b40799b48ddc9210",
+    "content-hash": "283a15613378c580c5fec617acffffd9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4477,6 +4477,70 @@
             "time": "2025-12-06T11:56:16+00:00"
         },
         {
+            "name": "onelogin/php-saml",
+            "version": "4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SAML-Toolkits/php-saml.git",
+                "reference": "26b3a47349415e5b7aa300ba4ab7fc316c65f19e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SAML-Toolkits/php-saml/zipball/26b3a47349415e5b7aa300ba4ab7fc316c65f19e",
+                "reference": "26b3a47349415e5b7aa300ba4ab7fc316c65f19e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "robrichards/xmlseclibs": "^3.1.5"
+            },
+            "require-dev": {
+                "pdepend/pdepend": "^2.8.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phploc/phploc": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "phpunit/phpunit": "^9.5",
+                "sebastian/phpcpd": "^4.0 || ^5.0 || ^6.0 ",
+                "squizlabs/php_codesniffer": "^3.5.8"
+            },
+            "suggest": {
+                "ext-curl": "Install curl lib to be able to use the IdPMetadataParser for parsing remote XMLs",
+                "ext-dom": "Install xml lib",
+                "ext-openssl": "Install openssl lib in order to handle with x509 certs (require to support sign and encryption)",
+                "ext-zlib": "Install zlib"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OneLogin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP SAML Toolkit",
+            "homepage": "https://github.com/SAML-Toolkits/php-saml",
+            "keywords": [
+                "Federation",
+                "SAML2",
+                "SSO",
+                "identity",
+                "saml"
+            ],
+            "support": {
+                "email": "sixto.martin.garcia@gmail.com",
+                "issues": "https://github.com/onelogin/SAML-Toolkits/issues",
+                "source": "https://github.com/onelogin/SAML-Toolkits/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/SAML-Toolkits",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-07T22:38:04+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v9.99.100",
             "source": {
@@ -5836,6 +5900,48 @@
                 "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
             },
             "time": "2026-05-16T17:55:38+00:00"
+        },
+        {
+            "name": "robrichards/xmlseclibs",
+            "version": "3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/robrichards/xmlseclibs.git",
+                "reference": "03062be78178cbb5e8f605cd255dc32a14981f92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/03062be78178cbb5e8f605cd255dc32a14981f92",
+                "reference": "03062be78178cbb5e8f605cd255dc32a14981f92",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">= 5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RobRichards\\XMLSecLibs\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A PHP library for XML Security",
+            "homepage": "https://github.com/robrichards/xmlseclibs",
+            "keywords": [
+                "security",
+                "signature",
+                "xml",
+                "xmldsig"
+            ],
+            "support": {
+                "issues": "https://github.com/robrichards/xmlseclibs/issues",
+                "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.5"
+            },
+            "time": "2026-03-13T10:31:56+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/config/sync/aabenforms_nemlogin.settings.yml
+++ b/config/sync/aabenforms_nemlogin.settings.yml
@@ -1,0 +1,24 @@
+# NemLog-in OIOSAML 3 Service Provider settings.
+#
+# Certificates and keys are NOT stored here: sp_cert_key / sp_private_key_key
+# name entries in the `key` module (drupal:key), so the OCES3 material stays out
+# of config/sync. Live activation is gated on an SP registration + metadata
+# exchange in NemLog-in integrationstest (ops), so all endpoints default empty.
+enabled: false
+strict: true
+# The SP entityId - must equal the value registered in NemLog-in and is the
+# audience the returned assertion is restricted to.
+sp_entity_id: ''
+# Absolute SP endpoint URLs (built from the site by default via the controller).
+acs_url: ''
+slo_url: ''
+# NemLog-in IdP metadata, filled in after the integrationstest exchange.
+idp_entity_id: 'https://saml.nemlog-in.dk'
+idp_sso_url: ''
+idp_slo_url: ''
+idp_cert: ''
+# `key` module entry names holding the SP OCES3 keypair (PEM).
+sp_cert_key: ''
+sp_private_key_key: ''
+# Minimum NSIS assurance the SP requests and re-verifies (low|substantial|high).
+required_assurance_level: 'substantial'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -8,6 +8,7 @@ module:
   aabenforms_digital_post_session_inbox: 0
   aabenforms_kombit: 0
   aabenforms_mitid: 0
+  aabenforms_nemlogin: 0
   aabenforms_tenant: 0
   aabenforms_webform: 0
   aabenforms_workflows: 0

--- a/web/modules/custom/aabenforms_core/src/Identity/IdentityProviderInterface.php
+++ b/web/modules/custom/aabenforms_core/src/Identity/IdentityProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\aabenforms_core\Identity;
+
+/**
+ * Contract for a citizen-identity provider.
+ *
+ * An identity provider drives an authentication protocol (OIDC or SAML) to its
+ * end and terminates in a verified session: it validates whatever its protocol
+ * hands back, produces a VerifiedIdentity, and persists it through a
+ * SessionManagerInterface keyed by the workflow_id bearer handle. Two
+ * implementations exist - MitID OIDC (demo / private-sector rail) and NemLog-in
+ * OIOSAML 3 (production kommune rail) - and they are interchangeable because
+ * they share both this contract and the session store.
+ */
+interface IdentityProviderInterface {
+
+  /**
+   * The stable provider id stamped onto every identity this provider asserts.
+   *
+   * Recorded on the session (VerifiedIdentity::$provider) and in the audit
+   * trail so a login can always be attributed to the rail that produced it.
+   *
+   * @return string
+   *   A stable machine id, e.g. 'mitid_oidc' or 'nemlogin_saml'.
+   */
+  public function getProviderId(): string;
+
+}

--- a/web/modules/custom/aabenforms_core/src/Identity/SessionManagerInterface.php
+++ b/web/modules/custom/aabenforms_core/src/Identity/SessionManagerInterface.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\aabenforms_core\Identity;
+
+/**
+ * Contract for the flow-scoped verified-identity session store.
+ *
+ * A session is keyed by an unguessable, short-lived workflow_id bearer handle
+ * (not a Drupal user account). Both identity rails - MitID OIDC and NemLog-in
+ * OIOSAML 3 - write through this contract, and every downstream consumer (the
+ * ECA gate, the webform intake, the CPR extractor) reads through it, so the
+ * two rails are fully interchangeable. The canonical implementation is aliased
+ * as the `aabenforms_identity.session_manager` service.
+ */
+interface SessionManagerInterface {
+
+  /**
+   * Stores verified-identity session data for a workflow instance.
+   *
+   * @param string $workflow_id
+   *   The workflow instance / bearer id.
+   * @param array $session_data
+   *   The flat session data (typically VerifiedIdentity::toSessionArray()).
+   *
+   * @return bool
+   *   TRUE on success, FALSE on failure.
+   */
+  public function storeSession(string $workflow_id, array $session_data): bool;
+
+  /**
+   * Retrieves session data for a workflow instance.
+   *
+   * @param string $workflow_id
+   *   The workflow instance / bearer id.
+   *
+   * @return array|null
+   *   The session data, or NULL if not found or expired.
+   */
+  public function getSession(string $workflow_id): ?array;
+
+  /**
+   * Deletes session data for a workflow instance.
+   *
+   * @param string $workflow_id
+   *   The workflow instance / bearer id.
+   *
+   * @return bool
+   *   TRUE on success, FALSE on failure.
+   */
+  public function deleteSession(string $workflow_id): bool;
+
+  /**
+   * Checks whether a valid (unexpired) session exists for a workflow.
+   *
+   * @param string $workflow_id
+   *   The workflow instance / bearer id.
+   *
+   * @return bool
+   *   TRUE if a valid session exists, FALSE otherwise.
+   */
+  public function hasValidSession(string $workflow_id): bool;
+
+  /**
+   * Gets the CPR number from a workflow session.
+   *
+   * @param string $workflow_id
+   *   The workflow instance / bearer id.
+   *
+   * @return string|null
+   *   The CPR number, or NULL if not available.
+   */
+  public function getCprFromSession(string $workflow_id): ?string;
+
+  /**
+   * Gets the person data from a workflow session.
+   *
+   * @param string $workflow_id
+   *   The workflow instance / bearer id.
+   *
+   * @return array|null
+   *   The person data, or NULL if not available.
+   */
+  public function getPersonDataFromSession(string $workflow_id): ?array;
+
+}

--- a/web/modules/custom/aabenforms_core/src/Identity/VerifiedIdentity.php
+++ b/web/modules/custom/aabenforms_core/src/Identity/VerifiedIdentity.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Drupal\aabenforms_core\Identity;
+
+/**
+ * Immutable value object for a verified citizen identity.
+ *
+ * This is the provider-neutral currency of the identity layer: an OIDC login
+ * (MitID via the Keycloak/private-sector rail) and a SAML login (NemLog-in
+ * OIOSAML 3, the production kommune rail) both terminate in a VerifiedIdentity,
+ * which is then flattened into the session store the whole platform reads.
+ *
+ * The session array shape (cpr, name, given_name, family_name, birthdate,
+ * email, assurance_level, mitid_uuid) predates this object; toSessionArray()
+ * reproduces it verbatim so a SAML rail can be added without touching a single
+ * downstream reader (the ECA gate, the CPR extractor, getPersonDataFromSession).
+ */
+final class VerifiedIdentity {
+
+  /**
+   * NSIS assurance ranking (unknown < low < substantial < high, fail-closed).
+   *
+   * The single source of truth for assurance ordering across the platform;
+   * MitIdOidcClient and MitIdValidateAction apply the same ranking.
+   */
+  public const ASSURANCE_RANKS = [
+    'unknown' => 0,
+    'low' => 1,
+    'substantial' => 2,
+    'high' => 3,
+  ];
+
+  /**
+   * Constructs a VerifiedIdentity.
+   *
+   * @param string $cpr
+   *   The 10-digit CPR number of the authenticated citizen.
+   * @param string $assuranceLevel
+   *   The NSIS level: 'low', 'substantial', 'high' or 'unknown'.
+   * @param string $provider
+   *   The provider id that asserted this identity (e.g. 'mitid_oidc',
+   *   'nemlogin_saml').
+   * @param string|null $subject
+   *   The provider subject identifier (OIDC sub / SAML NameID / MitID UUID).
+   * @param string|null $name
+   *   The full name, when the IdP issues it.
+   * @param string|null $givenName
+   *   The given name, when issued.
+   * @param string|null $familyName
+   *   The family name, when issued.
+   * @param string|null $birthdate
+   *   The birthdate, when issued.
+   * @param string|null $email
+   *   The email, when issued.
+   * @param string|null $issuer
+   *   The asserting IdP entity id / issuer, when known.
+   * @param int|null $authTime
+   *   The authentication instant as a Unix timestamp, when known.
+   */
+  public function __construct(
+    public readonly string $cpr,
+    public readonly string $assuranceLevel,
+    public readonly string $provider,
+    public readonly ?string $subject = NULL,
+    public readonly ?string $name = NULL,
+    public readonly ?string $givenName = NULL,
+    public readonly ?string $familyName = NULL,
+    public readonly ?string $birthdate = NULL,
+    public readonly ?string $email = NULL,
+    public readonly ?string $issuer = NULL,
+    public readonly ?int $authTime = NULL,
+  ) {}
+
+  /**
+   * Rank of this identity's assurance level (fail-closed to 0 for unknown).
+   *
+   * @return int
+   *   0 (unknown) to 3 (high).
+   */
+  public function assuranceRank(): int {
+    return self::ASSURANCE_RANKS[strtolower($this->assuranceLevel)] ?? 0;
+  }
+
+  /**
+   * Whether this identity meets a required NSIS assurance level.
+   *
+   * @param string $required
+   *   The required level ('low'|'substantial'|'high'). An empty string means
+   *   no requirement (always satisfied).
+   *
+   * @return bool
+   *   TRUE when this identity's level is at least the requirement.
+   */
+  public function meetsAssurance(string $required): bool {
+    $required = strtolower(trim($required));
+    if ($required === '') {
+      return TRUE;
+    }
+    $need = self::ASSURANCE_RANKS[$required] ?? 2;
+    return $this->assuranceRank() >= $need;
+  }
+
+  /**
+   * Flattens the identity into the platform's session array shape.
+   *
+   * The keys match exactly what MitIdSessionManager stores and
+   * getPersonDataFromSession reads, so both identity rails are interchangeable
+   * to every downstream consumer. Null person fields are omitted so a real
+   * MitID/NemLog-in login (which issues no address/name claims) does not stamp
+   * empty strings over absent data.
+   *
+   * @return array
+   *   The flat session data (person fields + provider metadata).
+   */
+  public function toSessionArray(): array {
+    $data = [
+      'cpr' => $this->cpr,
+      'assurance_level' => $this->assuranceLevel,
+      'identity_provider' => $this->provider,
+    ];
+    // The legacy key downstream readers use for the subject identifier.
+    if ($this->subject !== NULL) {
+      $data['mitid_uuid'] = $this->subject;
+    }
+    $optional = [
+      'name' => $this->name,
+      'given_name' => $this->givenName,
+      'family_name' => $this->familyName,
+      'birthdate' => $this->birthdate,
+      'email' => $this->email,
+      'issuer' => $this->issuer,
+    ];
+    foreach ($optional as $key => $value) {
+      if ($value !== NULL && $value !== '') {
+        $data[$key] = $value;
+      }
+    }
+    if ($this->authTime !== NULL) {
+      $data['authenticated_at'] = $this->authTime;
+    }
+    return $data;
+  }
+
+  /**
+   * Reconstructs a VerifiedIdentity from a stored session array.
+   *
+   * @param array $session
+   *   A session array as produced by toSessionArray() or the legacy OIDC flow.
+   *
+   * @return self
+   *   The identity value object.
+   */
+  public static function fromSessionArray(array $session): self {
+    return new self(
+      cpr: (string) ($session['cpr'] ?? ''),
+      assuranceLevel: (string) ($session['assurance_level'] ?? 'unknown'),
+      provider: (string) ($session['identity_provider'] ?? 'mitid_oidc'),
+      subject: $session['mitid_uuid'] ?? NULL,
+      name: $session['name'] ?? NULL,
+      givenName: $session['given_name'] ?? NULL,
+      familyName: $session['family_name'] ?? NULL,
+      birthdate: $session['birthdate'] ?? NULL,
+      email: $session['email'] ?? NULL,
+      issuer: $session['issuer'] ?? NULL,
+      authTime: isset($session['authenticated_at']) ? (int) $session['authenticated_at'] : NULL,
+    );
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Identity/VerifiedIdentityTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Identity/VerifiedIdentityTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit\Identity;
+
+use Drupal\aabenforms_core\Identity\VerifiedIdentity;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the VerifiedIdentity value object.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_core\Identity\VerifiedIdentity
+ * @group aabenforms_core
+ * @group identity
+ */
+class VerifiedIdentityTest extends UnitTestCase {
+
+  /**
+   * The session-array round trip preserves every populated field.
+   *
+   * @covers ::toSessionArray
+   * @covers ::fromSessionArray
+   */
+  public function testSessionRoundTrip(): void {
+    $identity = new VerifiedIdentity(
+      cpr: '0101801234',
+      assuranceLevel: 'substantial',
+      provider: 'nemlogin_saml',
+      subject: 'https://data.gov.dk/model/core/eid/person/uuid/abc',
+      name: 'Anders And',
+      givenName: 'Anders',
+      familyName: 'And',
+      birthdate: '1980-01-01',
+      email: 'anders@example.dk',
+      issuer: 'https://saml.nemlog-in.dk',
+      authTime: 1706356800,
+    );
+
+    $session = $identity->toSessionArray();
+    $this->assertSame('0101801234', $session['cpr']);
+    $this->assertSame('substantial', $session['assurance_level']);
+    $this->assertSame('nemlogin_saml', $session['identity_provider']);
+    // The subject is stored under the legacy key downstream readers use.
+    $this->assertSame('https://data.gov.dk/model/core/eid/person/uuid/abc', $session['mitid_uuid']);
+    $this->assertSame('Anders And', $session['name']);
+    $this->assertSame(1706356800, $session['authenticated_at']);
+
+    $restored = VerifiedIdentity::fromSessionArray($session);
+    $this->assertSame($identity->cpr, $restored->cpr);
+    $this->assertSame($identity->assuranceLevel, $restored->assuranceLevel);
+    $this->assertSame($identity->provider, $restored->provider);
+    $this->assertSame($identity->subject, $restored->subject);
+    $this->assertSame($identity->email, $restored->email);
+    $this->assertSame($identity->authTime, $restored->authTime);
+  }
+
+  /**
+   * Absent person fields are omitted, never stamped as empty strings.
+   *
+   * A real MitID/NemLog-in login issues no name/address claims; the session
+   * must not carry empty values that would overwrite data resolved elsewhere.
+   *
+   * @covers ::toSessionArray
+   */
+  public function testMinimalIdentityOmitsEmptyFields(): void {
+    $identity = new VerifiedIdentity(
+      cpr: '0101801234',
+      assuranceLevel: 'high',
+      provider: 'mitid_oidc',
+    );
+    $session = $identity->toSessionArray();
+
+    $this->assertArrayHasKey('cpr', $session);
+    $this->assertArrayNotHasKey('name', $session);
+    $this->assertArrayNotHasKey('mitid_uuid', $session);
+    $this->assertArrayNotHasKey('email', $session);
+    $this->assertArrayNotHasKey('authenticated_at', $session);
+  }
+
+  /**
+   * Assurance ranking is ordered and fails closed on unknown levels.
+   *
+   * @covers ::assuranceRank
+   * @covers ::meetsAssurance
+   * @dataProvider assuranceProvider
+   */
+  public function testAssurance(string $level, string $required, bool $expected): void {
+    $identity = new VerifiedIdentity(
+      cpr: '0101801234',
+      assuranceLevel: $level,
+      provider: 'nemlogin_saml',
+    );
+    $this->assertSame($expected, $identity->meetsAssurance($required));
+  }
+
+  /**
+   * Data provider for assurance comparisons.
+   *
+   * @return array
+   *   Rows of [asserted level, required level, expected meets-requirement].
+   */
+  public static function assuranceProvider(): array {
+    return [
+      'substantial meets substantial' => ['substantial', 'substantial', TRUE],
+      'high meets substantial' => ['high', 'substantial', TRUE],
+      'low fails substantial' => ['low', 'substantial', FALSE],
+      'unknown fails substantial (closed)' => ['garbage', 'substantial', FALSE],
+      'substantial fails high' => ['substantial', 'high', FALSE],
+      'low meets no requirement' => ['low', '', TRUE],
+      'case-insensitive' => ['Substantial', 'SUBSTANTIAL', TRUE],
+    ];
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/aabenforms_mitid.services.yml
+++ b/web/modules/custom/aabenforms_mitid/aabenforms_mitid.services.yml
@@ -13,6 +13,15 @@ services:
       - '@logger.factory'
       - '@aabenforms_core.audit_logger'
 
+  # Provider-neutral id for the verified-identity session store. Both identity
+  # rails (MitID OIDC and NemLog-in OIOSAML 3) and every downstream reader
+  # depend on this alias, not the concrete MitID service, so the store can
+  # outlive the aabenforms_mitid module.
+  aabenforms_identity.session_manager:
+    alias: aabenforms_mitid.session_manager
+  Drupal\aabenforms_core\Identity\SessionManagerInterface:
+    alias: aabenforms_mitid.session_manager
+
   aabenforms_mitid.token_verifier:
     class: Drupal\aabenforms_mitid\Service\MitIdTokenVerifier
     arguments:

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdOidcClient.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_mitid\Service;
 
+use Drupal\aabenforms_core\Identity\IdentityProviderInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use GuzzleHttp\ClientInterface;
@@ -22,7 +23,12 @@ use Psr\Log\LoggerInterface;
  * Keycloak mock supports it; turning it off only makes sense for
  * legacy IdPs that pre-date RFC 7636.
  */
-class MitIdOidcClient {
+class MitIdOidcClient implements IdentityProviderInterface {
+
+  /**
+   * The stable provider id for the MitID OIDC rail.
+   */
+  public const PROVIDER_ID = 'mitid_oidc';
 
   /**
    * The config factory.
@@ -96,6 +102,13 @@ class MitIdOidcClient {
     $this->cprExtractor = $cpr_extractor;
     $this->sessionManager = $session_manager;
     $this->tokenVerifier = $token_verifier;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProviderId(): string {
+    return self::PROVIDER_ID;
   }
 
   /**

--- a/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
+++ b/web/modules/custom/aabenforms_mitid/src/Service/MitIdSessionManager.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_mitid\Service;
 
+use Drupal\aabenforms_core\Identity\SessionManagerInterface;
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_mitid\DemoPersonas;
 use Drupal\Component\Datetime\TimeInterface;
@@ -26,7 +27,7 @@ use Psr\Log\LoggerInterface;
  * domain saw a fresh anonymous session and couldn't find the entry).
  * The workflow_id is generated with random_bytes so it's unguessable.
  */
-class MitIdSessionManager {
+class MitIdSessionManager implements SessionManagerInterface {
 
   /**
    * Session expiration time (15 minutes).

--- a/web/modules/custom/aabenforms_nemlogin/aabenforms_nemlogin.info.yml
+++ b/web/modules/custom/aabenforms_nemlogin/aabenforms_nemlogin.info.yml
@@ -1,0 +1,8 @@
+name: 'AabenForms NemLog-in (OIOSAML 3)'
+type: module
+description: 'Production kommune citizen login: a NemLog-in OIOSAML 3 SAML Service Provider that terminates in the shared verified-identity session store.'
+package: 'ÅbenForms'
+core_version_requirement: ^11
+dependencies:
+  - aabenforms_core:aabenforms_core
+  - key:key

--- a/web/modules/custom/aabenforms_nemlogin/aabenforms_nemlogin.routing.yml
+++ b/web/modules/custom/aabenforms_nemlogin/aabenforms_nemlogin.routing.yml
@@ -1,0 +1,35 @@
+aabenforms_nemlogin.login:
+  path: '/nemlogin/login'
+  defaults:
+    _controller: '\Drupal\aabenforms_nemlogin\Controller\NemloginController::login'
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'
+
+aabenforms_nemlogin.acs:
+  path: '/nemlogin/acs'
+  defaults:
+    _controller: '\Drupal\aabenforms_nemlogin\Controller\NemloginController::acs'
+  methods: [POST]
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'
+    _csrf_token: 'FALSE'
+
+aabenforms_nemlogin.slo:
+  path: '/nemlogin/slo'
+  defaults:
+    _controller: '\Drupal\aabenforms_nemlogin\Controller\NemloginController::slo'
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'
+
+aabenforms_nemlogin.metadata:
+  path: '/nemlogin/metadata'
+  defaults:
+    _controller: '\Drupal\aabenforms_nemlogin\Controller\NemloginController::metadata'
+  requirements:
+    _access: 'TRUE'

--- a/web/modules/custom/aabenforms_nemlogin/aabenforms_nemlogin.services.yml
+++ b/web/modules/custom/aabenforms_nemlogin/aabenforms_nemlogin.services.yml
@@ -1,0 +1,14 @@
+services:
+  aabenforms_nemlogin.settings_builder:
+    class: Drupal\aabenforms_nemlogin\Service\NemloginSettingsBuilder
+    arguments:
+      - '@config.factory'
+      - '@key.repository'
+
+  aabenforms_nemlogin.authenticator:
+    class: Drupal\aabenforms_nemlogin\Service\NemloginSamlAuthenticator
+    arguments:
+      - '@aabenforms_identity.session_manager'
+      - '@aabenforms_nemlogin.settings_builder'
+      - '@config.factory'
+      - '@logger.factory'

--- a/web/modules/custom/aabenforms_nemlogin/config/install/aabenforms_nemlogin.settings.yml
+++ b/web/modules/custom/aabenforms_nemlogin/config/install/aabenforms_nemlogin.settings.yml
@@ -1,0 +1,24 @@
+# NemLog-in OIOSAML 3 Service Provider settings.
+#
+# Certificates and keys are NOT stored here: sp_cert_key / sp_private_key_key
+# name entries in the `key` module (drupal:key), so the OCES3 material stays out
+# of config/sync. Live activation is gated on an SP registration + metadata
+# exchange in NemLog-in integrationstest (ops), so all endpoints default empty.
+enabled: false
+strict: true
+# The SP entityId - must equal the value registered in NemLog-in and is the
+# audience the returned assertion is restricted to.
+sp_entity_id: ''
+# Absolute SP endpoint URLs (built from the site by default via the controller).
+acs_url: ''
+slo_url: ''
+# NemLog-in IdP metadata, filled in after the integrationstest exchange.
+idp_entity_id: 'https://saml.nemlog-in.dk'
+idp_sso_url: ''
+idp_slo_url: ''
+idp_cert: ''
+# `key` module entry names holding the SP OCES3 keypair (PEM).
+sp_cert_key: ''
+sp_private_key_key: ''
+# Minimum NSIS assurance the SP requests and re-verifies (low|substantial|high).
+required_assurance_level: 'substantial'

--- a/web/modules/custom/aabenforms_nemlogin/config/schema/aabenforms_nemlogin.schema.yml
+++ b/web/modules/custom/aabenforms_nemlogin/config/schema/aabenforms_nemlogin.schema.yml
@@ -1,0 +1,40 @@
+aabenforms_nemlogin.settings:
+  type: config_object
+  label: 'NemLog-in OIOSAML 3 settings'
+  mapping:
+    enabled:
+      type: boolean
+      label: 'Enable the NemLog-in login rail'
+    strict:
+      type: boolean
+      label: 'Strict SAML validation (signatures, conditions, destination)'
+    sp_entity_id:
+      type: string
+      label: 'SP entityId'
+    acs_url:
+      type: string
+      label: 'Assertion Consumer Service URL'
+    slo_url:
+      type: string
+      label: 'Single Logout Service URL'
+    idp_entity_id:
+      type: string
+      label: 'IdP entityId'
+    idp_sso_url:
+      type: string
+      label: 'IdP Single Sign-On URL'
+    idp_slo_url:
+      type: string
+      label: 'IdP Single Logout URL'
+    idp_cert:
+      type: string
+      label: 'IdP signing certificate (PEM body)'
+    sp_cert_key:
+      type: string
+      label: 'Key module entry holding the SP certificate'
+    sp_private_key_key:
+      type: string
+      label: 'Key module entry holding the SP private key'
+    required_assurance_level:
+      type: string
+      label: 'Minimum NSIS assurance level'

--- a/web/modules/custom/aabenforms_nemlogin/src/Controller/NemloginController.php
+++ b/web/modules/custom/aabenforms_nemlogin/src/Controller/NemloginController.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Drupal\aabenforms_nemlogin\Controller;
+
+use Drupal\aabenforms_nemlogin\Service\NemloginSamlAuthenticator;
+use Drupal\aabenforms_nemlogin\Service\NemloginSettingsBuilder;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use OneLogin\Saml2\Auth as SamlAuth;
+use OneLogin\Saml2\Settings as SamlSettings;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * NemLog-in OIOSAML 3 Service Provider endpoints.
+ *
+ * Mirrors MitIdController's security posture on the SAML rail: the workflow_id
+ * bearer handle is always server-minted, the post-login return target is
+ * origin-validated, and the RelayState only ever carries an opaque lookup token
+ * (never the return URL directly). Both rails terminate in the same session
+ * store, so the frontend consumes the result identically.
+ */
+class NemloginController extends ControllerBase {
+
+  /**
+   * The SAML authenticator.
+   *
+   * @var \Drupal\aabenforms_nemlogin\Service\NemloginSamlAuthenticator
+   */
+  protected NemloginSamlAuthenticator $authenticator;
+
+  /**
+   * The php-saml settings builder.
+   *
+   * @var \Drupal\aabenforms_nemlogin\Service\NemloginSettingsBuilder
+   */
+  protected NemloginSettingsBuilder $settingsBuilder;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->authenticator = $container->get('aabenforms_nemlogin.authenticator');
+    $instance->settingsBuilder = $container->get('aabenforms_nemlogin.settings_builder');
+    return $instance;
+  }
+
+  /**
+   * Whether the NemLog-in rail is configured and enabled.
+   *
+   * @return bool
+   *   TRUE when enabled.
+   */
+  protected function enabled(): bool {
+    return (bool) $this->config('aabenforms_nemlogin.settings')->get('enabled');
+  }
+
+  /**
+   * Initiates a NemLog-in login (builds a signed AuthnRequest).
+   *
+   * Route: /nemlogin/login.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   A redirect to NemLog-in, or a 503 when the rail is not enabled.
+   */
+  public function login(Request $request): Response {
+    if (!$this->enabled()) {
+      return new JsonResponse(['error' => 'NemLog-in is not enabled'], 503);
+    }
+
+    // Server-mint the bearer handle; a client must never choose the session key.
+    $workflowId = 'wf_' . bin2hex(random_bytes(16));
+    $returnUrl = $this->safeReturnUrl($request);
+
+    // RelayState is an opaque token; the sensitive values live server-side in
+    // tempstore keyed by it, so nothing meaningful travels via the IdP.
+    $relayState = bin2hex(random_bytes(16));
+    $this->tempStore()->set('relay_' . $relayState, [
+      'workflow_id' => $workflowId,
+      'return_url' => $returnUrl,
+      'created' => time(),
+    ]);
+
+    try {
+      $auth = new SamlAuth($this->settingsBuilder->buildSettings());
+      // $stay = TRUE returns the redirect URL instead of exiting.
+      $ssoUrl = $auth->login($relayState, [], FALSE, FALSE, TRUE);
+      return new TrustedRedirectResponse($ssoUrl);
+    }
+    catch (\Exception $e) {
+      $this->getLogger('aabenforms_nemlogin')->error('NemLog-in AuthnRequest failed: @e', ['@e' => $e->getMessage()]);
+      return new JsonResponse(['error' => 'Could not start NemLog-in login'], 500);
+    }
+  }
+
+  /**
+   * Assertion Consumer Service: validates the assertion and mints a session.
+   *
+   * Route: /nemlogin/acs.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   A redirect to the return target with the session handle appended.
+   */
+  public function acs(Request $request): Response {
+    if (!$this->enabled()) {
+      return new JsonResponse(['error' => 'NemLog-in is not enabled'], 503);
+    }
+
+    $relayState = (string) $request->request->get('RelayState', '');
+    $stateData = $relayState !== '' ? $this->tempStore()->get('relay_' . $relayState) : NULL;
+    if (!$stateData) {
+      $this->getLogger('aabenforms_nemlogin')->error('NemLog-in ACS: unknown or missing RelayState.');
+      return new JsonResponse(['error' => 'Invalid or expired login state'], 400);
+    }
+    $this->tempStore()->delete('relay_' . $relayState);
+
+    $samlResponse = (string) $request->request->get('SAMLResponse', '');
+    if ($samlResponse === '') {
+      return new JsonResponse(['error' => 'Missing SAMLResponse'], 400);
+    }
+
+    try {
+      $this->authenticator->authenticateResponse($samlResponse, $stateData['workflow_id']);
+    }
+    catch (\Exception $e) {
+      $this->getLogger('aabenforms_nemlogin')->warning('NemLog-in ACS rejected: @e', ['@e' => $e->getMessage()]);
+      $this->messenger()->addError($this->t('Login could not be completed.'));
+      return new RedirectResponse('/');
+    }
+
+    // Bind the handle to the browser session (same-origin path) and hand it to
+    // the frontend on the return URL, exactly as the MitID rail does.
+    $request->getSession()->set('mitid_workflow_id', $stateData['workflow_id']);
+    $request->getSession()->set('mitid_authenticated', TRUE);
+
+    $returnUrl = $stateData['return_url'];
+    $separator = str_contains($returnUrl, '?') ? '&' : '?';
+    $redirectUrl = $returnUrl . $separator . 'session=' . urlencode($stateData['workflow_id']);
+    if (preg_match('#^https?://#i', $redirectUrl)) {
+      return new TrustedRedirectResponse($redirectUrl);
+    }
+    return new RedirectResponse($redirectUrl);
+  }
+
+  /**
+   * Single Logout Service endpoint.
+   *
+   * Route: /nemlogin/slo.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   A redirect to the homepage.
+   */
+  public function slo(Request $request): Response {
+    $request->getSession()->remove('mitid_workflow_id');
+    $request->getSession()->remove('mitid_authenticated');
+    if ($this->enabled()) {
+      try {
+        $auth = new SamlAuth($this->settingsBuilder->buildSettings());
+        $auth->processSLO();
+      }
+      catch (\Exception $e) {
+        $this->getLogger('aabenforms_nemlogin')->warning('NemLog-in SLO: @e', ['@e' => $e->getMessage()]);
+      }
+    }
+    return new RedirectResponse('/');
+  }
+
+  /**
+   * Publishes the SP metadata (for the NemLog-in registration exchange).
+   *
+   * Route: /nemlogin/metadata.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The SP metadata XML, or a 500 when it cannot be built or is invalid.
+   */
+  public function metadata(): Response {
+    try {
+      $settings = new SamlSettings($this->settingsBuilder->buildSettings(), TRUE);
+      $metadata = $settings->getSPMetadata();
+      $errors = $settings->validateMetadata($metadata);
+      if (!empty($errors)) {
+        $this->getLogger('aabenforms_nemlogin')->error('Invalid SP metadata: @e', ['@e' => implode(', ', $errors)]);
+        return new JsonResponse(['error' => 'Invalid SP metadata'], 500);
+      }
+      return new Response($metadata, 200, ['Content-Type' => 'text/xml']);
+    }
+    catch (\Exception $e) {
+      $this->getLogger('aabenforms_nemlogin')->error('SP metadata failed: @e', ['@e' => $e->getMessage()]);
+      return new JsonResponse(['error' => 'Could not build SP metadata'], 500);
+    }
+  }
+
+  /**
+   * Returns the module's private tempstore.
+   *
+   * @return \Drupal\Core\TempStore\PrivateTempStore
+   *   The tempstore.
+   */
+  protected function tempStore() {
+    return \Drupal::service('tempstore.private')->get('aabenforms_nemlogin');
+  }
+
+  /**
+   * Validates the return_url against open-redirect, matching the MitID guard.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return string
+   *   A safe local path or trusted-origin URL; defaults to '/'.
+   */
+  protected function safeReturnUrl(Request $request): string {
+    $returnUrl = (string) ($request->query->get('return_url') ?? '/');
+    // Browsers normalise backslashes to '//', so a "/\evil.com" would escape.
+    if (str_contains($returnUrl, '\\')) {
+      return '/';
+    }
+    if (preg_match('#^https?://#i', $returnUrl)) {
+      $currentHost = $request->getSchemeAndHttpHost();
+      $host = parse_url($returnUrl, PHP_URL_SCHEME) . '://' . parse_url($returnUrl, PHP_URL_HOST);
+      $port = parse_url($returnUrl, PHP_URL_PORT);
+      $hostWithPort = $port ? $host . ':' . $port : $host;
+      $allowed = array_filter([$currentHost, getenv('CORS_ALLOW_ORIGIN') ?: '']);
+      if (!in_array($host, $allowed, TRUE) && !in_array($hostWithPort, $allowed, TRUE)) {
+        return '/';
+      }
+      return $returnUrl;
+    }
+    if (str_starts_with($returnUrl, '//')) {
+      return '/';
+    }
+    if (!str_starts_with($returnUrl, '/')) {
+      $returnUrl = '/' . $returnUrl;
+    }
+    return $returnUrl;
+  }
+
+}

--- a/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSamlAuthenticator.php
+++ b/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSamlAuthenticator.php
@@ -280,7 +280,7 @@ class NemloginSamlAuthenticator implements IdentityProviderInterface {
     $parts = array_filter([
       $this->first($attributes, self::ATTR_FIRST_NAME),
       $this->first($attributes, self::ATTR_LAST_NAME),
-    ], 'strlen');
+    ], static fn (string $part): bool => $part !== '');
     return $parts === [] ? NULL : implode(' ', $parts);
   }
 

--- a/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSamlAuthenticator.php
+++ b/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSamlAuthenticator.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace Drupal\aabenforms_nemlogin\Service;
+
+use Drupal\aabenforms_core\Identity\IdentityProviderInterface;
+use Drupal\aabenforms_core\Identity\SessionManagerInterface;
+use Drupal\aabenforms_core\Identity\VerifiedIdentity;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use OneLogin\Saml2\Response as SamlResponse;
+use OneLogin\Saml2\Settings as SamlSettings;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Validates a NemLog-in OIOSAML 3 assertion and mints a verified session.
+ *
+ * This is the production kommune identity rail. It is the SAML sibling of
+ * MitIdOidcClient: a different protocol in, the same VerifiedIdentity out,
+ * stored through the same SessionManagerInterface. Every downstream reader (the
+ * ECA gate, CPR extractor, webform intake) is therefore unaware which rail
+ * authenticated the citizen.
+ *
+ * The assertion-to-identity mapping (buildIdentity / resolveAssuranceLevel) is
+ * kept pure so it can be unit-tested against attribute fixtures without a live
+ * IdP; authenticateResponse() wraps it with php-saml signature/condition
+ * validation.
+ */
+class NemloginSamlAuthenticator implements IdentityProviderInterface {
+
+  /**
+   * The stable provider id for the NemLog-in SAML rail.
+   */
+  public const PROVIDER_ID = 'nemlogin_saml';
+
+  /**
+   * OIOSAML 3 attribute Names (Faelleskommunal / core eID attributprofil).
+   */
+  public const ATTR_CPR = 'https://data.gov.dk/model/core/eid/cprNumber';
+  public const ATTR_FULL_NAME = 'https://data.gov.dk/model/core/eid/fullName';
+  public const ATTR_FIRST_NAME = 'https://data.gov.dk/model/core/eid/firstName';
+  public const ATTR_LAST_NAME = 'https://data.gov.dk/model/core/eid/lastName';
+  public const ATTR_EMAIL = 'https://data.gov.dk/model/core/eid/email';
+  public const ATTR_DOB = 'https://data.gov.dk/model/core/eid/dateOfBirth';
+  public const ATTR_ALIAS = 'https://data.gov.dk/model/core/eid/alias';
+
+  /**
+   * NSIS Level-of-Assurance attribute and its value URIs (OIOSAML 3).
+   */
+  public const ATTR_NSIS_LOA = 'https://data.gov.dk/concept/core/nsis/loa';
+
+  /**
+   * Legacy numeric assurance attribute (OIOSAML 2 identification means).
+   */
+  public const ATTR_LEGACY_ASSURANCE = 'dk:gov:saml:attribute:AssuranceLevel';
+
+  /**
+   * The verified-identity session store (provider-neutral).
+   *
+   * @var \Drupal\aabenforms_core\Identity\SessionManagerInterface
+   */
+  protected SessionManagerInterface $sessionManager;
+
+  /**
+   * The php-saml settings builder.
+   *
+   * @var \Drupal\aabenforms_nemlogin\Service\NemloginSettingsBuilder
+   */
+  protected NemloginSettingsBuilder $settingsBuilder;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructs a NemloginSamlAuthenticator.
+   *
+   * @param \Drupal\aabenforms_core\Identity\SessionManagerInterface $session_manager
+   *   The verified-identity session store.
+   * @param \Drupal\aabenforms_nemlogin\Service\NemloginSettingsBuilder $settings_builder
+   *   The php-saml settings builder.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct(
+    SessionManagerInterface $session_manager,
+    NemloginSettingsBuilder $settings_builder,
+    ConfigFactoryInterface $config_factory,
+    LoggerChannelFactoryInterface $logger_factory,
+  ) {
+    $this->sessionManager = $session_manager;
+    $this->settingsBuilder = $settings_builder;
+    $this->configFactory = $config_factory;
+    $this->logger = $logger_factory->get('aabenforms_nemlogin');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProviderId(): string {
+    return self::PROVIDER_ID;
+  }
+
+  /**
+   * Validates a posted SAMLResponse and stores the resulting session.
+   *
+   * @param string $saml_response_b64
+   *   The base64 SAMLResponse as posted to the ACS endpoint.
+   * @param string $workflow_id
+   *   The workflow / bearer handle to store the session under.
+   *
+   * @return \Drupal\aabenforms_core\Identity\VerifiedIdentity
+   *   The verified identity.
+   *
+   * @throws \RuntimeException
+   *   When the assertion is invalid or its assurance is below the requirement.
+   */
+  public function authenticateResponse(string $saml_response_b64, string $workflow_id): VerifiedIdentity {
+    $settings = new SamlSettings($this->settingsBuilder->buildSettings());
+    $response = new SamlResponse($settings, $saml_response_b64);
+
+    if (!$response->isValid()) {
+      $reason = $response->getErrorException()?->getMessage() ?? 'unknown';
+      $this->logger->warning('NemLog-in assertion rejected: {reason}', ['reason' => $reason]);
+      throw new \RuntimeException('Invalid NemLog-in SAML assertion.');
+    }
+
+    $identity = $this->buildIdentity($response->getAttributes(), $response->getNameId());
+    return $this->completeLogin($identity, $workflow_id);
+  }
+
+  /**
+   * Enforces assurance, stores the identity and returns it.
+   *
+   * Shared by the live ACS path and any test harness that has already produced
+   * a VerifiedIdentity. Fails closed: an identity below the configured minimum
+   * NSIS level never reaches the session store.
+   *
+   * @param \Drupal\aabenforms_core\Identity\VerifiedIdentity $identity
+   *   The verified identity to persist.
+   * @param string $workflow_id
+   *   The workflow / bearer handle.
+   *
+   * @return \Drupal\aabenforms_core\Identity\VerifiedIdentity
+   *   The stored identity.
+   *
+   * @throws \RuntimeException
+   *   When the assurance is below the configured requirement.
+   */
+  public function completeLogin(VerifiedIdentity $identity, string $workflow_id): VerifiedIdentity {
+    $required = (string) ($this->configFactory->get('aabenforms_nemlogin.settings')
+      ->get('required_assurance_level') ?: 'substantial');
+    if (!$identity->meetsAssurance($required)) {
+      $this->logger->warning('NemLog-in assurance {have} below required {need}.', [
+        'have' => $identity->assuranceLevel,
+        'need' => $required,
+      ]);
+      throw new \RuntimeException(sprintf(
+        'NemLog-in assurance level "%s" is below the required "%s".',
+        $identity->assuranceLevel,
+        $required
+      ));
+    }
+
+    if ($identity->cpr === '') {
+      throw new \RuntimeException('NemLog-in assertion carried no CPR number.');
+    }
+
+    $this->sessionManager->storeSession($workflow_id, $identity->toSessionArray());
+    $this->logger->info('NemLog-in session stored for workflow {wf} (cpr {masked}, loa {loa}).', [
+      'wf' => $workflow_id,
+      'masked' => substr($identity->cpr, 0, 6) . 'XXXX',
+      'loa' => $identity->assuranceLevel,
+    ]);
+    return $identity;
+  }
+
+  /**
+   * Maps OIOSAML 3 assertion attributes to a VerifiedIdentity.
+   *
+   * Pure: no I/O, no php-saml. This is the heart of the rail and is exercised
+   * directly by unit tests against attribute fixtures.
+   *
+   * @param array $attributes
+   *   The php-saml getAttributes() shape: attribute Name => list of values.
+   * @param string|null $name_id
+   *   The assertion Subject NameID (the persistent person UUID URI).
+   *
+   * @return \Drupal\aabenforms_core\Identity\VerifiedIdentity
+   *   The mapped identity (assurance not yet enforced).
+   */
+  public function buildIdentity(array $attributes, ?string $name_id): VerifiedIdentity {
+    return new VerifiedIdentity(
+      cpr: $this->first($attributes, self::ATTR_CPR),
+      assuranceLevel: $this->resolveAssuranceLevel($attributes),
+      provider: self::PROVIDER_ID,
+      subject: $name_id ?: NULL,
+      name: $this->first($attributes, self::ATTR_FULL_NAME) ?: $this->composeName($attributes),
+      givenName: $this->first($attributes, self::ATTR_FIRST_NAME) ?: NULL,
+      familyName: $this->first($attributes, self::ATTR_LAST_NAME) ?: NULL,
+      birthdate: $this->first($attributes, self::ATTR_DOB) ?: NULL,
+      email: $this->first($attributes, self::ATTR_EMAIL) ?: NULL,
+      issuer: (string) ($this->configFactory->get('aabenforms_nemlogin.settings')->get('idp_entity_id') ?: '') ?: NULL,
+      authTime: NULL,
+    );
+  }
+
+  /**
+   * Resolves the NSIS assurance level from either assurance scheme.
+   *
+   * NemLog-in may assert an NSIS LoA (OIOSAML 3) or, for a non-NSIS means, a
+   * legacy numeric AssuranceLevel. Fails closed: anything unrecognised is
+   * 'unknown' and never satisfies a substantial/high requirement.
+   *
+   * @param array $attributes
+   *   The php-saml getAttributes() shape.
+   *
+   * @return string
+   *   'low', 'substantial', 'high' or 'unknown'.
+   */
+  public function resolveAssuranceLevel(array $attributes): string {
+    $loa = $this->first($attributes, self::ATTR_NSIS_LOA);
+    if ($loa !== '') {
+      // Value is a URI ending in Low|Substantial|High, or a bare word.
+      $tail = strtolower(substr($loa, (int) strrpos($loa, '/') + 1) ?: $loa);
+      if (isset(VerifiedIdentity::ASSURANCE_RANKS[$tail])) {
+        return $tail;
+      }
+    }
+    $legacy = $this->first($attributes, self::ATTR_LEGACY_ASSURANCE);
+    return match ($legacy) {
+      '4' => 'high',
+      '3' => 'substantial',
+      '2', '1' => 'low',
+      default => 'unknown',
+    };
+  }
+
+  /**
+   * Returns the first value of a multi-valued SAML attribute, or ''.
+   *
+   * @param array $attributes
+   *   The attribute map.
+   * @param string $name
+   *   The attribute Name.
+   *
+   * @return string
+   *   The first value, or the empty string when absent. 'N/A' (returned by
+   *   NemLog-in for name-protected citizens) is treated as absent.
+   */
+  protected function first(array $attributes, string $name): string {
+    $value = '';
+    if (isset($attributes[$name]) && is_array($attributes[$name]) && $attributes[$name] !== []) {
+      $value = trim((string) reset($attributes[$name]));
+    }
+    return $value === 'N/A' ? '' : $value;
+  }
+
+  /**
+   * Builds a full name from first/last parts when no fullName is asserted.
+   *
+   * @param array $attributes
+   *   The attribute map.
+   *
+   * @return string|null
+   *   The composed name, or NULL when neither part is present.
+   */
+  protected function composeName(array $attributes): ?string {
+    $parts = array_filter([
+      $this->first($attributes, self::ATTR_FIRST_NAME),
+      $this->first($attributes, self::ATTR_LAST_NAME),
+    ], 'strlen');
+    return $parts === [] ? NULL : implode(' ', $parts);
+  }
+
+}

--- a/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSettingsBuilder.php
+++ b/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSettingsBuilder.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\aabenforms_nemlogin\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\key\KeyRepositoryInterface;
+
+/**
+ * Assembles the onelogin/php-saml settings array for the NemLog-in SP.
+ *
+ * The OCES3 keypair never lives in config: sp_cert_key / sp_private_key_key
+ * name `key` module entries, so the PEM material is read at runtime and stays
+ * out of config/sync. NemLog-in requires signed AuthnRequests and encrypts its
+ * assertions, so the security block turns those on and the SP private key is
+ * what decrypts the returned assertion.
+ */
+class NemloginSettingsBuilder {
+
+  /**
+   * NSIS Substantial authn-context class reference (the SP's default minimum).
+   */
+  public const LOA_SUBSTANTIAL = 'https://data.gov.dk/concept/core/nsis/loa/Substantial';
+
+  /**
+   * Maps the configured minimum level to its NSIS authn-context class ref.
+   */
+  protected const LOA_CLASS_REFS = [
+    'low' => 'https://data.gov.dk/concept/core/nsis/loa/Low',
+    'substantial' => 'https://data.gov.dk/concept/core/nsis/loa/Substantial',
+    'high' => 'https://data.gov.dk/concept/core/nsis/loa/High',
+  ];
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * The key repository.
+   *
+   * @var \Drupal\key\KeyRepositoryInterface
+   */
+  protected KeyRepositoryInterface $keyRepository;
+
+  /**
+   * Constructs a NemloginSettingsBuilder.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\key\KeyRepositoryInterface $key_repository
+   *   The key repository.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, KeyRepositoryInterface $key_repository) {
+    $this->configFactory = $config_factory;
+    $this->keyRepository = $key_repository;
+  }
+
+  /**
+   * Builds the php-saml settings array from configuration.
+   *
+   * @return array
+   *   The settings array for OneLogin\Saml2\Auth / Settings / Response.
+   */
+  public function buildSettings(): array {
+    $config = $this->configFactory->get('aabenforms_nemlogin.settings');
+    $required = (string) ($config->get('required_assurance_level') ?: 'substantial');
+    $classRef = self::LOA_CLASS_REFS[strtolower($required)] ?? self::LOA_SUBSTANTIAL;
+
+    return [
+      'strict' => (bool) ($config->get('strict') ?? TRUE),
+      'debug' => FALSE,
+      'sp' => [
+        'entityId' => (string) $config->get('sp_entity_id'),
+        'assertionConsumerService' => [
+          'url' => (string) $config->get('acs_url'),
+          'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        ],
+        'singleLogoutService' => [
+          'url' => (string) $config->get('slo_url'),
+          'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+        'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+        'x509cert' => $this->readKey((string) $config->get('sp_cert_key')),
+        'privateKey' => $this->readKey((string) $config->get('sp_private_key_key')),
+      ],
+      'idp' => [
+        'entityId' => (string) $config->get('idp_entity_id'),
+        'singleSignOnService' => [
+          'url' => (string) $config->get('idp_sso_url'),
+          'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+        'singleLogoutService' => [
+          'url' => (string) $config->get('idp_slo_url'),
+          'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+        'x509cert' => (string) $config->get('idp_cert'),
+      ],
+      'security' => [
+        'authnRequestsSigned' => TRUE,
+        'logoutRequestSigned' => TRUE,
+        'logoutResponseSigned' => TRUE,
+        'wantMessagesSigned' => TRUE,
+        'wantAssertionsSigned' => TRUE,
+        'wantAssertionsEncrypted' => TRUE,
+        'wantNameIdEncrypted' => FALSE,
+        'signMetadata' => TRUE,
+        'requestedAuthnContext' => [$classRef],
+        'requestedAuthnContextComparison' => 'minimum',
+        'signatureAlgorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+        'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
+      ],
+    ];
+  }
+
+  /**
+   * Reads PEM material from a named key entry, tolerating an unconfigured key.
+   *
+   * @param string $key_name
+   *   The `key` module entry id, or '' when unset.
+   *
+   * @return string
+   *   The key value, or '' when the entry is unset or missing.
+   */
+  protected function readKey(string $key_name): string {
+    if ($key_name === '') {
+      return '';
+    }
+    $key = $this->keyRepository->getKey($key_name);
+    return $key ? (string) $key->getKeyValue() : '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_nemlogin/tests/src/Unit/Service/NemloginSamlAuthenticatorTest.php
+++ b/web/modules/custom/aabenforms_nemlogin/tests/src/Unit/Service/NemloginSamlAuthenticatorTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_nemlogin\Unit\Service;
+
+use Drupal\aabenforms_core\Identity\SessionManagerInterface;
+use Drupal\aabenforms_core\Identity\VerifiedIdentity;
+use Drupal\aabenforms_nemlogin\Service\NemloginSamlAuthenticator;
+use Drupal\aabenforms_nemlogin\Service\NemloginSettingsBuilder;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the NemLog-in OIOSAML 3 attribute-to-identity mapping and gating.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_nemlogin\Service\NemloginSamlAuthenticator
+ * @group aabenforms_nemlogin
+ * @group identity
+ */
+class NemloginSamlAuthenticatorTest extends UnitTestCase {
+
+  /**
+   * The mocked session store.
+   *
+   * @var \Drupal\aabenforms_core\Identity\SessionManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $sessionManager;
+
+  /**
+   * The authenticator under test.
+   *
+   * @var \Drupal\aabenforms_nemlogin\Service\NemloginSamlAuthenticator
+   */
+  protected NemloginSamlAuthenticator $authenticator;
+
+  /**
+   * Builds the authenticator with a configurable required assurance level.
+   *
+   * @param string $requiredLevel
+   *   The configured minimum NSIS level.
+   */
+  protected function makeAuthenticator(string $requiredLevel = 'substantial'): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['idp_entity_id', 'https://saml.nemlog-in.dk'],
+      ['required_assurance_level', $requiredLevel],
+    ]);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->with('aabenforms_nemlogin.settings')->willReturn($config);
+
+    $channel = $this->createMock(LoggerChannelInterface::class);
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($channel);
+
+    $this->sessionManager = $this->createMock(SessionManagerInterface::class);
+    $settingsBuilder = $this->createMock(NemloginSettingsBuilder::class);
+
+    $this->authenticator = new NemloginSamlAuthenticator(
+      $this->sessionManager,
+      $settingsBuilder,
+      $configFactory,
+      $loggerFactory,
+    );
+  }
+
+  /**
+   * A full OIOSAML 3 citizen assertion maps to a complete VerifiedIdentity.
+   *
+   * @covers ::buildIdentity
+   * @covers ::resolveAssuranceLevel
+   */
+  public function testBuildIdentityFromFullAssertion(): void {
+    $this->makeAuthenticator();
+    $identity = $this->authenticator->buildIdentity(
+      $this->citizenAttributes(),
+      'https://data.gov.dk/model/core/eid/person/uuid/7d9c-abc',
+    );
+
+    $this->assertSame('0101801234', $identity->cpr);
+    $this->assertSame('substantial', $identity->assuranceLevel);
+    $this->assertSame('nemlogin_saml', $identity->provider);
+    $this->assertSame('https://data.gov.dk/model/core/eid/person/uuid/7d9c-abc', $identity->subject);
+    $this->assertSame('Anders And', $identity->name);
+    $this->assertSame('Anders', $identity->givenName);
+    $this->assertSame('And', $identity->familyName);
+    $this->assertSame('anders@example.dk', $identity->email);
+    $this->assertSame('https://saml.nemlog-in.dk', $identity->issuer);
+  }
+
+  /**
+   * The NSIS LoA value URI is reduced to its bare level word.
+   *
+   * @covers ::resolveAssuranceLevel
+   * @dataProvider loaProvider
+   */
+  public function testResolveAssuranceLevel(array $attributes, string $expected): void {
+    $this->makeAuthenticator();
+    $this->assertSame($expected, $this->authenticator->resolveAssuranceLevel($attributes));
+  }
+
+  /**
+   * Data provider for assurance resolution across both schemes.
+   *
+   * @return array
+   *   Rows of [attribute map, expected level].
+   */
+  public static function loaProvider(): array {
+    $loa = NemloginSamlAuthenticator::ATTR_NSIS_LOA;
+    $legacy = NemloginSamlAuthenticator::ATTR_LEGACY_ASSURANCE;
+    return [
+      'nsis high uri' => [[$loa => ['https://data.gov.dk/concept/core/nsis/loa/High']], 'high'],
+      'nsis substantial uri' => [[$loa => ['https://data.gov.dk/concept/core/nsis/loa/Substantial']], 'substantial'],
+      'nsis low uri' => [[$loa => ['https://data.gov.dk/concept/core/nsis/loa/Low']], 'low'],
+      'legacy 4 is high' => [[$legacy => ['4']], 'high'],
+      'legacy 3 is substantial' => [[$legacy => ['3']], 'substantial'],
+      'legacy 2 is low' => [[$legacy => ['2']], 'low'],
+      'nothing is unknown (closed)' => [[], 'unknown'],
+      'garbage is unknown (closed)' => [[$loa => ['nonsense']], 'unknown'],
+    ];
+  }
+
+  /**
+   * A Substantial login satisfies a Substantial requirement and is stored.
+   *
+   * @covers ::completeLogin
+   */
+  public function testCompleteLoginStoresWhenAssuranceMet(): void {
+    $this->makeAuthenticator('substantial');
+    $this->sessionManager->expects($this->once())
+      ->method('storeSession')
+      ->with('wf_abc', $this->callback(fn ($data) => ($data['cpr'] ?? NULL) === '0101801234'))
+      ->willReturn(TRUE);
+
+    $identity = $this->authenticator->buildIdentity($this->citizenAttributes(), 'sub');
+    $result = $this->authenticator->completeLogin($identity, 'wf_abc');
+    $this->assertSame('0101801234', $result->cpr);
+  }
+
+  /**
+   * A Substantial login fails closed against a High requirement.
+   *
+   * @covers ::completeLogin
+   */
+  public function testCompleteLoginRejectsBelowRequired(): void {
+    $this->makeAuthenticator('high');
+    $this->sessionManager->expects($this->never())->method('storeSession');
+
+    $identity = $this->authenticator->buildIdentity($this->citizenAttributes(), 'sub');
+    $this->expectException(\RuntimeException::class);
+    $this->authenticator->completeLogin($identity, 'wf_abc');
+  }
+
+  /**
+   * A name-protected citizen (N/A names, alias pseudonym) yields no name.
+   *
+   * @covers ::buildIdentity
+   */
+  public function testNameProtectedCitizen(): void {
+    $this->makeAuthenticator();
+    $attributes = [
+      NemloginSamlAuthenticator::ATTR_CPR => ['0101801234'],
+      NemloginSamlAuthenticator::ATTR_NSIS_LOA => ['https://data.gov.dk/concept/core/nsis/loa/Substantial'],
+      NemloginSamlAuthenticator::ATTR_FULL_NAME => ['N/A'],
+      NemloginSamlAuthenticator::ATTR_FIRST_NAME => ['N/A'],
+      NemloginSamlAuthenticator::ATTR_LAST_NAME => ['N/A'],
+      NemloginSamlAuthenticator::ATTR_ALIAS => ['Pseudonym'],
+    ];
+    $identity = $this->authenticator->buildIdentity($attributes, 'sub');
+    $this->assertSame('0101801234', $identity->cpr);
+    $this->assertNull($identity->name);
+    $this->assertNull($identity->givenName);
+  }
+
+  /**
+   * A representative NemLog-in citizen getAttributes() payload.
+   *
+   * @return array
+   *   The attribute map (attribute Name => list of string values).
+   */
+  protected function citizenAttributes(): array {
+    return [
+      NemloginSamlAuthenticator::ATTR_CPR => ['0101801234'],
+      NemloginSamlAuthenticator::ATTR_NSIS_LOA => ['https://data.gov.dk/concept/core/nsis/loa/Substantial'],
+      NemloginSamlAuthenticator::ATTR_FULL_NAME => ['Anders And'],
+      NemloginSamlAuthenticator::ATTR_FIRST_NAME => ['Anders'],
+      NemloginSamlAuthenticator::ATTR_LAST_NAME => ['And'],
+      NemloginSamlAuthenticator::ATTR_EMAIL => ['anders@example.dk'],
+      NemloginSamlAuthenticator::ATTR_DOB => ['1980-01-01'],
+    ];
+  }
+
+}


### PR DESCRIPTION
## What this adds

The production kommune identity rail, and the abstraction that lets it coexist with the existing MitID OIDC rail with **zero changes to any downstream reader** (the ECA gate, CPR extractor, and webform intake are untouched).

### Phase 1 - provider-neutral identity contracts (aabenforms_core)
- **VerifiedIdentity**: immutable value object both rails produce. `toSessionArray()` reproduces the existing flat session shape verbatim, so the two rails are interchangeable. Carries the NSIS assurance ranking (unknown<low<substantial<high, fail-closed).
- **SessionManagerInterface**: the flow-scoped session-store contract; `MitIdSessionManager` now implements it.
- **IdentityProviderInterface**: marks a rail that terminates in a VerifiedIdentity; `MitIdOidcClient` implements it (`getProviderId` = `mitid_oidc`).
- Service aliases `aabenforms_identity.session_manager` (and the interface), so consumers can depend on the neutral id.

### Phase 2 - aabenforms_nemlogin (NemLog-in OIOSAML 3 SP)
- **NemloginSamlAuthenticator** (implements `IdentityProviderInterface`): validates a posted assertion via `onelogin/php-saml`, maps OIOSAML 3 attributes (`data.gov.dk/model/core/eid/*`) to a VerifiedIdentity, resolves NSIS assurance from both the LoA and legacy schemes (fail-closed), enforces the configured minimum, and stores the session. The attribute mapping is pure and unit-tested against citizen assertion fixtures, incl. name-protected citizens.
- **NemloginSettingsBuilder**: assembles php-saml settings from config + the `key` module (OCES3 keypair stays out of `config/sync`); requests NSIS Substantial with `Comparison=minimum`, signed AuthnRequests, encrypted assertions.
- **NemloginController**: `/nemlogin/login|acs|slo|metadata`, mirroring the MitID security posture (server-minted `workflow_id`, opaque RelayState, origin-checked `return_url`). Dormant until `settings.enabled` and an SP registration exist.

## Testing
- 21 new unit tests (VerifiedIdentity + NemloginSamlAuthenticator) pass.
- Existing MitID (unit + kernel) and workflows tests unaffected; container rebuilds and all services resolve.
- Adds `onelogin/php-saml ^4` (+ `robrichards/xmlseclibs`).

## Not in scope (enrollment-gated, ops)
Live login needs an SP registration + metadata exchange in NemLog-in integrationstest, and an OCES3 keypair loaded into the `key` module. The demo (OIDC mock rail) keeps working unchanged.

Part of the pilot spine (Track 1). Stacked on #177.