### PR TITLE
Track 4: live SBSYS ESDH connector (SBSIP REST)

### DIFF
--- a/web/modules/custom/aabenforms_esdh/aabenforms_esdh.info.yml
+++ b/web/modules/custom/aabenforms_esdh/aabenforms_esdh.info.yml
@@ -9,3 +9,4 @@ dependencies:
   - aabenforms_core:aabenforms_core
   - aabenforms_case:aabenforms_case
   - eca:eca
+  - drupal:key

--- a/web/modules/custom/aabenforms_esdh/config/install/aabenforms_esdh.settings.yml
+++ b/web/modules/custom/aabenforms_esdh/config/install/aabenforms_esdh.settings.yml
@@ -1,1 +1,9 @@
 active_connector: demo
+# SBSYS (SBSIP REST) live transport - all empty until an operator enrolls.
+# The client secret is held in a drupal:key entry named by sbsys_client_secret_key,
+# never in config/sync. sbsys_templates maps a case type to its SBSIP template id.
+sbsys_base_url: ''
+sbsys_token_url: ''
+sbsys_client_id: ''
+sbsys_client_secret_key: ''
+sbsys_templates: {}

--- a/web/modules/custom/aabenforms_esdh/config/schema/aabenforms_esdh.schema.yml
+++ b/web/modules/custom/aabenforms_esdh/config/schema/aabenforms_esdh.schema.yml
@@ -5,3 +5,21 @@ aabenforms_esdh.settings:
     active_connector:
       type: string
       label: 'Active ESDH connector'
+    sbsys_base_url:
+      type: string
+      label: 'SBSIP base URL'
+    sbsys_token_url:
+      type: string
+      label: 'SBSIP OAuth2 token URL (defaults to base URL + /api/token)'
+    sbsys_client_id:
+      type: string
+      label: 'SBSIP OAuth2 client id'
+    sbsys_client_secret_key:
+      type: string
+      label: 'Key module entry holding the SBSIP client secret'
+    sbsys_templates:
+      type: sequence
+      label: 'Per-case-type SBSIP template ids'
+      sequence:
+        type: string
+        label: 'Template id'

--- a/web/modules/custom/aabenforms_esdh/src/Plugin/AabenformsEsdh/SbsysEsdhConnector.php
+++ b/web/modules/custom/aabenforms_esdh/src/Plugin/AabenformsEsdh/SbsysEsdhConnector.php
@@ -7,42 +7,221 @@ namespace Drupal\aabenforms_esdh\Plugin\AabenformsEsdh;
 use Drupal\aabenforms_case\Entity\AabenformsCase;
 use Drupal\aabenforms_esdh\Attribute\EsdhConnector;
 use Drupal\aabenforms_esdh\EsdhConnectorBase;
-use Drupal\aabenforms_esdh\Exception\EsdhException;
 use Drupal\aabenforms_esdh\Model\EsdhResult;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\key\KeyRepositoryInterface;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * SBSYS connector (community-owned ESDH, ~45 kommuner) - production stub.
+ * Live SBSYS connector (community-owned ESDH, ~45 kommuner) via SBSIP REST.
  *
- * Transport: SBSIP (SBSYS IntegrationsPlatform) REST, OAuth2 (client_credentials
- * or password grant). Base URL is customer-specific (e.g.
- * https://sbsysapi.<kommune>.dk). A live implementation would:
- *   1. POST api/token (OAuth2) -> bearer token.
- *   2. POST api/v10/sag/template  (create case FROM A CASE TEMPLATE - SBSIP
- *      cannot create a case without a template id; store per-case-type
- *      template ids in config).
- *   3. api/sag/{id}/part          (add the citizen as a party).
- *   4. api/sag/{id}/dokumenter    (attach documents) + api/journalarknote/create
- *      (journal note).
- * Idempotency: search api/sag/search by a stable external key before create.
- * Errors: 5xx/timeout -> transient (retry); 4xx validation -> permanent.
+ * Transport: SBSIP (SBSYS IntegrationsPlatform) REST with an OAuth2
+ * client-credentials token. The sequence, per SBSIP: obtain a bearer token,
+ * idempotency-search by a stable external key (never create twice), then create
+ * the case FROM A CASE TEMPLATE (SBSIP cannot create a case without a template
+ * id, so per-case-type template ids live in config). Documents/parts are a
+ * separable follow-on; this minimal path journalises the case itself.
  *
- * Not wired in this session: needs the SBSIP base URL, OAuth2 client creds
- * (from env), and per-case-type template ids. Fails hard until configured.
+ * Contract (like every connector): NEVER throws - all failure modes are an
+ * EsdhResult. A 5xx/timeout is transient (the caller retries and does not close
+ * the case); a 4xx/validation is permanent. Idempotency + the transient flag
+ * mean a re-fired flow is safe.
+ *
+ * Live only when configured (base URL + OAuth2 creds + template ids); otherwise
+ * it returns a permanent rejection, so the demo/default path is unaffected.
  */
 #[EsdhConnector(
   id: 'sbsys',
   label: new TranslatableMarkup('SBSYS (via SBSIP REST)'),
 )]
-final class SbsysEsdhConnector extends EsdhConnectorBase {
+final class SbsysEsdhConnector extends EsdhConnectorBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The ESDH system id recorded on the case.
+   */
+  private const SYSTEM = 'sbsys';
+
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    private readonly ClientInterface $httpClient,
+    private readonly KeyRepositoryInterface $keyRepository,
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly LoggerInterface $logger,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    /** @var \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory */
+    $loggerFactory = $container->get('logger.factory');
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('http_client'),
+      $container->get('key.repository'),
+      $container->get('config.factory'),
+      $loggerFactory->get('aabenforms_esdh'),
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function journaliseCase(AabenformsCase $case, array $documents = []): EsdhResult {
-    // Production stub: never silently pretend to journalise. A live SBSYS
-    // connector requires SBSIP base URL + OAuth2 creds + case-template ids.
-    throw new EsdhException('SBSYS connector is not configured (needs SBSIP base URL, OAuth2 credentials, and per-case-type template ids). Use the demo connector in non-production.');
+    $config = $this->configFactory->get('aabenforms_esdh.settings');
+    $baseUrl = rtrim((string) $config->get('sbsys_base_url'), '/');
+    $clientId = (string) $config->get('sbsys_client_id');
+    $secret = $this->readSecret((string) $config->get('sbsys_client_secret_key'));
+
+    if ($baseUrl === '' || $clientId === '' || $secret === '') {
+      return EsdhResult::rejected(self::SYSTEM, 'SBSYS is not configured (needs SBSIP base URL, client id and secret).', FALSE);
+    }
+
+    $summary = $this->caseSummary($case);
+    $templateId = $this->templateFor($config, $summary['case_type']);
+    if ($templateId === '') {
+      return EsdhResult::rejected(self::SYSTEM, sprintf('No SBSYS case template configured for case type "%s".', $summary['case_type']), FALSE);
+    }
+
+    // A stable, PII-free external key so a re-run finds the existing case.
+    $externalKey = 'aabenforms:' . $case->uuid();
+
+    try {
+      $token = $this->fetchToken($baseUrl, $config, $clientId, $secret);
+
+      $existing = $this->searchExisting($baseUrl, $token, $externalKey);
+      if ($existing !== NULL && $existing !== '') {
+        return EsdhResult::journalised(self::SYSTEM, $existing, TRUE);
+      }
+
+      $reference = $this->createCase($baseUrl, $token, $templateId, $externalKey, $summary);
+      if ($reference === '') {
+        return EsdhResult::rejected(self::SYSTEM, 'SBSYS created a case but returned no reference.', TRUE);
+      }
+      return EsdhResult::journalised(self::SYSTEM, $reference, FALSE);
+    }
+    catch (RequestException $e) {
+      $code = $e->getResponse()?->getStatusCode() ?? 0;
+      // 5xx / no-response (timeout, connection) are retry-able; 4xx are not.
+      $transient = $code === 0 || $code >= 500;
+      $this->logger->warning('SBSYS journalise failed for case @id: HTTP @code @msg', [
+        '@id' => $case->id(),
+        '@code' => $code,
+        '@msg' => $e->getMessage(),
+      ]);
+      return EsdhResult::rejected(
+        self::SYSTEM,
+        sprintf('SBSYS %s (HTTP %d).', $transient ? 'transport error' : 'rejected the request', $code),
+        $transient,
+      );
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('SBSYS journalise error for case @id: @msg', [
+        '@id' => $case->id(),
+        '@msg' => $e->getMessage(),
+      ]);
+      // Unknown errors are treated as transient so a flow never closes on them.
+      return EsdhResult::rejected(self::SYSTEM, 'SBSYS error: ' . $e->getMessage(), TRUE);
+    }
+  }
+
+  /**
+   * Obtains an OAuth2 client-credentials bearer token.
+   */
+  private function fetchToken(string $baseUrl, $config, string $clientId, string $secret): string {
+    $tokenUrl = (string) ($config->get('sbsys_token_url') ?: $baseUrl . '/api/token');
+    $response = $this->httpClient->request('POST', $tokenUrl, [
+      'form_params' => [
+        'grant_type' => 'client_credentials',
+        'client_id' => $clientId,
+        'client_secret' => $secret,
+      ],
+      'timeout' => 30,
+    ]);
+    $data = json_decode((string) $response->getBody(), TRUE);
+    $token = is_array($data) ? (string) ($data['access_token'] ?? '') : '';
+    if ($token === '') {
+      throw new \RuntimeException('SBSYS token response carried no access_token.');
+    }
+    return $token;
+  }
+
+  /**
+   * Searches for an already-journalised case by its external key.
+   *
+   * @return string|null
+   *   The existing SBSYS reference, or NULL when none exists.
+   */
+  private function searchExisting(string $baseUrl, string $token, string $externalKey): ?string {
+    $response = $this->httpClient->request('GET', $baseUrl . '/api/sag/search', [
+      'headers' => ['Authorization' => 'Bearer ' . $token],
+      'query' => ['externalKey' => $externalKey],
+      'timeout' => 30,
+    ]);
+    $data = json_decode((string) $response->getBody(), TRUE);
+    $results = is_array($data) ? ($data['results'] ?? $data) : [];
+    if (is_array($results) && $results !== []) {
+      $first = reset($results);
+      $ref = is_array($first) ? ($first['sagsnummer'] ?? $first['reference'] ?? '') : '';
+      return $ref !== '' ? (string) $ref : NULL;
+    }
+    return NULL;
+  }
+
+  /**
+   * Creates a case from the configured template and returns its reference.
+   */
+  private function createCase(string $baseUrl, string $token, string $templateId, string $externalKey, array $summary): string {
+    $response = $this->httpClient->request('POST', $baseUrl . '/api/v10/sag/template', [
+      'headers' => ['Authorization' => 'Bearer ' . $token],
+      'json' => [
+        'templateId' => $templateId,
+        'externalKey' => $externalKey,
+        'titel' => $summary['title'],
+        'kleEmne' => $summary['kle_emne'],
+        'handlekommune' => $summary['handlekommune'],
+      ],
+      'timeout' => 30,
+    ]);
+    $data = json_decode((string) $response->getBody(), TRUE);
+    if (!is_array($data)) {
+      return '';
+    }
+    return (string) ($data['sagsnummer'] ?? $data['reference'] ?? $data['id'] ?? '');
+  }
+
+  /**
+   * Resolves the SBSYS template id for a case type from config.
+   */
+  private function templateFor($config, string $caseType): string {
+    $templates = $config->get('sbsys_templates');
+    if (is_array($templates) && isset($templates[$caseType])) {
+      return (string) $templates[$caseType];
+    }
+    return '';
+  }
+
+  /**
+   * Reads the client secret from its key entry, tolerating an unset key.
+   */
+  private function readSecret(string $keyName): string {
+    if ($keyName === '') {
+      return '';
+    }
+    $key = $this->keyRepository->getKey($keyName);
+    return $key ? (string) $key->getKeyValue() : '';
   }
 
 }

--- a/web/modules/custom/aabenforms_esdh/tests/src/Unit/SbsysEsdhConnectorTest.php
+++ b/web/modules/custom/aabenforms_esdh/tests/src/Unit/SbsysEsdhConnectorTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_esdh\Unit;
+
+use Drupal\aabenforms_case\Entity\AabenformsCase;
+use Drupal\aabenforms_esdh\Model\EsdhResult;
+use Drupal\aabenforms_esdh\Plugin\AabenformsEsdh\SbsysEsdhConnector;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\key\KeyInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests the live SBSYS connector's SBSIP sequence and result mapping.
+ *
+ * The HTTP transport is a Guzzle MockHandler (no live SBSIP), so the test
+ * exercises the connector's own logic: not-configured / no-template rejections,
+ * the token -> search -> create happy path, idempotency on a search hit, and
+ * the transient (5xx) vs permanent (4xx) failure mapping.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_esdh\Plugin\AabenformsEsdh\SbsysEsdhConnector
+ * @group aabenforms_esdh
+ */
+class SbsysEsdhConnectorTest extends UnitTestCase {
+
+  /**
+   * A permanent rejection when SBSYS is unconfigured.
+   *
+   * @covers ::journaliseCase
+   */
+  public function testNotConfiguredIsPermanentRejection(): void {
+    $connector = $this->connector([new Response(200, [], '{}')], configured: FALSE);
+    $result = $connector->journaliseCase($this->case());
+    $this->assertSame(EsdhResult::STATUS_REJECTED, $result->status);
+    $this->assertFalse($result->transient);
+  }
+
+  /**
+   * A permanent rejection when no template is configured for the case type.
+   *
+   * @covers ::journaliseCase
+   */
+  public function testMissingTemplateIsPermanentRejection(): void {
+    $connector = $this->connector([], templates: ['other_type' => 'T1']);
+    $result = $connector->journaliseCase($this->case());
+    $this->assertSame(EsdhResult::STATUS_REJECTED, $result->status);
+    $this->assertFalse($result->transient);
+  }
+
+  /**
+   * Token -> search(miss) -> create yields a journalised (created) result.
+   *
+   * @covers ::journaliseCase
+   */
+  public function testHappyPathCreatesCase(): void {
+    $connector = $this->connector([
+      new Response(200, [], json_encode(['access_token' => 'tok'])),
+      new Response(200, [], json_encode(['results' => []])),
+      new Response(201, [], json_encode(['sagsnummer' => 'SAG-2026-42'])),
+    ]);
+    $result = $connector->journaliseCase($this->case());
+    $this->assertTrue($result->isJournalised());
+    $this->assertSame(EsdhResult::STATUS_CREATED, $result->status);
+    $this->assertSame('SAG-2026-42', $result->reference);
+    $this->assertSame('sbsys', $result->esdhSystem);
+  }
+
+  /**
+   * A search hit short-circuits to a journalised (exists) result - idempotent.
+   *
+   * @covers ::journaliseCase
+   */
+  public function testIdempotentSearchHit(): void {
+    $connector = $this->connector([
+      new Response(200, [], json_encode(['access_token' => 'tok'])),
+      new Response(200, [], json_encode(['results' => [['sagsnummer' => 'SAG-EXISTS']]])),
+    ]);
+    $result = $connector->journaliseCase($this->case());
+    $this->assertSame(EsdhResult::STATUS_EXISTS, $result->status);
+    $this->assertSame('SAG-EXISTS', $result->reference);
+  }
+
+  /**
+   * A 5xx is a transient rejection (the caller retries, never closes the case).
+   *
+   * @covers ::journaliseCase
+   */
+  public function testServerErrorIsTransient(): void {
+    $connector = $this->connector([
+      new Response(200, [], json_encode(['access_token' => 'tok'])),
+      new Response(503, [], 'busy'),
+    ]);
+    $result = $connector->journaliseCase($this->case());
+    $this->assertSame(EsdhResult::STATUS_REJECTED, $result->status);
+    $this->assertTrue($result->transient);
+  }
+
+  /**
+   * A 4xx is a permanent rejection.
+   *
+   * @covers ::journaliseCase
+   */
+  public function testClientErrorIsPermanent(): void {
+    $connector = $this->connector([
+      new Response(200, [], json_encode(['access_token' => 'tok'])),
+      new Response(400, [], 'bad request'),
+    ]);
+    $result = $connector->journaliseCase($this->case());
+    $this->assertSame(EsdhResult::STATUS_REJECTED, $result->status);
+    $this->assertFalse($result->transient);
+  }
+
+  /**
+   * Builds a connector whose HTTP transport replays the queued responses.
+   *
+   * @param \GuzzleHttp\Psr7\Response[] $responses
+   *   The queued responses.
+   * @param bool $configured
+   *   Whether base URL / client id / secret are set.
+   * @param array $templates
+   *   The per-case-type template map (defaults to one for 'merudgifter').
+   */
+  private function connector(array $responses, bool $configured = TRUE, array $templates = ['merudgifter' => 'TPL-1']): SbsysEsdhConnector {
+    $client = new Client(['handler' => HandlerStack::create(new MockHandler($responses))]);
+
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['sbsys_base_url', $configured ? 'https://sbsysapi.example.dk' : ''],
+      ['sbsys_token_url', ''],
+      ['sbsys_client_id', $configured ? 'client-1' : ''],
+      ['sbsys_client_secret_key', $configured ? 'sbsys_secret' : ''],
+      ['sbsys_templates', $templates],
+    ]);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->with('aabenforms_esdh.settings')->willReturn($config);
+
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn('s3cr3t');
+    $keyRepository = $this->createMock(KeyRepositoryInterface::class);
+    $keyRepository->method('getKey')->willReturn($key);
+
+    return new SbsysEsdhConnector(
+      [],
+      'sbsys',
+      ['label' => 'SBSYS'],
+      $client,
+      $keyRepository,
+      $configFactory,
+      new NullLogger(),
+    );
+  }
+
+  /**
+   * A mocked case exposing the fields caseSummary() reads.
+   */
+  private function case(): AabenformsCase {
+    $case = $this->createMock(AabenformsCase::class);
+    $case->method('getCaseType')->willReturn('merudgifter');
+    $case->method('uuid')->willReturn('11111111-2222-3333-4444-555555555555');
+    $case->method('id')->willReturn('1');
+    $case->method('get')->willReturnCallback(function (string $field) {
+      $values = [
+        'title' => 'Merudgifter SEL 41',
+        'kle_emne' => '32.18.04',
+        'handlekommune' => '0751',
+        'journal_ref' => '',
+      ];
+      return (object) ['value' => $values[$field] ?? ''];
+    });
+    return $case;
+  }
+
+}


### PR DESCRIPTION
Turns the first ESDH connector from a throw-only stub into a real transport. The framework (plugin type, manager, `EsdhResult` with the transient contract, the idempotent `EsdhJournalAction`, the `esdh_ref` base field, the resolver) already existed; this fills in one connector. Part of the pilot spine (Track 4). Stacked on #180.

## What this adds
- **SbsysEsdhConnector** now implements `ContainerFactoryPluginInterface` and injects the Guzzle client, `drupal:key` repository, config, and a logger. `journaliseCase()` runs the SBSIP sequence: OAuth2 client-credentials token -> **idempotency search** by a stable external key (case UUID) -> create the case from the configured **per-case-type template**. It returns `EsdhResult::journalised` (created/exists) or `::rejected` and **never throws**: a 5xx/timeout is **transient** (the caller retries and does not close the case), a 4xx is **permanent**. Unconfigured or missing-template -> permanent rejection, so the demo default is untouched.
- **Config**: `sbsys_base_url` / `sbsys_token_url` / `sbsys_client_id` / `sbsys_client_secret_key` (a `drupal:key` entry) / `sbsys_templates` (case type -> template id). The secret stays out of `config/sync`. Module gains the `key` dependency.

## Testing (9 esdh tests green)
`SbsysEsdhConnectorTest` drives a Guzzle `MockHandler` (no live SBSIP): not-configured and no-template permanent rejections, token->search->create happy path, idempotent search hit -> exists, 5xx -> transient, 4xx -> permanent. The existing demo/action tests still pass; whole `web/modules/custom` tree phcs clean; the module enables with the new `key` dep, the SBSYS connector instantiates via DI, and the resolver default stays `demo`.

## Not in scope (enrollment-gated / follow-up)
Live SBSYS activates only when an operator sets `active_connector=sbsys` + the SBSIP base URL / OAuth2 creds / per-case-type template ids + a serviceaftale. Document (PDF) assembly and a per-connector queue worker are the separable follow-ons the README already tracks.