### PR TITLE
Track 3a: live SF1601 Digital Post transport (LiveSf1601Client + cert bridge)

### DIFF
--- a/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.services.yml
+++ b/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.services.yml
@@ -10,10 +10,16 @@ services:
   aabenforms_digital_post.memo_builder:
     class: Drupal\aabenforms_digital_post\Memo\MemoBuilder
 
-  # Certificate locator: file-based default. Factory picks based on config.
+  # Certificate locator: file-based or drupal:key. Factory picks based on config.
   aabenforms_digital_post.certificate_locator.file:
     class: Drupal\aabenforms_digital_post\Certificate\FileCertificateLocator
     arguments: ['@config.factory']
+
+  aabenforms_digital_post.certificate_locator.key:
+    class: Drupal\aabenforms_digital_post\Certificate\KeyCertificateLocator
+    arguments:
+      - '@config.factory'
+      - '@key.repository'
 
   aabenforms_digital_post.certificate_locator:
     class: Drupal\aabenforms_digital_post\Certificate\CertificateLocatorInterface
@@ -24,6 +30,7 @@ services:
     arguments:
       - '@config.factory'
       - '@aabenforms_digital_post.certificate_locator.file'
+      - '@aabenforms_digital_post.certificate_locator.key'
 
   # Sf1601 transport: fake_db or wiremock for now. Factory picks based on test_mode.
   aabenforms_digital_post.sf1601_client.fake_db:
@@ -43,6 +50,17 @@ services:
       - '@logger.channel.aabenforms_digital_post'
       - '@aabenforms_digital_post.memo_builder'
 
+  # Live SF1601 transport (Serviceplatformen exttest/prod). Writes `pending`.
+  aabenforms_digital_post.sf1601_client.live:
+    class: Drupal\aabenforms_digital_post\TestMode\LiveSf1601Client
+    arguments:
+      - '@database'
+      - '@datetime.time'
+      - '@logger.channel.aabenforms_digital_post'
+      - '@aabenforms_digital_post.memo_builder'
+      - '@config.factory'
+      - '@aabenforms_digital_post.certificate_locator'
+
   aabenforms_digital_post.sf1601_client:
     class: Drupal\aabenforms_digital_post\Service\Sf1601ClientInterface
     factory: ['@aabenforms_digital_post.sf1601_client_factory', 'create']
@@ -53,6 +71,7 @@ services:
       - '@config.factory'
       - '@aabenforms_digital_post.sf1601_client.fake_db'
       - '@aabenforms_digital_post.sf1601_client.wiremock'
+      - '@aabenforms_digital_post.sf1601_client.live'
 
   # Audit emitter: defaults to CoreAuditEmitter (wraps aabenforms_core.audit_logger).
   aabenforms_digital_post.audit_emitter:

--- a/web/modules/custom/aabenforms_digital_post/config/install/aabenforms_digital_post.settings.yml
+++ b/web/modules/custom/aabenforms_digital_post/config/install/aabenforms_digital_post.settings.yml
@@ -1,8 +1,13 @@
 test_mode: fake_db
 sender_cvr: ''
 sender_name: ''
+# The CVR the SF1601 SAML token authenticates as (the sending authority).
+# Falls back to sender_cvr when empty.
+authority_cvr: ''
 cert_source: file
 cert_path: ''
+# The drupal:key entry holding the PKCS#12 when cert_source=key.
+cert_key: ''
 cert_passphrase_state: ''
 wiremock_url: 'http://wiremock:8080'
 live_test_endpoint: 'https://exttest.serviceplatformen.dk/service/KombiPostAfsend_1/kombi'

--- a/web/modules/custom/aabenforms_digital_post/config/schema/aabenforms_digital_post.schema.yml
+++ b/web/modules/custom/aabenforms_digital_post/config/schema/aabenforms_digital_post.schema.yml
@@ -14,6 +14,9 @@ aabenforms_digital_post.settings:
     sender_name:
       type: string
       label: 'Sender display name'
+    authority_cvr:
+      type: string
+      label: 'Authority CVR (SF1601 token identity; falls back to sender_cvr)'
     cert_source:
       type: string
       label: 'Certificate source'
@@ -23,6 +26,9 @@ aabenforms_digital_post.settings:
     cert_path:
       type: string
       label: 'Certificate file path (cert_source=file)'
+    cert_key:
+      type: string
+      label: 'Key module entry holding the PKCS#12 (cert_source=key)'
     cert_passphrase_state:
       type: string
       label: 'Passphrase source identifier (env var name or key entity id)'

--- a/web/modules/custom/aabenforms_digital_post/src/Certificate/Certificate.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Certificate/Certificate.php
@@ -7,16 +7,31 @@ namespace Drupal\aabenforms_digital_post\Certificate;
 /**
  * Immutable certificate material returned by a CertificateLocator.
  *
- * Carries the cert as a file path and an optional passphrase. Raw bytes
- * are intentionally NOT in this DTO - SOAP clients read from the path,
- * and log emitters should never have a reason to see the bytes.
+ * Carries the cert as a file path and an optional passphrase. A locator that
+ * has no file on disk (the drupal:key source) instead carries the PKCS#12
+ * bytes in $pkcs12 and leaves $path empty; the vendor adapter reads whichever
+ * is present. Log emitters must never touch $pkcs12.
  */
 final class Certificate {
 
+  /**
+   * Constructs a Certificate.
+   *
+   * @param string $path
+   *   Absolute path to the PKCS#12/PEM file, or '' when the cert is held as
+   *   bytes in $pkcs12 (the key source).
+   * @param string|null $passphrase
+   *   The PKCS#12 passphrase, or NULL when none.
+   * @param string $sourceLabel
+   *   A short label for the locator that produced this (e.g. 'file', 'key').
+   * @param string|null $pkcs12
+   *   The raw PKCS#12 bytes when the cert is not on disk; NULL otherwise.
+   */
   public function __construct(
     public readonly string $path,
     public readonly ?string $passphrase,
     public readonly string $sourceLabel,
+    public readonly ?string $pkcs12 = NULL,
   ) {
   }
 

--- a/web/modules/custom/aabenforms_digital_post/src/Certificate/CertificateLocatorFactory.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Certificate/CertificateLocatorFactory.php
@@ -10,15 +10,16 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 /**
  * Selects the concrete CertificateLocator based on config.cert_source.
  *
- * Today only "file" is shipped. Future session: register "key" (drupal:key
- * contrib) and "os2web_key" (via optional bridge submodule) services and
- * pick them here by string match.
+ * Ships "file" (path + env-var passphrase) and "key" (PKCS#12 held in a
+ * drupal:key entry). A future "os2web_key" bridge submodule would register its
+ * own locator and be picked here by string match.
  */
 final class CertificateLocatorFactory {
 
   public function __construct(
     private readonly ConfigFactoryInterface $configFactory,
     private readonly FileCertificateLocator $fileLocator,
+    private readonly KeyCertificateLocator $keyLocator,
   ) {
   }
 
@@ -34,8 +35,9 @@ final class CertificateLocatorFactory {
       ->get('cert_source');
     return match ($source) {
       'file', '' => $this->fileLocator,
+      'key' => $this->keyLocator,
       default => throw new CertificateException(sprintf(
-        'cert_source "%s" is not supported in this build. Available: file.',
+        'cert_source "%s" is not supported in this build. Available: file, key.',
         $source
       )),
     };

--- a/web/modules/custom/aabenforms_digital_post/src/Certificate/KeyCertificateLocator.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Certificate/KeyCertificateLocator.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\Certificate;
+
+use Drupal\aabenforms_digital_post\Exception\CertificateException;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\key\KeyRepositoryInterface;
+
+/**
+ * Certificate locator backed by the drupal:key module.
+ *
+ * The FOCES3/OCES3 PKCS#12 lives in a `key` entry (named by config `cert_key`)
+ * rather than on disk, so the secret stays in the key module's encrypted
+ * storage and out of config/sync. The passphrase is resolved the same way the
+ * file locator does - from the environment variable named by
+ * `cert_passphrase_state` - so a passphrase is never version-controlled either.
+ */
+final class KeyCertificateLocator implements CertificateLocatorInterface {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly KeyRepositoryInterface $keyRepository,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function locate(): Certificate {
+    $config = $this->configFactory->get('aabenforms_digital_post.settings');
+    $keyName = (string) $config->get('cert_key');
+    if ($keyName === '') {
+      throw new CertificateException('aabenforms_digital_post.settings:cert_key is empty (cert_source=key).');
+    }
+    $key = $this->keyRepository->getKey($keyName);
+    if ($key === NULL) {
+      throw new CertificateException(sprintf('Key entry "%s" does not exist.', $keyName));
+    }
+    $bytes = (string) $key->getKeyValue();
+    if ($bytes === '') {
+      throw new CertificateException(sprintf('Key entry "%s" is empty.', $keyName));
+    }
+
+    $envVar = (string) $config->get('cert_passphrase_state');
+    $passphrase = NULL;
+    if ($envVar !== '') {
+      $value = getenv($envVar);
+      $passphrase = $value === FALSE ? NULL : $value;
+    }
+
+    return new Certificate(
+      path: '',
+      passphrase: $passphrase,
+      sourceLabel: 'key',
+      pkcs12: $bytes,
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsRenewal(): bool {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expiresAt(): ?\DateTimeImmutable {
+    try {
+      $certificate = $this->locate();
+    }
+    catch (CertificateException) {
+      return NULL;
+    }
+    $store = [];
+    $passphrase = $certificate->passphrase ?? '';
+    if ($certificate->pkcs12 === NULL || !openssl_pkcs12_read($certificate->pkcs12, $store, $passphrase)) {
+      return NULL;
+    }
+    $parsed = @openssl_x509_parse((string) ($store['cert'] ?? ''));
+    if ($parsed === FALSE || !isset($parsed['validTo_time_t'])) {
+      return NULL;
+    }
+    return (new \DateTimeImmutable())->setTimestamp((int) $parsed['validTo_time_t']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/src/Certificate/VendorCertificateLocatorAdapter.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Certificate/VendorCertificateLocatorAdapter.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\Certificate;
+
+use ItkDev\Serviceplatformen\Certificate\AbstractCertificateLocator;
+use ItkDev\Serviceplatformen\Certificate\Exception\CertificateLocatorException;
+
+/**
+ * Bridges the module's Certificate DTO to itk-dev's CertificateLocatorInterface.
+ *
+ * The live SF1601 client obtains a module Certificate (path + passphrase, or
+ * raw PKCS#12 bytes) from the module's own locator, then wraps it in this
+ * adapter so the vendor SF1601 service can call getCertificates(). At runtime
+ * the REST path only ever reads getCertificates()['cert'|'pkey'] (the
+ * openssl_pkcs12_read output), so that is the method that matters; the others
+ * exist to satisfy the interface.
+ */
+final class VendorCertificateLocatorAdapter extends AbstractCertificateLocator {
+
+  /**
+   * Constructs the adapter from a module Certificate DTO.
+   *
+   * @param \Drupal\aabenforms_digital_post\Certificate\Certificate $certificate
+   *   The located module certificate (file path or in-memory PKCS#12 bytes).
+   */
+  public function __construct(private readonly Certificate $certificate) {
+    parent::__construct($certificate->passphrase ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCertificates(): array {
+    $bytes = $this->readPkcs12();
+    $store = [];
+    $passphrase = $this->hasPassphrase() ? $this->getPassphrase() : NULL;
+    if (!openssl_pkcs12_read($bytes, $store, (string) $passphrase)) {
+      throw new CertificateLocatorException(sprintf(
+        'Could not read PKCS#12 certificate from %s (wrong passphrase or corrupt file).',
+        $this->certificate->sourceLabel
+      ));
+    }
+    return $store;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCertificate(): string {
+    $store = $this->getCertificates();
+    return (string) ($store['cert'] ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAbsolutePathToCertificate(): string {
+    // Deprecated in the interface and unused by the REST send path. A
+    // key-sourced cert has no path, so refuse rather than return a bad value.
+    if ($this->certificate->path !== '') {
+      return $this->certificate->path;
+    }
+    throw new CertificateLocatorException('This certificate is held in memory and has no filesystem path.');
+  }
+
+  /**
+   * Returns the PKCS#12 bytes, from memory or by reading the file.
+   *
+   * @return string
+   *   The raw PKCS#12 bytes.
+   *
+   * @throws \ItkDev\Serviceplatformen\Certificate\CertificateLocatorException
+   *   When neither bytes nor a readable file are available.
+   */
+  private function readPkcs12(): string {
+    if ($this->certificate->pkcs12 !== NULL && $this->certificate->pkcs12 !== '') {
+      return $this->certificate->pkcs12;
+    }
+    if ($this->certificate->path === '' || !is_readable($this->certificate->path)) {
+      throw new CertificateLocatorException(sprintf(
+        'Certificate source "%s" has no bytes and no readable file.',
+        $this->certificate->sourceLabel
+      ));
+    }
+    $bytes = file_get_contents($this->certificate->path);
+    if ($bytes === FALSE) {
+      throw new CertificateLocatorException(sprintf('Could not read certificate file "%s".', $this->certificate->path));
+    }
+    return $bytes;
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/src/DigitalPost/Result.php
+++ b/web/modules/custom/aabenforms_digital_post/src/DigitalPost/Result.php
@@ -7,12 +7,16 @@ namespace Drupal\aabenforms_digital_post\DigitalPost;
 /**
  * Immutable result of a Digital Post send attempt.
  *
- * Either success with a transaction id, or failure with a typed reason
- * code.
+ * One of three outcomes: success, pending, or failure with a typed reason
+ * code. `pending` exists for the live transport: a 2xx from
+ * kombiPostAfsend() means the message was ACCEPTED for delivery, not that it
+ * was delivered - the real delivery/failure arrives asynchronously as a
+ * Beskedfordeler receipt. A live send therefore never returns success.
  */
 final class Result {
 
   public const SUCCESS = 'success';
+  public const PENDING = 'pending';
   public const FAILURE = 'failure';
 
   // Reason codes (failures only).
@@ -47,6 +51,22 @@ final class Result {
   }
 
   /**
+   * Builds a pending Result: accepted for delivery, outcome not yet known.
+   *
+   * The live transport returns this on a 2xx from Serviceplatformen. The final
+   * delivered/failed state is reconciled later from the asynchronous receipt.
+   */
+  public static function pending(string $transactionId, string $message = '', ?string $rawResponse = NULL): self {
+    return new self(
+      status: self::PENDING,
+      transactionId: $transactionId,
+      reasonCode: NULL,
+      message: $message,
+      rawResponse: $rawResponse,
+    );
+  }
+
+  /**
    * Builds a failure Result with a typed reason code.
    */
   public static function failure(string $transactionId, string $reasonCode, string $message, ?string $rawResponse = NULL): self {
@@ -64,6 +84,13 @@ final class Result {
    */
   public function isSuccess(): bool {
     return $this->status === self::SUCCESS;
+  }
+
+  /**
+   * Whether this Result is pending (accepted, awaiting an async receipt).
+   */
+  public function isPending(): bool {
+    return $this->status === self::PENDING;
   }
 
   /**

--- a/web/modules/custom/aabenforms_digital_post/src/Service/Sf1601ClientFactory.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Service/Sf1601ClientFactory.php
@@ -6,14 +6,16 @@ namespace Drupal\aabenforms_digital_post\Service;
 
 use Drupal\aabenforms_digital_post\Exception\DigitalPostException;
 use Drupal\aabenforms_digital_post\TestMode\FakeSendDatabaseLogger;
+use Drupal\aabenforms_digital_post\TestMode\LiveSf1601Client;
 use Drupal\aabenforms_digital_post\TestMode\WireMockSoapClient;
 use Drupal\Core\Config\ConfigFactoryInterface;
 
 /**
  * Picks the Sf1601 transport implementation based on config.test_mode.
  *
- * Session 1 supports fake_db and wiremock. Session 2 adds live_test and
- * live (both via itk-dev/serviceplatformen).
+ * The fake_db and wiremock modes are the offline/mock rails; live_test and live
+ * route to the real Serviceplatformen exttest/prod endpoints via the same
+ * LiveSf1601Client (it reads test_mode to pick the endpoint).
  */
 final class Sf1601ClientFactory {
 
@@ -21,6 +23,7 @@ final class Sf1601ClientFactory {
     private readonly ConfigFactoryInterface $configFactory,
     private readonly FakeSendDatabaseLogger $fakeDbClient,
     private readonly WireMockSoapClient $wireMockClient,
+    private readonly LiveSf1601Client $liveClient,
   ) {
   }
 
@@ -38,10 +41,7 @@ final class Sf1601ClientFactory {
       '' => throw new DigitalPostException('Digital Post test_mode is not configured; refusing to send. Set it explicitly (fake_db in dev).'),
       'fake_db' => $this->fakeDbClient,
       'wiremock' => $this->wireMockClient,
-      'live_test', 'live' => throw new DigitalPostException(sprintf(
-        'test_mode "%s" is not supported in session 1. Use fake_db or wiremock.',
-        $mode
-      )),
+      'live_test', 'live' => $this->liveClient,
       default => throw new DigitalPostException(sprintf('Unknown test_mode "%s".', $mode)),
     };
   }

--- a/web/modules/custom/aabenforms_digital_post/src/TestMode/LiveSf1601Client.php
+++ b/web/modules/custom/aabenforms_digital_post/src/TestMode/LiveSf1601Client.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\TestMode;
+
+use Drupal\aabenforms_digital_post\Certificate\CertificateLocatorInterface;
+use Drupal\aabenforms_digital_post\Certificate\VendorCertificateLocatorAdapter;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\aabenforms_digital_post\Memo\MemoBuilder;
+use Drupal\aabenforms_digital_post\Service\Sf1601ClientInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use ItkDev\Serviceplatformen\Service\SF1601\SF1601;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Live SF1601 Digital Post transport (Serviceplatformen exttest / prod).
+ *
+ * Reuses MemoBuilder to construct the MeMo Message and passes it straight to
+ * the itk-dev SF1601 service's kombiPostAfsend(). The crucial contract: a 2xx
+ * from Serviceplatformen means the message was ACCEPTED, not delivered, so this
+ * client returns Result::pending() and writes a `pending` log row - never
+ * `success`. The real delivered/failed outcome arrives asynchronously as a
+ * Beskedfordeler receipt (handled by the beskedfordeler submodule). Like every
+ * transport it NEVER throws; all failure modes become Result::failure().
+ *
+ * Idempotent: the transaction_id unique key plus a pre-send lookup mean a retry
+ * with the same id does not re-send an official letter.
+ */
+final class LiveSf1601Client implements Sf1601ClientInterface {
+
+  /**
+   * Constructs the live client.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
+   * @param \Drupal\aabenforms_digital_post\Memo\MemoBuilder $memoBuilder
+   *   The MeMo builder.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\aabenforms_digital_post\Certificate\CertificateLocatorInterface $certificateLocator
+   *   The module certificate locator.
+   * @param \Closure|null $serviceFactory
+   *   Optional (string $cvr, bool $testMode): SF1601 factory. Only tests set
+   *   it, to inject a stubbed service and bypass the real cert + network.
+   */
+  public function __construct(
+    private readonly Connection $database,
+    private readonly TimeInterface $time,
+    private readonly LoggerInterface $logger,
+    private readonly MemoBuilder $memoBuilder,
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly CertificateLocatorInterface $certificateLocator,
+    private readonly ?\Closure $serviceFactory = NULL,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function send(DigitalPost $post, string $transactionId): Result {
+    // Idempotency: if this transaction was already accepted (pending) or
+    // recorded as sent, never re-post the letter - just report it pending.
+    $existing = $this->existingStatus($transactionId);
+    if ($existing === Result::PENDING || $existing === Result::SUCCESS) {
+      return Result::pending($transactionId, 'Already submitted (idempotent replay).');
+    }
+
+    $config = $this->configFactory->get('aabenforms_digital_post.settings');
+    $authorityCvr = (string) ($config->get('authority_cvr') ?: $config->get('sender_cvr'));
+    if ($authorityCvr === '') {
+      return Result::failure(
+        $transactionId,
+        Result::REASON_VALIDATION,
+        'No authority_cvr / sender_cvr configured for the live SF1601 client.',
+      );
+    }
+    $testMode = $this->modeLabel() !== 'live';
+
+    $previous = error_reporting();
+    error_reporting($previous & ~E_DEPRECATED);
+    try {
+      $message = $this->memoBuilder->buildMessage($post);
+      $service = $this->buildService($authorityCvr, $testMode);
+      $response = $service->kombiPostAfsend($transactionId, SF1601::TYPE_DIGITAL_POST, $message);
+      $status = $response->getStatusCode();
+      // getContent(FALSE) never throws on a 4xx/5xx, so we can inspect the body.
+      $body = $response->getContent(FALSE);
+      $result = $this->mapResponse($status, $body, $transactionId);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Live Digital Post send failed: tx=@tx @msg', [
+        '@tx' => $transactionId,
+        '@msg' => $e->getMessage(),
+      ]);
+      $result = Result::failure(
+        $transactionId,
+        Result::REASON_TRANSPORT,
+        'Live send failed: ' . $e->getMessage(),
+      );
+    }
+    finally {
+      error_reporting($previous);
+    }
+
+    $this->recordAttempt($post, $result);
+    return $result;
+  }
+
+  /**
+   * Maps a Serviceplatformen HTTP status + body onto a Result.
+   *
+   * Pure and side-effect-free so it can be unit-tested directly. A 2xx is
+   * pending (accepted, not delivered); a 4xx is a permanent validation/recipient
+   * problem; a 5xx (or anything else) is a transient transport failure.
+   *
+   * @param int $status
+   *   The HTTP status code from kombiPostAfsend().
+   * @param string $body
+   *   The response body (for the audit trail; may be empty).
+   * @param string $transactionId
+   *   The transaction id.
+   *
+   * @return \Drupal\aabenforms_digital_post\DigitalPost\Result
+   *   The mapped result.
+   */
+  public function mapResponse(int $status, string $body, string $transactionId): Result {
+    if ($status >= 200 && $status < 300) {
+      return Result::pending($transactionId, sprintf('Accepted by Serviceplatformen (HTTP %d).', $status), $body);
+    }
+    if ($status >= 400 && $status < 500) {
+      return Result::failure(
+        $transactionId,
+        Result::REASON_VALIDATION,
+        sprintf('Serviceplatformen rejected the message (HTTP %d).', $status),
+        $body,
+      );
+    }
+    return Result::failure(
+      $transactionId,
+      Result::REASON_TRANSPORT,
+      sprintf('Serviceplatformen transport error (HTTP %d).', $status),
+      $body,
+    );
+  }
+
+  /**
+   * Constructs the vendor SF1601 service.
+   *
+   * Encapsulates ALL vendor construction - locating the certificate and
+   * wrapping it in the vendor adapter - so the injected $serviceFactory (tests
+   * only) can supply a stubbed service without any real certificate.
+   *
+   * @param string $authorityCvr
+   *   The sending authority CVR.
+   * @param bool $testMode
+   *   TRUE for the exttest endpoint, FALSE for production.
+   *
+   * @return \ItkDev\Serviceplatformen\Service\SF1601\SF1601
+   *   The configured service.
+   */
+  private function buildService(string $authorityCvr, bool $testMode): SF1601 {
+    if ($this->serviceFactory !== NULL) {
+      return ($this->serviceFactory)($authorityCvr, $testMode);
+    }
+    $adapter = new VendorCertificateLocatorAdapter($this->certificateLocator->locate());
+    return new SF1601([
+      'authority_cvr' => $authorityCvr,
+      'certificate_locator' => $adapter,
+      'test_mode' => $testMode,
+    ]);
+  }
+
+  /**
+   * Returns the current recorded status for a transaction id, or NULL.
+   */
+  private function existingStatus(string $transactionId): ?string {
+    try {
+      $status = $this->database->select('aabenforms_digital_post_log', 'l')
+        ->fields('l', ['status'])
+        ->condition('transaction_id', $transactionId)
+        ->range(0, 1)
+        ->execute()
+        ->fetchField();
+      return $status === FALSE ? NULL : (string) $status;
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Writes the attempt to the audit log (idempotent on transaction_id).
+   */
+  private function recordAttempt(DigitalPost $post, Result $result): void {
+    $payload = [
+      'recipient' => [
+        'type' => $post->recipient->type,
+        'identifier_hash' => $post->recipient->identifierHash(),
+      ],
+      'sender' => ['cvr' => $post->sender->cvr, 'name' => $post->sender->name],
+      'subject' => $post->subject,
+      'type' => $post->type,
+      'meta' => $post->meta,
+    ];
+    try {
+      $this->database->insert('aabenforms_digital_post_log')
+        ->fields([
+          'transaction_id' => $result->transactionId,
+          'mode' => $this->modeLabel(),
+          'recipient_type' => $post->recipient->type,
+          'recipient_identifier_hash' => $post->recipient->identifierHash(),
+          'sender_cvr' => $post->sender->cvr,
+          'subject' => mb_substr($post->subject, 0, 255),
+          'status' => $result->status,
+          'reason_code' => $result->reasonCode,
+          'payload' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}',
+          'response' => $result->rawResponse !== NULL ? mb_substr($result->rawResponse, 0, 65535) : NULL,
+          'created' => $this->time->getRequestTime(),
+        ])
+        ->execute();
+      Cache::invalidateTags(['aabenforms_dashboard:activity']);
+    }
+    catch (\Throwable $e) {
+      // A duplicate transaction_id (unique key) means the attempt is already
+      // recorded - safe to ignore. Any other write error is logged, never
+      // surfaced: the send itself already happened.
+      $this->logger->warning('Live Digital Post log write skipped for tx=@tx: @msg', [
+        '@tx' => $result->transactionId,
+        '@msg' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function modeLabel(): string {
+    $mode = (string) $this->configFactory->get('aabenforms_digital_post.settings')->get('test_mode');
+    return $mode === 'live' ? 'live' : 'live_test';
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Kernel/LiveSf1601ClientTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Kernel/LiveSf1601ClientTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Kernel;
+
+use Drupal\aabenforms_digital_post\Certificate\CertificateLocatorInterface;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\aabenforms_digital_post\TestMode\LiveSf1601Client;
+use Drupal\KernelTests\KernelTestBase;
+use ItkDev\Serviceplatformen\Service\SF1601\SF1601;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Tests the live SF1601 client's result mapping, logging and idempotency.
+ *
+ * The vendor SF1601 service is stubbed (no cert, no network) so the test
+ * exercises the client's own logic: a 2xx is pending (never success), errors
+ * fail with typed reasons, and a re-send with the same transaction id is a
+ * no-op.
+ *
+ * @group aabenforms_digital_post
+ */
+class LiveSf1601ClientTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'domain_access',
+    'aabenforms_core',
+    'aabenforms_digital_post',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['aabenforms_digital_post']);
+    $this->installSchema('aabenforms_digital_post', ['aabenforms_digital_post_log']);
+    $this->config('aabenforms_digital_post.settings')
+      ->set('test_mode', 'live_test')
+      ->set('sender_cvr', '12345678')
+      ->save();
+  }
+
+  /**
+   * A 2xx response yields a pending Result and a pending log row - not success.
+   */
+  public function testAcceptedIsPendingNeverSuccess(): void {
+    $client = $this->clientReturning($this->responseWithStatus(200, '<receipt>ok</receipt>'));
+    $result = $client->send($this->samplePost(), 'tx-accepted');
+
+    $this->assertTrue($result->isPending());
+    $this->assertFalse($result->isSuccess());
+    $this->assertSame('pending', $this->logStatus('tx-accepted'));
+  }
+
+  /**
+   * A 5xx response is a transient transport failure.
+   */
+  public function testServerErrorIsTransportFailure(): void {
+    $client = $this->clientReturning($this->responseWithStatus(503, 'busy'));
+    $result = $client->send($this->samplePost(), 'tx-5xx');
+
+    $this->assertFalse($result->isPending());
+    $this->assertSame(Result::FAILURE, $result->status);
+    $this->assertSame(Result::REASON_TRANSPORT, $result->reasonCode);
+    $this->assertSame('failure', $this->logStatus('tx-5xx'));
+  }
+
+  /**
+   * A 4xx response is a permanent validation failure.
+   */
+  public function testClientErrorIsValidationFailure(): void {
+    $client = $this->clientReturning($this->responseWithStatus(400, 'bad memo'));
+    $result = $client->send($this->samplePost(), 'tx-4xx');
+
+    $this->assertSame(Result::REASON_VALIDATION, $result->reasonCode);
+  }
+
+  /**
+   * A thrown transport exception never escapes - it becomes a failure Result.
+   */
+  public function testExceptionBecomesFailure(): void {
+    $service = $this->createMock(SF1601::class);
+    $service->method('kombiPostAfsend')->willThrowException(new \RuntimeException('boom'));
+    $client = $this->client($service);
+
+    $result = $client->send($this->samplePost(), 'tx-throw');
+    $this->assertSame(Result::FAILURE, $result->status);
+    $this->assertSame(Result::REASON_TRANSPORT, $result->reasonCode);
+  }
+
+  /**
+   * Re-sending the same transaction id does not re-post and writes one row.
+   */
+  public function testIdempotentReplay(): void {
+    $client = $this->clientReturning($this->responseWithStatus(200, 'ok'));
+    $client->send($this->samplePost(), 'tx-dupe');
+    $second = $client->send($this->samplePost(), 'tx-dupe');
+
+    $this->assertTrue($second->isPending());
+    $count = (int) $this->container->get('database')
+      ->select('aabenforms_digital_post_log', 'l')
+      ->condition('transaction_id', 'tx-dupe')
+      ->countQuery()->execute()->fetchField();
+    $this->assertSame(1, $count);
+  }
+
+  /**
+   * Builds a client whose stubbed SF1601 returns the given response.
+   */
+  private function clientReturning(ResponseInterface $response): LiveSf1601Client {
+    $service = $this->createMock(SF1601::class);
+    $service->method('kombiPostAfsend')->willReturn($response);
+    return $this->client($service);
+  }
+
+  /**
+   * Builds the client wired to the container with a stubbed service factory.
+   */
+  private function client(SF1601 $service): LiveSf1601Client {
+    return new LiveSf1601Client(
+      $this->container->get('database'),
+      $this->container->get('datetime.time'),
+      $this->container->get('logger.channel.aabenforms_digital_post'),
+      $this->container->get('aabenforms_digital_post.memo_builder'),
+      $this->container->get('config.factory'),
+      $this->createMock(CertificateLocatorInterface::class),
+      static fn (string $cvr, bool $testMode): SF1601 => $service,
+    );
+  }
+
+  /**
+   * A ResponseInterface stub with the given status and body.
+   */
+  private function responseWithStatus(int $status, string $body): ResponseInterface {
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getStatusCode')->willReturn($status);
+    $response->method('getContent')->willReturn($body);
+    return $response;
+  }
+
+  /**
+   * The recorded status for a transaction id, or NULL.
+   */
+  private function logStatus(string $transactionId): ?string {
+    $value = $this->container->get('database')
+      ->select('aabenforms_digital_post_log', 'l')
+      ->fields('l', ['status'])
+      ->condition('transaction_id', $transactionId)
+      ->execute()->fetchField();
+    return $value === FALSE ? NULL : (string) $value;
+  }
+
+  /**
+   * A minimal valid DigitalPost.
+   */
+  private function samplePost(): DigitalPost {
+    return new DigitalPost(
+      Recipient::cpr('2512489996'),
+      new Sender('12345678', 'Test Kommune'),
+      'Afgørelse i din sag',
+      '<p>Kommunen har truffet afgørelse.</p>',
+    );
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Certificate/VendorCertificateLocatorAdapterTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Certificate/VendorCertificateLocatorAdapterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\Certificate;
+
+use Drupal\aabenforms_digital_post\Certificate\Certificate;
+use Drupal\aabenforms_digital_post\Certificate\VendorCertificateLocatorAdapter;
+use Drupal\Tests\UnitTestCase;
+use ItkDev\Serviceplatformen\Certificate\Exception\CertificateLocatorException;
+
+/**
+ * Tests the module-DTO -> vendor-locator certificate adapter.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\Certificate\VendorCertificateLocatorAdapter
+ * @group aabenforms_digital_post
+ */
+class VendorCertificateLocatorAdapterTest extends UnitTestCase {
+
+  /**
+   * The self-signed PKCS#12 bytes generated for the test.
+   */
+  protected string $pkcs12;
+
+  /**
+   * The passphrase protecting the test PKCS#12.
+   */
+  protected string $passphrase = 'test-pass';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $pkey = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    $this->assertNotFalse($pkey, 'Could not generate a test key.');
+    $csr = openssl_csr_new(['commonName' => 'aabenforms-test'], $pkey);
+    $x509 = openssl_csr_sign($csr, NULL, $pkey, 1);
+    $bytes = '';
+    openssl_pkcs12_export($x509, $bytes, $pkey, $this->passphrase);
+    $this->pkcs12 = $bytes;
+  }
+
+  /**
+   * The store from openssl_pkcs12_read (cert + pkey) is returned from bytes.
+   *
+   * @covers ::getCertificates
+   * @covers ::getCertificate
+   */
+  public function testGetCertificatesFromBytes(): void {
+    $certificate = new Certificate('', $this->passphrase, 'key', $this->pkcs12);
+    $adapter = new VendorCertificateLocatorAdapter($certificate);
+
+    $store = $adapter->getCertificates();
+    $this->assertArrayHasKey('cert', $store);
+    $this->assertArrayHasKey('pkey', $store);
+    $this->assertStringContainsString('BEGIN CERTIFICATE', $store['cert']);
+    $this->assertStringContainsString('BEGIN CERTIFICATE', $adapter->getCertificate());
+  }
+
+  /**
+   * A file-backed Certificate is read from disk when it carries no bytes.
+   *
+   * @covers ::getCertificates
+   */
+  public function testGetCertificatesFromFile(): void {
+    $path = tempnam(sys_get_temp_dir(), 'af-p12-');
+    file_put_contents($path, $this->pkcs12);
+    try {
+      $certificate = new Certificate($path, $this->passphrase, 'file');
+      $adapter = new VendorCertificateLocatorAdapter($certificate);
+      $store = $adapter->getCertificates();
+      $this->assertArrayHasKey('pkey', $store);
+    }
+    finally {
+      @unlink($path);
+    }
+  }
+
+  /**
+   * A wrong passphrase surfaces as a CertificateLocatorException.
+   *
+   * @covers ::getCertificates
+   */
+  public function testWrongPassphraseThrows(): void {
+    $certificate = new Certificate('', 'wrong-pass', 'key', $this->pkcs12);
+    $adapter = new VendorCertificateLocatorAdapter($certificate);
+    $this->expectException(CertificateLocatorException::class);
+    $adapter->getCertificates();
+  }
+
+  /**
+   * A bytes-only certificate refuses getAbsolutePathToCertificate().
+   *
+   * @covers ::getAbsolutePathToCertificate
+   */
+  public function testInMemoryCertHasNoPath(): void {
+    $adapter = new VendorCertificateLocatorAdapter(new Certificate('', $this->passphrase, 'key', $this->pkcs12));
+    $this->expectException(CertificateLocatorException::class);
+    $adapter->getAbsolutePathToCertificate();
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/DigitalPost/ResultTest.php
@@ -51,6 +51,19 @@ class ResultTest extends UnitTestCase {
   }
 
   /**
+   * Pending() is accepted-but-not-delivered: pending, and NOT a success.
+   */
+  public function testPendingFactory(): void {
+    $r = Result::pending('tx-p', 'accepted (HTTP 200)', '<receipt/>');
+    $this->assertTrue($r->isPending());
+    $this->assertFalse($r->isSuccess());
+    $this->assertSame(Result::PENDING, $r->status);
+    $this->assertSame('tx-p', $r->transactionId);
+    $this->assertNull($r->reasonCode);
+    $this->assertSame('<receipt/>', $r->rawResponse);
+  }
+
+  /**
    * AuditContext() exposes the four log-safe fields and nothing else.
    */
   public function testAuditContextShape(): void {


### PR DESCRIPTION
Turns the flagship Digital Post integration from mock to actually-delivered, behind config and fail-safe. Part of the pilot spine (Track 3). Stacked on #178.

## What this adds
- **LiveSf1601Client** (`implements Sf1601ClientInterface`, never throws): reuses `MemoBuilder::buildMessage()` and calls itk-dev `SF1601::kombiPostAfsend()`. **The crucial correctness point:** a 2xx from Serviceplatformen means the message was *accepted*, not delivered - so it returns `Result::pending()` and writes a `pending` log row, **never** `success`. The real delivered/failed outcome arrives asynchronously (Track 3b). Idempotent via the `transaction_id` unique key + a pre-send lookup (no double-sent letters).
- **`Result`** gains `PENDING` + `Result::pending()` + `isPending()`; `isSuccess()` stays false for pending.
- **Cert bridge:** `VendorCertificateLocatorAdapter` maps the module's `Certificate` DTO to itk-dev's `CertificateLocatorInterface` via `openssl_pkcs12_read`; `KeyCertificateLocator` sources the PKCS#12 from a `drupal:key` entry and is wired into the `CertificateLocatorFactory` `key` arm; `Certificate` gains optional in-memory PKCS#12 bytes.
- **Wiring:** the factory's throwing `live_test`/`live` arm now returns the live client (`test_mode` selects exttest vs prod). Config adds `authority_cvr` (falls back to `sender_cvr`) and `cert_key`.

## Testing
- `VendorCertificateLocatorAdapterTest` (self-signed `.p12` generated in-test).
- `ResultTest` pending coverage.
- `LiveSf1601ClientTest` (kernel, SF1601 stubbed - no cert, no network): 2xx -> pending **never success**, 4xx -> validation, 5xx -> transport, thrown -> failure, idempotent replay writes one row.
- Full `aabenforms_digital_post` suite: 63 green. Whole `web/modules/custom` tree phcs clean.

## Not in scope (enrollment-gated, ops)
A real send needs a FOCES3/OCES3 systemcertifikat loaded into the `key` module and a kommune-approved serviceaftale + compliancetest on Serviceplatformen exttest. The demo (`fake_db`) is untouched. Track 3b adds the asynchronous delivery receipt.