### PR TITLE
Track 3b: Beskedfordeler async delivery receipt (aabenforms_digital_post_beskedfordeler)

### DIFF
--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.info.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.info.yml
@@ -1,0 +1,9 @@
+name: 'AabenForms Digital Post - Beskedfordeler receipts'
+type: module
+description: 'Asynchronous SF1461/Beskedfordeler delivery receipts: reconciles a pending Digital Post send to delivered/failed on its case. Optional - the core send never depends on it.'
+package: 'ÅbenForms'
+core_version_requirement: ^11
+dependencies:
+  - aabenforms_digital_post:aabenforms_digital_post
+  - aabenforms_case:aabenforms_case
+  - eca:eca

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.install
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.install
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @file
+ * Install/update hooks for the Digital Post Beskedfordeler receipt submodule.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Database\Database;
+
+/**
+ * Installs the delivery-tracking base fields on the case entity.
+ *
+ * Base fields contributed to another module's entity type are not always
+ * created automatically on a config-import-driven enable, so install them
+ * explicitly and idempotently. Mirrors aabenforms_esdh.
+ */
+function _aabenforms_digital_post_beskedfordeler_install_case_fields(): void {
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type = \Drupal::entityTypeManager()->getDefinition('aabenforms_case');
+  $fields = aabenforms_digital_post_beskedfordeler_entity_base_field_info($entity_type);
+  foreach ($fields as $name => $definition) {
+    if ($update_manager->getFieldStorageDefinition($name, 'aabenforms_case') === NULL) {
+      $update_manager->installFieldStorageDefinition($name, 'aabenforms_case', 'aabenforms_digital_post_beskedfordeler', $definition);
+    }
+  }
+}
+
+/**
+ * Adds the receipt columns to the Digital Post log table (idempotent).
+ */
+function _aabenforms_digital_post_beskedfordeler_install_log_columns(): void {
+  $schema = Database::getConnection()->schema();
+  $table = 'aabenforms_digital_post_log';
+  $columns = [
+    'receipt_status' => [
+      'type' => 'varchar',
+      'length' => 16,
+      'not null' => FALSE,
+      'description' => 'Asynchronous delivery outcome: pending, delivered, failed.',
+    ],
+    'delivered_at' => [
+      'type' => 'int',
+      'unsigned' => TRUE,
+      'not null' => FALSE,
+      'description' => 'Unix timestamp the receipt confirmed delivery.',
+    ],
+    'receipt_reason' => [
+      'type' => 'varchar',
+      'length' => 255,
+      'not null' => FALSE,
+      'description' => 'Human-readable receipt reason (transient/permanent failure detail).',
+    ],
+  ];
+  foreach ($columns as $name => $spec) {
+    if (!$schema->fieldExists($table, $name)) {
+      $schema->addField($table, $name, $spec);
+    }
+  }
+}
+
+/**
+ * Implements hook_install().
+ */
+function aabenforms_digital_post_beskedfordeler_install(): void {
+  _aabenforms_digital_post_beskedfordeler_install_case_fields();
+  _aabenforms_digital_post_beskedfordeler_install_log_columns();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function aabenforms_digital_post_beskedfordeler_uninstall(): void {
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  foreach (['digital_post_tx', 'digital_post_receipt_status', 'digital_post_delivered_at'] as $name) {
+    $definition = $update_manager->getFieldStorageDefinition($name, 'aabenforms_case');
+    if ($definition !== NULL) {
+      $update_manager->uninstallFieldStorageDefinition($definition);
+    }
+  }
+}
+
+/**
+ * Ensures fields + columns exist on sites enabled before the install hook.
+ */
+function aabenforms_digital_post_beskedfordeler_update_10001(): void {
+  _aabenforms_digital_post_beskedfordeler_install_case_fields();
+  _aabenforms_digital_post_beskedfordeler_install_log_columns();
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.module
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.module
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Hooks for the Digital Post Beskedfordeler receipt submodule.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Adds the Digital Post delivery-tracking fields to the case entity without
+ * coupling aabenforms_case to Digital Post - delivery stays an optional add-on.
+ * Delivery is orthogonal to the case lifecycle status (a receipt never drives a
+ * modtaget/oplyst transition), so it lives on its own queryable, revisionable
+ * fields. digital_post_tx is written at send time and is what an inbound
+ * asynchronous receipt correlates on. Mirrors the esdh_ref pattern.
+ */
+function aabenforms_digital_post_beskedfordeler_entity_base_field_info(EntityTypeInterface $entity_type): array {
+  if ($entity_type->id() !== 'aabenforms_case') {
+    return [];
+  }
+
+  $fields = [];
+  $fields['digital_post_tx'] = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('Digital Post transaction id'))
+    ->setDescription(new TranslatableMarkup('The SF1601 send transaction id, correlated against an asynchronous delivery receipt.'))
+    ->setRevisionable(TRUE)
+    ->setSetting('max_length', 64)
+    ->setDisplayConfigurable('view', TRUE);
+
+  $fields['digital_post_receipt_status'] = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('Digital Post delivery status'))
+    ->setDescription(new TranslatableMarkup('pending, delivered or failed - reconciled from the Beskedfordeler receipt.'))
+    ->setRevisionable(TRUE)
+    ->setSetting('max_length', 16)
+    ->setDisplayConfigurable('view', TRUE);
+
+  $fields['digital_post_delivered_at'] = BaseFieldDefinition::create('timestamp')
+    ->setLabel(new TranslatableMarkup('Digital Post delivered at'))
+    ->setDescription(new TranslatableMarkup('When the delivery receipt confirmed delivery.'))
+    ->setRevisionable(TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  return $fields;
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.routing.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.routing.yml
@@ -1,0 +1,10 @@
+aabenforms_digital_post_beskedfordeler.receipt:
+  path: '/api/digital-post/receipt'
+  defaults:
+    _controller: '\Drupal\aabenforms_digital_post_beskedfordeler\Controller\ReceiptController::receive'
+  methods: [POST]
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'
+    _csrf_token: 'FALSE'

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.services.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/aabenforms_digital_post_beskedfordeler.services.yml
@@ -1,0 +1,13 @@
+services:
+  logger.channel.aabenforms_digital_post_beskedfordeler:
+    parent: logger.channel_base
+    arguments: ['aabenforms_digital_post_beskedfordeler']
+
+  aabenforms_digital_post_beskedfordeler.receipt_handler:
+    class: Drupal\aabenforms_digital_post_beskedfordeler\Service\DigitalPostReceiptHandler
+    arguments:
+      - '@database'
+      - '@entity_type.manager'
+      - '@datetime.time'
+      - '@aabenforms_core.audit_logger'
+      - '@logger.channel.aabenforms_digital_post_beskedfordeler'

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/config/install/aabenforms_digital_post_beskedfordeler.settings.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/config/install/aabenforms_digital_post_beskedfordeler.settings.yml
@@ -1,0 +1,6 @@
+# Beskedfordeler receipt intake settings.
+#
+# The receipt endpoint (/api/digital-post/receipt) is open, so it is gated by a
+# shared secret held in a drupal:key entry named here. Empty means the endpoint
+# rejects everything (fail-closed) until an operator configures it.
+receipt_secret_key: ''

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/config/schema/aabenforms_digital_post_beskedfordeler.schema.yml
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/config/schema/aabenforms_digital_post_beskedfordeler.schema.yml
@@ -1,0 +1,7 @@
+aabenforms_digital_post_beskedfordeler.settings:
+  type: config_object
+  label: 'Beskedfordeler receipt settings'
+  mapping:
+    receipt_secret_key:
+      type: string
+      label: 'Key module entry holding the receipt shared secret'

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/src/Controller/ReceiptController.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/src/Controller/ReceiptController.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post_beskedfordeler\Controller;
+
+use Drupal\aabenforms_digital_post_beskedfordeler\Service\DigitalPostReceiptHandler;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Flood\FloodInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Receives asynchronous Beskedfordeler delivery receipts.
+ *
+ * The route is open (_access: 'TRUE') because the caller is an external system,
+ * so this controller carries its own hardening, mirroring the webform submit
+ * API: a shared-secret check (fail-closed - no secret configured means no
+ * intake), flood control, and strict body validation. A valid receipt is handed
+ * to DigitalPostReceiptHandler, which correlates it by transaction id.
+ */
+class ReceiptController extends ControllerBase {
+
+  /**
+   * The receipt handler.
+   *
+   * @var \Drupal\aabenforms_digital_post_beskedfordeler\Service\DigitalPostReceiptHandler
+   */
+  protected DigitalPostReceiptHandler $receiptHandler;
+
+  /**
+   * The key repository.
+   *
+   * @var \Drupal\key\KeyRepositoryInterface
+   */
+  protected KeyRepositoryInterface $keyRepository;
+
+  /**
+   * The flood service.
+   *
+   * @var \Drupal\Core\Flood\FloodInterface
+   */
+  protected FloodInterface $flood;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->receiptHandler = $container->get('aabenforms_digital_post_beskedfordeler.receipt_handler');
+    $instance->keyRepository = $container->get('key.repository');
+    $instance->flood = $container->get('flood');
+    return $instance;
+  }
+
+  /**
+   * Handles a POSTed delivery receipt.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The intake result.
+   */
+  public function receive(Request $request): JsonResponse {
+    // Shared-secret gate, fail-closed: an unconfigured secret rejects everything.
+    if (!$this->secretMatches($request)) {
+      return new JsonResponse(['error' => 'Forbidden'], 403);
+    }
+
+    // Flood control: a rolling one-minute window per client IP.
+    $floodId = $request->getClientIp() ?? 'unknown';
+    if (!$this->flood->isAllowed('aabenforms_digital_post_beskedfordeler.receipt', 60, 60, $floodId)) {
+      return new JsonResponse(['error' => 'Too many requests'], 429);
+    }
+    $this->flood->register('aabenforms_digital_post_beskedfordeler.receipt', 60, $floodId);
+
+    $data = json_decode((string) $request->getContent(), TRUE);
+    if (!is_array($data) || !isset($data['transaction_id'], $data['status'])) {
+      return new JsonResponse(['error' => 'Invalid receipt payload'], 400);
+    }
+    $transactionId = (string) $data['transaction_id'];
+    $status = (string) $data['status'];
+    if (!in_array($status, [DigitalPostReceiptHandler::OUTCOME_DELIVERED, DigitalPostReceiptHandler::OUTCOME_FAILED], TRUE)) {
+      return new JsonResponse(['error' => 'Unknown status'], 400);
+    }
+    $transient = (bool) ($data['transient'] ?? FALSE);
+    $reason = (string) ($data['reason'] ?? '');
+
+    $state = $this->receiptHandler->handle($transactionId, $status, $transient, $reason);
+    if ($state === DigitalPostReceiptHandler::STATE_UNKNOWN) {
+      return new JsonResponse(['error' => 'Unknown transaction'], 404);
+    }
+    return new JsonResponse(['state' => $state], 200);
+  }
+
+  /**
+   * Verifies the shared secret header against the configured key entry.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return bool
+   *   TRUE when the secret is configured and matches (constant-time).
+   */
+  protected function secretMatches(Request $request): bool {
+    $keyName = (string) $this->config('aabenforms_digital_post_beskedfordeler.settings')->get('receipt_secret_key');
+    if ($keyName === '') {
+      return FALSE;
+    }
+    $key = $this->keyRepository->getKey($keyName);
+    $expected = $key ? (string) $key->getKeyValue() : '';
+    if ($expected === '') {
+      return FALSE;
+    }
+    $provided = (string) $request->headers->get('X-Beskedfordeler-Secret', '');
+    return $provided !== '' && hash_equals($expected, $provided);
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/src/Plugin/Action/RecordDigitalPostRefAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/src/Plugin/Action/RecordDigitalPostRefAction.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post_beskedfordeler\Plugin\Action;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_case\Plugin\Action\CaseActionBase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+
+/**
+ * ECA Action: record the Digital Post transaction id on the case.
+ *
+ * Called by a flow right after aabenforms_digital_post_send so the pending
+ * send becomes resolvable: it stamps the send transaction id and a `pending`
+ * delivery status onto the case's queryable digital_post_tx field. When the
+ * asynchronous Beskedfordeler receipt later arrives, DigitalPostReceiptHandler
+ * finds the case by that id and finalises the outcome. Idempotent - a re-fired
+ * flow does not overwrite an existing reference.
+ */
+#[Action(
+  id: 'aabenforms_case_record_digital_post',
+  label: new TranslatableMarkup('Record Digital Post reference on case'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Stamps the Digital Post transaction id + pending delivery status onto the case for later receipt reconciliation.'),
+  version_introduced: '1.0.0',
+)]
+class RecordDigitalPostRefAction extends CaseActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'case_id_token' => 'case_id',
+      'transaction_id_token' => '[digital_post_result:transaction_id]',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['case_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Case id token'),
+      '#description' => $this->t('Token holding the case id, e.g. case_id or [case_id].'),
+      '#default_value' => $this->configuration['case_id_token'],
+      '#required' => TRUE,
+    ];
+    $form['transaction_id_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Transaction id token'),
+      '#description' => $this->t('Token holding the send transaction id, e.g. [digital_post_result:transaction_id].'),
+      '#default_value' => $this->configuration['transaction_id_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
+    $this->configuration['transaction_id_token'] = $form_state->getValue('transaction_id_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    try {
+      $caseId = $this->getTokenValue((string) ($this->configuration['case_id_token'] ?? 'case_id'), '');
+      $transactionId = $this->getTokenValue((string) ($this->configuration['transaction_id_token'] ?? ''), '');
+      if ($caseId === '' || $transactionId === '') {
+        $this->recordStep('Digital Post-reference', 'Mangler sags-id eller transaktions-id.', 'failed');
+        return;
+      }
+
+      $case = $this->entityTypeManager->getStorage('aabenforms_case')->load($caseId);
+      if (!$case instanceof AabenformsCase) {
+        $this->recordStep('Digital Post-reference', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
+        return;
+      }
+
+      // Idempotent: never overwrite an already-recorded reference.
+      if ((string) $case->get('digital_post_tx')->value !== '') {
+        $this->recordStep('Digital Post-reference', sprintf('Sag #%s har allerede en Digital Post-reference.', $caseId));
+        return;
+      }
+
+      $case->set('digital_post_tx', $transactionId);
+      $case->set('digital_post_receipt_status', 'pending');
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage('Digital Post afsendt (afventer kvittering).');
+      $case->setRevisionCreationTime($this->time->getRequestTime());
+      $case->setRevisionUserId((int) $this->currentUser->id());
+      $case->save();
+
+      $this->recordStep('Digital Post-reference', sprintf('Sag #%s knyttet til Digital Post-transaktion.', $caseId));
+    }
+    catch (\Throwable $e) {
+      $this->handleError($e, 'Record Digital Post reference');
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/src/Service/DigitalPostReceiptHandler.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/src/Service/DigitalPostReceiptHandler.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post_beskedfordeler\Service;
+
+use Drupal\aabenforms_core\Service\AuditLogger;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Reconciles an asynchronous Beskedfordeler receipt to its send and case.
+ *
+ * A live SF1601 send returns `pending`: accepted, not delivered. The real
+ * outcome arrives later as an SF1461/Beskedfordeler receipt carrying the send
+ * transaction id. This handler correlates that receipt to the log row and to
+ * the case (via the queryable digital_post_tx field) and records the outcome.
+ *
+ * Honours the "never act on a transient failure" contract: a transient failure
+ * (timeout / 5xx at the carrier) leaves both the log and the case `pending` so
+ * the carrier's retry can still succeed; only a permanent outcome
+ * (delivered / permanent failure) finalises the state with an audited case
+ * revision. Delivery is orthogonal to the case lifecycle, so it writes the
+ * delivery field, never an allowedTransitions() status move.
+ */
+class DigitalPostReceiptHandler {
+
+  public const OUTCOME_DELIVERED = 'delivered';
+  public const OUTCOME_FAILED = 'failed';
+
+  /**
+   * The reconciled states written to the log/case.
+   */
+  public const STATE_DELIVERED = 'delivered';
+  public const STATE_FAILED = 'failed';
+  public const STATE_PENDING = 'pending';
+  public const STATE_UNKNOWN = 'unknown';
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly TimeInterface $time,
+    private readonly AuditLogger $auditLogger,
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
+  /**
+   * Reconciles a receipt for a transaction id.
+   *
+   * @param string $transactionId
+   *   The send transaction id the receipt refers to.
+   * @param string $outcome
+   *   OUTCOME_DELIVERED or OUTCOME_FAILED.
+   * @param bool $transient
+   *   For a failure, TRUE when it is retry-able (the carrier may still deliver).
+   * @param string $reason
+   *   A short human-readable reason for the audit trail.
+   *
+   * @return string
+   *   The reconciled state (delivered|failed|pending|unknown).
+   */
+  public function handle(string $transactionId, string $outcome, bool $transient = FALSE, string $reason = ''): string {
+    if ($transactionId === '') {
+      return self::STATE_UNKNOWN;
+    }
+
+    $state = $this->resolveState($outcome, $transient);
+    $logMatched = $this->updateLogRow($transactionId, $state, $reason);
+    $caseMatched = $this->updateCase($transactionId, $state, $reason);
+
+    if (!$logMatched && !$caseMatched) {
+      $this->logger->warning('Beskedfordeler receipt for unknown transaction @tx (ignored).', ['@tx' => $transactionId]);
+      return self::STATE_UNKNOWN;
+    }
+    return $state;
+  }
+
+  /**
+   * Maps an outcome + transient flag to the state to persist.
+   */
+  private function resolveState(string $outcome, bool $transient): string {
+    if ($outcome === self::OUTCOME_DELIVERED) {
+      return self::STATE_DELIVERED;
+    }
+    // A transient failure is NOT final - keep it pending for the carrier retry.
+    return $transient ? self::STATE_PENDING : self::STATE_FAILED;
+  }
+
+  /**
+   * Writes the receipt columns onto the matching log row.
+   *
+   * @return bool
+   *   TRUE when a log row matched.
+   */
+  private function updateLogRow(string $transactionId, string $state, string $reason): bool {
+    try {
+      $fields = [
+        'receipt_status' => $state,
+        'receipt_reason' => $reason !== '' ? mb_substr($reason, 0, 255) : NULL,
+      ];
+      if ($state === self::STATE_DELIVERED) {
+        $fields['delivered_at'] = $this->time->getRequestTime();
+      }
+      $updated = $this->database->update('aabenforms_digital_post_log')
+        ->fields($fields)
+        ->condition('transaction_id', $transactionId)
+        ->execute();
+      return (int) $updated > 0;
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Beskedfordeler log update failed for @tx: @msg', [
+        '@tx' => $transactionId,
+        '@msg' => $e->getMessage(),
+      ]);
+      return FALSE;
+    }
+  }
+
+  /**
+   * Writes the delivery outcome onto the correlated case (audited revision).
+   *
+   * A transient (still-pending) outcome makes no case change - the case stays
+   * pending for the retry.
+   *
+   * @return bool
+   *   TRUE when a case matched.
+   */
+  private function updateCase(string $transactionId, string $state, string $reason): bool {
+    try {
+      $storage = $this->entityTypeManager->getStorage('aabenforms_case');
+      $ids = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('digital_post_tx', $transactionId)
+        ->range(0, 1)
+        ->execute();
+      if ($ids === []) {
+        return FALSE;
+      }
+      $case = $storage->load((int) reset($ids));
+      if ($case === NULL) {
+        return FALSE;
+      }
+
+      // Transient failure: leave the case pending (no finalisation, no revision).
+      if ($state === self::STATE_PENDING) {
+        return TRUE;
+      }
+
+      $case->set('digital_post_receipt_status', $state);
+      if ($state === self::STATE_DELIVERED) {
+        $case->set('digital_post_delivered_at', $this->time->getRequestTime());
+      }
+      $case->setNewRevision(TRUE);
+      $case->setRevisionLogMessage(sprintf('Digital Post: %s%s', $state, $reason !== '' ? ' (' . $reason . ')' : ''));
+      $case->setRevisionCreationTime($this->time->getRequestTime());
+      $case->save();
+
+      $this->auditLogger->log(
+        'digital_post_receipt',
+        (string) $case->id(),
+        $state,
+        $state === self::STATE_DELIVERED ? 'success' : 'failure',
+        ['transaction_id' => $transactionId],
+      );
+      return TRUE;
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Beskedfordeler case update failed for @tx: @msg', [
+        '@tx' => $transactionId,
+        '@msg' => $e->getMessage(),
+      ]);
+      return FALSE;
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/tests/src/Kernel/DigitalPostReceiptHandlerTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/tests/src/Kernel/DigitalPostReceiptHandlerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post_beskedfordeler\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_digital_post_beskedfordeler\Service\DigitalPostReceiptHandler;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests asynchronous receipt reconciliation onto the log row and the case.
+ *
+ * @group aabenforms_digital_post
+ */
+class DigitalPostReceiptHandlerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'node',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'domain_access',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+    'aabenforms_digital_post',
+    'aabenforms_digital_post_beskedfordeler',
+  ];
+
+  /**
+   * The handler under test.
+   */
+  protected DigitalPostReceiptHandler $handler;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_digital_post', ['aabenforms_digital_post_log']);
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log', 'aabenforms_trace']);
+    // The submodule's hook_install adds the receipt columns; run it explicitly.
+    \Drupal::moduleHandler()->loadInclude('aabenforms_digital_post_beskedfordeler', 'install');
+    _aabenforms_digital_post_beskedfordeler_install_log_columns();
+
+    $this->handler = $this->container->get('aabenforms_digital_post_beskedfordeler.receipt_handler');
+  }
+
+  /**
+   * A delivered receipt finalises the log row and the case (audited revision).
+   */
+  public function testDeliveredFinalisesCase(): void {
+    $case = $this->seed('tx-delivered');
+    $vidBefore = $case->getRevisionId();
+
+    $state = $this->handler->handle('tx-delivered', DigitalPostReceiptHandler::OUTCOME_DELIVERED, FALSE, 'e-Boks');
+    $this->assertSame(DigitalPostReceiptHandler::STATE_DELIVERED, $state);
+
+    $reloaded = $this->reload($case);
+    $this->assertSame('delivered', $reloaded->get('digital_post_receipt_status')->value);
+    $this->assertNotEmpty($reloaded->get('digital_post_delivered_at')->value);
+    $this->assertNotSame($vidBefore, $reloaded->getRevisionId(), 'A new revision was written.');
+    $this->assertSame('delivered', $this->logStatus('tx-delivered'));
+  }
+
+  /**
+   * A permanent failure marks the case failed.
+   */
+  public function testPermanentFailureMarksCaseFailed(): void {
+    $this->seed('tx-failed');
+    $state = $this->handler->handle('tx-failed', DigitalPostReceiptHandler::OUTCOME_FAILED, FALSE, 'recipient unknown');
+    $this->assertSame(DigitalPostReceiptHandler::STATE_FAILED, $state);
+    $this->assertSame('failed', $this->reloadByTx('tx-failed')->get('digital_post_receipt_status')->value);
+    $this->assertSame('failed', $this->logStatus('tx-failed'));
+  }
+
+  /**
+   * A transient failure leaves the case pending (no finalisation, no revision).
+   */
+  public function testTransientFailureStaysPending(): void {
+    $case = $this->seed('tx-transient');
+    $vidBefore = $case->getRevisionId();
+
+    $state = $this->handler->handle('tx-transient', DigitalPostReceiptHandler::OUTCOME_FAILED, TRUE, 'carrier 503');
+    $this->assertSame(DigitalPostReceiptHandler::STATE_PENDING, $state);
+
+    $reloaded = $this->reload($case);
+    $this->assertSame('pending', $reloaded->get('digital_post_receipt_status')->value);
+    $this->assertSame($vidBefore, $reloaded->getRevisionId(), 'No revision on a transient failure.');
+    $this->assertSame('pending', $this->logStatus('tx-transient'));
+  }
+
+  /**
+   * An unknown transaction id is reported as unknown and changes nothing.
+   */
+  public function testUnknownTransaction(): void {
+    $state = $this->handler->handle('tx-nope', DigitalPostReceiptHandler::OUTCOME_DELIVERED, FALSE, '');
+    $this->assertSame(DigitalPostReceiptHandler::STATE_UNKNOWN, $state);
+  }
+
+  /**
+   * Seeds a pending log row and a case both keyed to a transaction id.
+   */
+  private function seed(string $transactionId): AabenformsCase {
+    $this->container->get('database')->insert('aabenforms_digital_post_log')
+      ->fields([
+        'transaction_id' => $transactionId,
+        'mode' => 'live_test',
+        'recipient_type' => 'cpr',
+        'recipient_identifier_hash' => hash('sha256', 'cpr:2512489996'),
+        'sender_cvr' => '12345678',
+        'subject' => 'Afgørelse',
+        'status' => 'pending',
+        'reason_code' => NULL,
+        'payload' => '{}',
+        'response' => NULL,
+        'created' => 1706356800,
+        'receipt_status' => 'pending',
+        'delivered_at' => NULL,
+        'receipt_reason' => NULL,
+      ])
+      ->execute();
+
+    $case = AabenformsCase::create([
+      'case_type' => 'merudgifter',
+      'status' => 'afgoerelse',
+      'digital_post_tx' => $transactionId,
+      'digital_post_receipt_status' => 'pending',
+    ]);
+    $case->save();
+    return $case;
+  }
+
+  /**
+   * Reloads a case fresh from storage.
+   */
+  private function reload(AabenformsCase $case): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $storage->resetCache([$case->id()]);
+    return $storage->load($case->id());
+  }
+
+  /**
+   * Loads the case correlated to a transaction id.
+   */
+  private function reloadByTx(string $transactionId): AabenformsCase {
+    $storage = $this->container->get('entity_type.manager')->getStorage('aabenforms_case');
+    $ids = $storage->getQuery()->accessCheck(FALSE)->condition('digital_post_tx', $transactionId)->execute();
+    return $storage->load((int) reset($ids));
+  }
+
+  /**
+   * The receipt_status recorded on the log row.
+   */
+  private function logStatus(string $transactionId): ?string {
+    $value = $this->container->get('database')
+      ->select('aabenforms_digital_post_log', 'l')
+      ->fields('l', ['receipt_status'])
+      ->condition('transaction_id', $transactionId)
+      ->execute()->fetchField();
+    return $value === FALSE ? NULL : (string) $value;
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/tests/src/Kernel/ReceiptControllerTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_beskedfordeler/tests/src/Kernel/ReceiptControllerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post_beskedfordeler\Kernel;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_digital_post_beskedfordeler\Controller\ReceiptController;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\key\Entity\Key;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests the hardened Beskedfordeler receipt intake endpoint.
+ *
+ * @group aabenforms_digital_post
+ */
+class ReceiptControllerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'node',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'domain_access',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    'aabenforms_case',
+    'aabenforms_digital_post',
+    'aabenforms_digital_post_beskedfordeler',
+  ];
+
+  /**
+   * The controller under test.
+   */
+  protected ReceiptController $controller;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installSchema('aabenforms_digital_post', ['aabenforms_digital_post_log']);
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log', 'aabenforms_trace']);
+    $this->installConfig(['aabenforms_digital_post_beskedfordeler']);
+    \Drupal::moduleHandler()->loadInclude('aabenforms_digital_post_beskedfordeler', 'install');
+    _aabenforms_digital_post_beskedfordeler_install_log_columns();
+
+    $this->controller = ReceiptController::create($this->container);
+  }
+
+  /**
+   * With no secret configured the endpoint rejects everything (fail-closed).
+   */
+  public function testFailsClosedWithoutSecret(): void {
+    $response = $this->controller->receive($this->request(['transaction_id' => 't', 'status' => 'delivered'], 'anything'));
+    $this->assertSame(403, $response->getStatusCode());
+  }
+
+  /**
+   * A wrong secret is rejected.
+   */
+  public function testWrongSecretRejected(): void {
+    $this->configureSecret('right-secret');
+    $response = $this->controller->receive($this->request(['transaction_id' => 't', 'status' => 'delivered'], 'wrong-secret'));
+    $this->assertSame(403, $response->getStatusCode());
+  }
+
+  /**
+   * A malformed payload with the right secret is a 400.
+   */
+  public function testMalformedPayload(): void {
+    $this->configureSecret('s');
+    $request = $this->request(['nope' => TRUE], 's');
+    $this->assertSame(400, $this->controller->receive($request)->getStatusCode());
+  }
+
+  /**
+   * A valid, authenticated receipt reconciles and returns 200 with the state.
+   */
+  public function testValidReceiptReconciles(): void {
+    $this->configureSecret('s');
+    $this->seedCase('tx-ok');
+    $response = $this->controller->receive($this->request([
+      'transaction_id' => 'tx-ok',
+      'status' => 'delivered',
+    ], 's'));
+    $this->assertSame(200, $response->getStatusCode());
+    $this->assertStringContainsString('delivered', (string) $response->getContent());
+  }
+
+  /**
+   * An unknown transaction (right secret) is a 404.
+   */
+  public function testUnknownTransactionIs404(): void {
+    $this->configureSecret('s');
+    $response = $this->controller->receive($this->request([
+      'transaction_id' => 'tx-missing',
+      'status' => 'delivered',
+    ], 's'));
+    $this->assertSame(404, $response->getStatusCode());
+  }
+
+  /**
+   * Configures the shared secret in a key entry and points config at it.
+   */
+  private function configureSecret(string $secret): void {
+    Key::create([
+      'id' => 'beskedfordeler_secret',
+      'label' => 'Test secret',
+      'key_type' => 'authentication',
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => $secret],
+    ])->save();
+    $this->config('aabenforms_digital_post_beskedfordeler.settings')
+      ->set('receipt_secret_key', 'beskedfordeler_secret')
+      ->save();
+  }
+
+  /**
+   * Builds a POST request with a JSON body and the secret header.
+   */
+  private function request(array $body, string $secret): Request {
+    $request = Request::create('/api/digital-post/receipt', 'POST', [], [], [], [], json_encode($body));
+    $request->headers->set('X-Beskedfordeler-Secret', $secret);
+    return $request;
+  }
+
+  /**
+   * Seeds a case correlated to a transaction id.
+   */
+  private function seedCase(string $transactionId): void {
+    AabenformsCase::create([
+      'case_type' => 'merudgifter',
+      'status' => 'afgoerelse',
+      'digital_post_tx' => $transactionId,
+      'digital_post_receipt_status' => 'pending',
+    ])->save();
+  }
+
+}


### PR DESCRIPTION
Completes the live Digital Post slice: the asynchronous SF1461/Beskedfordeler receipt that turns a `pending` send into `delivered`/`failed` on its case. New **optional** submodule - the core send never depends on it. Part of the pilot spine (Track 3). Stacked on #179.

## What this adds
- **Closes the correlation gap** the research surfaced (nothing linked a transaction id to a case): `hook_entity_base_field_info` adds queryable, revisionable `digital_post_tx` / `digital_post_receipt_status` / `digital_post_delivered_at` to `aabenforms_case` (mirroring `esdh_ref`), and the **RecordDigitalPostRefAction** ECA action stamps the transaction id + `pending` status onto the case at send time.
- **DigitalPostReceiptHandler** correlates an inbound receipt by transaction id, updates the log row's new receipt columns, and finalises the case delivery **field** with an audited revision. It honours the *never act on a transient failure* contract: a transient failure leaves both log and case `pending` for the carrier retry (no revision). Delivery is orthogonal to the case lifecycle, so it never drives a status transition.
- **ReceiptController**: hardened POST intake at `/api/digital-post/receipt` - open route + **fail-closed** shared-secret (via `drupal:key`), flood control, strict body validation - mirroring the webform submit API.
- `.install` adds `receipt_status` / `delivered_at` / `receipt_reason` columns to the Digital Post log and installs the case base fields idempotently.

## Testing (9, all green)
- Handler: delivered finalises (revision), permanent failure -> failed, transient -> stays pending (no revision), unknown transaction -> unknown.
- Controller: fail-closed with no secret (403), wrong secret (403), malformed body (400), valid receipt reconciles (200), unknown transaction (404).
- Full `aabenforms_digital_post` suite: 78 green. Whole `web/modules/custom` tree phcs clean.

## Not in scope (enrollment-gated / follow-up)
The push-receipt intake is buildable now; the AMQP **pull** path needs a Beskedfordeler broker + an SF1461 serviceaftale + InvocationContext UUIDs, and live activation needs the FOCES3 cert from Track 3a. Left as flagged follow-ups.