### PR TITLE
Add one-command tenant/magistrate provisioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,12 +256,19 @@ git commit -m "Update webform to 6.3.1"
 
 ### 3. Testing Multi-Tenancy
 ```bash
-# Create test tenant domains
-ddev drush domain:create aarhus.aabenforms.ddev.site "Aarhus Kommune"
-ddev drush domain:create odense.aabenforms.ddev.site "Odense Kommune"
+# Provision tenants (Domain + per-tenant CPR key + encryption profile) in one
+# command each. A tenant can be a whole kommune or a single magistrat.
+ddev drush aabenforms:tenant:provision aarhus_mtm "Aarhus - Teknik og Miljoe" \
+  --hostname=mtm.aarhus.aabenforms.ddev.site
+ddev drush aabenforms:tenant:provision odense "Odense Kommune" \
+  --hostname=odense.aabenforms.ddev.site
+
+# Each tenant's CPR key uses the env provider; set its variable (base64 of 32
+# random bytes) and restart before storing CPR, e.g.:
+#   AABENFORMS_CPR_KEY_AARHUS_MTM, AABENFORMS_CPR_KEY_ODENSE
 
 # Add to /etc/hosts (or DDEV auto-manages with use_dns_when_possible)
-# 127.0.0.1 aarhus.aabenforms.ddev.site
+# 127.0.0.1 mtm.aarhus.aabenforms.ddev.site
 # 127.0.0.1 odense.aabenforms.ddev.site
 ```
 

--- a/web/modules/custom/aabenforms_core/README.md
+++ b/web/modules/custom/aabenforms_core/README.md
@@ -79,21 +79,31 @@ serviceplatformen:
 
 ### 3. Multi-Tenancy (Optional)
 
-If using Domain module for multi-tenancy:
+A tenant is a Domain plus its own CPR encryption key and profile, so cases and
+CPR are isolated per tenant. A tenant does not have to be a whole kommune: in a
+magistratsstyre like Aarhus, give each magistrat its own subdomain and provision
+it as its own tenant. Stand one up in a single command:
 
 ```bash
-# Install domain module
-ddev composer require drupal/domain
-ddev drush pm:enable domain domain_access -y
+ddev drush pm:enable aabenforms_tenant -y
 
-# Create tenant domains
-ddev drush domain:create aarhus.aabenforms.ddev.site "Aarhus Kommune"
-ddev drush domain:create odense.aabenforms.ddev.site "Odense Kommune"
+# Provision a magistrat as a tenant (Domain + per-tenant CPR key + profile).
+ddev drush aabenforms:tenant:provision aarhus_mtm "Aarhus - Teknik og Miljoe" \
+  --hostname=mtm.aarhus.aabenforms.ddev.site
+
+# Preview without changing anything.
+ddev drush aabenforms:tenant:provision aarhus_mtm "Aarhus - Teknik og Miljoe" --dry-run
 ```
 
-Tenant-specific configuration is stored at:
-- `aabenforms_core.tenant.aarhus`
-- `aabenforms_core.tenant.odense`
+The per-tenant CPR key uses the `env` provider, so provisioning creates only
+config; the command reports the environment variable to set (base64 of 32
+random bytes) before CPR can be stored for the tenant, e.g.
+`AABENFORMS_CPR_KEY_AARHUS_MTM`. Set it in the host environment and restart.
+Re-running the command is safe (idempotent).
+
+Optional tenant-specific integration configuration is stored at:
+- `aabenforms_core.tenant.aarhus_mtm`
+- `aabenforms_core.tenant.aarhus_mbu`
 
 ## Usage
 

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -112,6 +112,7 @@ function aabenforms_core_theme(): array {
         'hero_metric' => NULL,
         'secondary_metrics' => [],
         'main_link' => [],
+        'secondary_link' => [],
       ],
     ],
     'aabenforms_dashboard_landing' => [

--- a/web/modules/custom/aabenforms_core/css/dashboard.css
+++ b/web/modules/custom/aabenforms_core/css/dashboard.css
@@ -177,6 +177,10 @@
   margin-top: auto;
   padding-top: var(--af-space-3);
   border-top: 1px solid var(--af-color-border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--af-space-2) var(--af-space-4);
+  align-items: center;
 }
 
 .af-card__cta {
@@ -184,6 +188,11 @@
   font-weight: 500;
   color: var(--af-color-brand-strong);
   text-decoration: none;
+}
+
+.af-card__cta--secondary {
+  font-weight: 400;
+  color: var(--af-color-text-muted);
 }
 
 .af-card__cta:hover,

--- a/web/modules/custom/aabenforms_core/src/Controller/DashboardController.php
+++ b/web/modules/custom/aabenforms_core/src/Controller/DashboardController.php
@@ -127,6 +127,7 @@ class DashboardController extends ControllerBase {
       '#hero_metric' => $this->safeAccessor($id, 'getHeroMetric', fn () => $section->getHeroMetric()),
       '#secondary_metrics' => $this->safeAccessor($id, 'getSecondaryMetrics', fn () => $section->getSecondaryMetrics(), []),
       '#main_link' => $this->safeAccessor($id, 'getMainLink', fn () => $section->getMainLink(), []),
+      '#secondary_link' => $this->safeAccessor($id, 'getSecondaryLink', fn () => $section->getSecondaryLink(), []),
     ];
 
     // If everything bombed (no badge, no metric, no link) tag the card

--- a/web/modules/custom/aabenforms_core/src/Dashboard/AabenformsDashboardSectionBase.php
+++ b/web/modules/custom/aabenforms_core/src/Dashboard/AabenformsDashboardSectionBase.php
@@ -72,6 +72,13 @@ abstract class AabenformsDashboardSectionBase extends PluginBase implements Aabe
   /**
    * {@inheritdoc}
    */
+  public function getSecondaryLink(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheTags(): array {
     return [];
   }

--- a/web/modules/custom/aabenforms_core/src/Dashboard/AabenformsDashboardSectionInterface.php
+++ b/web/modules/custom/aabenforms_core/src/Dashboard/AabenformsDashboardSectionInterface.php
@@ -73,4 +73,13 @@ interface AabenformsDashboardSectionInterface extends PluginInspectionInterface,
    */
   public function getMainLink(): array;
 
+  /**
+   * Optional second footer CTA, shown after the main link.
+   *
+   * @return array
+   *   ['label' => string|TranslatableMarkup, 'url' => \Drupal\Core\Url], or an
+   *   empty array for no secondary link.
+   */
+  public function getSecondaryLink(): array;
+
 }

--- a/web/modules/custom/aabenforms_core/templates/aabenforms-dashboard-section-card.html.twig
+++ b/web/modules/custom/aabenforms_core/templates/aabenforms-dashboard-section-card.html.twig
@@ -9,6 +9,7 @@
  * - hero_metric: { label, value } | null  (mutually exclusive with badge)
  * - secondary_metrics: [ { label, value } ]
  * - main_link: { label, url }
+ * - secondary_link: { label, url } | null  (optional second CTA)
  */
 #}
 <article class="af-card" data-section="{{ section_id }}">
@@ -45,6 +46,11 @@
       <a href="{{ main_link.url }}" class="af-card__cta">
         {{ main_link.label }} <span aria-hidden="true">→</span>
       </a>
+      {% if secondary_link.url %}
+        <a href="{{ secondary_link.url }}" class="af-card__cta af-card__cta--secondary">
+          {{ secondary_link.label }} <span aria-hidden="true">→</span>
+        </a>
+      {% endif %}
     </footer>
   {% endif %}
 </article>

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.links.action.yml
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.links.action.yml
@@ -1,0 +1,5 @@
+aabenforms_tenant.provision:
+  title: 'Provision tenant'
+  route_name: aabenforms_tenant.provision
+  appears_on:
+    - aabenforms_tenant.settings

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.routing.yml
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.routing.yml
@@ -5,3 +5,11 @@ aabenforms_tenant.settings:
     _title: 'AabenForms tenant settings'
   requirements:
     _permission: 'administer site configuration'
+
+aabenforms_tenant.provision:
+  path: '/admin/config/aabenforms/tenant/provision'
+  defaults:
+    _form: '\Drupal\aabenforms_tenant\Form\ProvisionTenantForm'
+    _title: 'Provision tenant'
+  requirements:
+    _permission: 'administer site configuration'

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.services.yml
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.services.yml
@@ -1,0 +1,6 @@
+services:
+  aabenforms_tenant.tenant_provisioner:
+    class: Drupal\aabenforms_tenant\Service\TenantProvisioner
+    arguments:
+      - '@entity_type.manager'
+      - '@logger.factory'

--- a/web/modules/custom/aabenforms_tenant/drush.services.yml
+++ b/web/modules/custom/aabenforms_tenant/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  aabenforms_tenant.drush_commands:
+    class: Drupal\aabenforms_tenant\Drush\TenantCommands
+    arguments:
+      - '@aabenforms_tenant.tenant_provisioner'
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/aabenforms_tenant/src/Drush/TenantCommands.php
+++ b/web/modules/custom/aabenforms_tenant/src/Drush/TenantCommands.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_tenant\Drush;
+
+use Drupal\aabenforms_tenant\Service\TenantProvisioner;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for standing up AabenForms tenants (kommuner / magistrater).
+ *
+ * A tenant needs a Domain plus a matching per-tenant CPR key and encryption
+ * profile whose ids line up exactly with what the runtime derives; getting any
+ * of that wrong makes CPR encryption fail closed. `aabenforms:tenant:provision`
+ * creates all three idempotently, so standing up e.g. "Aarhus / Teknik og
+ * Miljoe" is one command instead of manual config.
+ */
+final class TenantCommands extends DrushCommands {
+
+  public function __construct(
+    private readonly TenantProvisioner $provisioner,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Provision a tenant: Domain + per-tenant CPR key + encryption profile.
+   *
+   * Idempotent: artifacts that already exist are left untouched. The per-tenant
+   * key uses the `env` provider, so this command creates only config - you must
+   * set the reported environment variable (base64 of 32 random bytes) and
+   * restart before CPR can be stored for the tenant.
+   *
+   * @param string $tenantId
+   *   The canonical tenant id (lowercase letters, digits, underscores), e.g.
+   *   aarhus_mtm. Becomes the Domain id and the tenant discriminator.
+   * @param string $label
+   *   The human-readable tenant name, e.g. "Aarhus - Teknik og Miljoe".
+   * @param array $options
+   *   The command options.
+   *
+   * @option hostname
+   *   The hostname routing to this tenant. Defaults to
+   *   <tenant-id-with-dashes>.aabenforms.dk.
+   * @option dry-run
+   *   Report what would be created without changing anything.
+   *
+   * @command aabenforms:tenant:provision
+   * @aliases af:tenant-provision
+   * @usage drush aabenforms:tenant:provision aarhus_mtm "Aarhus - Teknik og Miljoe" --hostname=mtm.aarhus.aabenforms.dk
+   *   Stand up the Teknik og Miljoe magistrat as an isolated tenant.
+   * @usage drush aabenforms:tenant:provision aarhus_mtm "Aarhus - Teknik og Miljoe" --dry-run
+   *   Show what provisioning would create.
+   */
+  public function provision(
+    string $tenantId,
+    string $label,
+    array $options = ['hostname' => NULL, 'dry-run' => FALSE],
+  ): int {
+    $hostname = is_string($options['hostname']) && $options['hostname'] !== ''
+      ? $options['hostname']
+      : str_replace('_', '-', $tenantId) . '.aabenforms.dk';
+
+    if (!empty($options['dry-run'])) {
+      return $this->dryRun($tenantId, $hostname);
+    }
+
+    try {
+      $result = $this->provisioner->provision($tenantId, $label, $hostname);
+    }
+    catch (\InvalidArgumentException | \RuntimeException $e) {
+      $this->logger()->error($e->getMessage());
+      return self::EXIT_FAILURE;
+    }
+
+    if ($result['created'] === []) {
+      $this->io()->success(dt('Tenant @id already provisioned (@host); nothing changed.', [
+        '@id' => $result['tenant_id'],
+        '@host' => $result['hostname'],
+      ]));
+    }
+    else {
+      $this->io()->success(dt('Provisioned tenant @id (@host):', [
+        '@id' => $result['tenant_id'],
+        '@host' => $result['hostname'],
+      ]));
+      $this->io()->listing($result['created']);
+      if ($result['existing'] !== []) {
+        $this->io()->writeln(dt('Already present:'));
+        $this->io()->listing($result['existing']);
+      }
+    }
+
+    $this->io()->writeln(dt('CPR key material is read from the environment variable: @env', [
+      '@env' => $result['env_variable'],
+    ]));
+    foreach ($result['warnings'] as $warning) {
+      $this->logger()->warning($warning);
+    }
+    return self::EXIT_SUCCESS;
+  }
+
+  /**
+   * Prints what provisioning would create for a tenant.
+   */
+  private function dryRun(string $tenantId, string $hostname): int {
+    try {
+      $state = $this->provisioner->describe($tenantId);
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->logger()->error($e->getMessage());
+      return self::EXIT_FAILURE;
+    }
+    $mark = static fn (bool $present): string => $present ? 'exists' : 'would create';
+    $this->io()->writeln(dt('Dry run for tenant @id (@host):', [
+      '@id' => $state['tenant_id'],
+      '@host' => $hostname,
+    ]));
+    $this->io()->table(
+      [dt('Artifact'), dt('State')],
+      [
+        ['domain.record.' . $state['tenant_id'], $mark($state['domain'])],
+        ['key.key.cpr_' . $state['tenant_id'], $mark($state['key'])],
+        ['encrypt.profile.aabenforms_aes256_' . $state['tenant_id'], $mark($state['profile'])],
+        [$state['env_variable'], $state['env_set'] ? 'set' : 'NOT set'],
+      ],
+    );
+    return self::EXIT_SUCCESS;
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/src/Form/ProvisionTenantForm.php
+++ b/web/modules/custom/aabenforms_tenant/src/Form/ProvisionTenantForm.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_tenant\Form;
+
+use Drupal\aabenforms_tenant\Service\TenantProvisioner;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Stands up a tenant (kommune / magistrat) from the admin UI.
+ *
+ * The one-command Drush provisioner, surfaced as a form so an operator can
+ * create a Domain + per-tenant CPR key + encryption profile without the CLI.
+ * The key uses the env provider, so the form reminds the operator which
+ * environment variable to set afterwards.
+ */
+final class ProvisionTenantForm extends FormBase {
+
+  /**
+   * The tenant provisioner.
+   *
+   * @var \Drupal\aabenforms_tenant\Service\TenantProvisioner
+   */
+  protected TenantProvisioner $provisioner;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->provisioner = $container->get('aabenforms_tenant.tenant_provisioner');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'aabenforms_tenant_provision';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form['intro'] = [
+      '#markup' => '<p>' . $this->t('Provision a tenant: a Domain plus its own CPR encryption key and profile, so cases and CPR are isolated per tenant. Re-running is safe. For a magistratsstyre like Aarhus, give each magistrat its own subdomain.') . '</p>',
+    ];
+    $form['tenant_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Tenant id'),
+      '#description' => $this->t('Lowercase letters, digits and underscores only, e.g. aarhus_mtm. This becomes the domain id and the tenant discriminator.'),
+      '#required' => TRUE,
+      '#maxlength' => 64,
+    ];
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Label'),
+      '#description' => $this->t('Human-readable name, e.g. Aarhus - Teknik og Miljoe.'),
+      '#required' => TRUE,
+    ];
+    $form['hostname'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Hostname'),
+      '#description' => $this->t('The host that routes to this tenant, e.g. mtm.aarhus.aabenforms.dk.'),
+      '#required' => TRUE,
+    ];
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Provision tenant'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    try {
+      $result = $this->provisioner->provision(
+        (string) $form_state->getValue('tenant_id'),
+        (string) $form_state->getValue('label'),
+        (string) $form_state->getValue('hostname'),
+      );
+    }
+    catch (\InvalidArgumentException | \RuntimeException $e) {
+      $this->messenger()->addError($e->getMessage());
+      $form_state->setRebuild();
+      return;
+    }
+
+    if ($result['created'] === []) {
+      $this->messenger()->addStatus($this->t('Tenant @id was already provisioned; nothing changed.', [
+        '@id' => $result['tenant_id'],
+      ]));
+    }
+    else {
+      $this->messenger()->addStatus($this->t('Provisioned tenant @id: @changes.', [
+        '@id' => $result['tenant_id'],
+        '@changes' => implode(', ', $result['created']),
+      ]));
+    }
+    foreach ($result['warnings'] as $warning) {
+      $this->messenger()->addWarning($warning);
+    }
+    $this->messenger()->addStatus($this->t('CPR key material is read from the environment variable @env.', [
+      '@env' => $result['env_variable'],
+    ]));
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/src/Plugin/AabenformsDashboard/TenantHealthSection.php
+++ b/web/modules/custom/aabenforms_tenant/src/Plugin/AabenformsDashboard/TenantHealthSection.php
@@ -106,6 +106,28 @@ class TenantHealthSection extends AabenformsDashboardSectionBase {
    * {@inheritdoc}
    */
   public function getMainLink(): array {
+    // "See tenants" is the Domain list where all tenants are visible. Fall back
+    // to the provision form if the viewer cannot administer domains, so the
+    // card always has a working primary link.
+    $seeTenants = Url::fromRoute('domain.admin');
+    if ($seeTenants->access()) {
+      return ['label' => $this->t('See tenants'), 'url' => $seeTenants];
+    }
+    return [
+      'label' => $this->t('Provision tenant'),
+      'url' => Url::fromRoute('aabenforms_tenant.provision'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSecondaryLink(): array {
+    // Only offer "Provision tenant" as the second CTA when the primary is the
+    // tenant list (avoid duplicating it when it is already the main link).
+    if (!Url::fromRoute('domain.admin')->access()) {
+      return [];
+    }
     return [
       'label' => $this->t('Provision tenant'),
       'url' => Url::fromRoute('aabenforms_tenant.provision'),

--- a/web/modules/custom/aabenforms_tenant/src/Plugin/AabenformsDashboard/TenantHealthSection.php
+++ b/web/modules/custom/aabenforms_tenant/src/Plugin/AabenformsDashboard/TenantHealthSection.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_tenant\Plugin\AabenformsDashboard;
+
+use Drupal\aabenforms_core\Dashboard\AabenformsDashboardSectionBase;
+use Drupal\aabenforms_core\Dashboard\Attribute\AabenformsDashboardSection;
+use Drupal\aabenforms_tenant\Service\TenantProvisioner;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Glass-box card for tenant (kommune / magistrat) isolation health.
+ *
+ * Hidden in the single-tenant demo (one or zero domains). Once several tenants
+ * exist it surfaces, at a glance, whether every tenant has the CPR key +
+ * encryption profile it needs - a missing pair means CPR encryption would fail
+ * closed for that tenant, so it is worth flagging before a citizen hits it.
+ */
+#[AabenformsDashboardSection(id: 'tenants', weight: -36)]
+class TenantHealthSection extends AabenformsDashboardSectionBase {
+
+  /**
+   * Cached per-tenant provisioning states.
+   *
+   * @var array<int, array>|null
+   */
+  private ?array $states = NULL;
+
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    array $plugin_definition,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+    protected readonly TenantProvisioner $provisioner,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('aabenforms_tenant.tenant_provisioner'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLabel(): TranslatableMarkup {
+    return $this->t('Tenants');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isApplicable(): bool {
+    // Single-tenant / demo mode has zero or one domain and no isolation to
+    // report; hide the card until multi-tenancy is actually in use.
+    return count($this->states()) > 1;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatusBadge(): ?array {
+    $incomplete = $this->countMissingConfig();
+    if ($incomplete > 0) {
+      return [
+        'label' => $this->t('@n tenant(s) missing CPR key/profile', ['@n' => $incomplete]),
+        'tone' => 'warning',
+      ];
+    }
+    return [
+      'label' => $this->t('@n tenants isolated', ['@n' => count($this->states())]),
+      'tone' => 'success',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSecondaryMetrics(): array {
+    $keysPending = 0;
+    foreach ($this->states() as $state) {
+      if (!$state['env_set']) {
+        $keysPending++;
+      }
+    }
+    return [
+      ['label' => $this->t('Tenants'), 'value' => count($this->states())],
+      ['label' => $this->t('Key env vars pending'), 'value' => $keysPending],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMainLink(): array {
+    return [
+      'label' => $this->t('Provision tenant'),
+      'url' => Url::fromRoute('aabenforms_tenant.provision'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags(): array {
+    return ['config:domain.record_list'];
+  }
+
+  /**
+   * Number of tenants missing their CPR key or encryption profile.
+   */
+  private function countMissingConfig(): int {
+    $missing = 0;
+    foreach ($this->states() as $state) {
+      if (!$state['key'] || !$state['profile']) {
+        $missing++;
+      }
+    }
+    return $missing;
+  }
+
+  /**
+   * Loads each domain's provisioning state, tolerating an absent Domain module.
+   *
+   * @return array<int, array>
+   *   One describe() result per tenant/domain.
+   */
+  private function states(): array {
+    if ($this->states !== NULL) {
+      return $this->states;
+    }
+    $this->states = [];
+    try {
+      $domains = $this->entityTypeManager->getStorage('domain')->loadMultiple();
+    }
+    catch (\Throwable) {
+      // No Domain module / storage: leave empty, the card stays hidden.
+      return $this->states;
+    }
+    foreach ($domains as $domain) {
+      try {
+        $this->states[] = $this->provisioner->describe($domain->id());
+      }
+      catch (\Throwable) {
+        // Skip a domain with a non-canonical id rather than hide the card.
+      }
+    }
+    return $this->states;
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/src/Service/TenantProvisioner.php
+++ b/web/modules/custom/aabenforms_tenant/src/Service/TenantProvisioner.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_tenant\Service;
+
+use Drupal\Core\Config\ConfigValueException;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Stands up a tenant (kommune or magistrat) in one idempotent operation.
+ *
+ * A tenant is a `domain` config entity; its machine id is what
+ * TenantResolver::getCurrentTenantId() returns and what
+ * aabenforms_tenant stamps onto every case/submission. For CPR to be
+ * encrypted per tenant, that tenant also needs a `key` + `encrypt.profile`
+ * whose profile id EXACTLY matches what CprAccess::tenantProfile() derives
+ * (aabenforms_aes256_<sanitized-id>). Doing this by hand is fragile: a
+ * mismatched profile id makes CPR encryption fail closed (submissions
+ * rejected), and a shared key silently breaks cross-tenant isolation.
+ *
+ * This service creates all three config entities in the exact shape the
+ * runtime expects, load-or-create so re-running is safe. It NEVER writes or
+ * reads secret material: the per-tenant key uses the `env` provider (one
+ * variable per tenant, mirroring the global AABENFORMS_CPR_KEY), so the key
+ * lives only in the host environment - off git and off the database. The
+ * operator injects it out of band; provision() reports the variable name and
+ * warns while it is still empty.
+ */
+final class TenantProvisioner {
+
+  /**
+   * The per-tenant profile-id prefix.
+   *
+   * MUST stay in lockstep with CprAccess::DEFAULT_PROFILE (which is protected,
+   * so it cannot be referenced directly). The runtime profile id is
+   * CprAccess::tenantProfile() = this prefix . '_' . sanitized-tenant-id.
+   *
+   * @see \Drupal\aabenforms_core\Service\CprAccess::tenantProfile()
+   */
+  private const PROFILE_PREFIX = 'aabenforms_aes256';
+
+  /**
+   * The environment-variable prefix for a tenant's CPR key material.
+   */
+  private const ENV_PREFIX = 'AABENFORMS_CPR_KEY_';
+
+  /**
+   * The logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private LoggerInterface $logger;
+
+  /**
+   * Constructs a TenantProvisioner.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The logger factory.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->logger = $loggerFactory->get('aabenforms_tenant');
+  }
+
+  /**
+   * Provisions a tenant: Domain + per-tenant CPR key + encryption profile.
+   *
+   * Idempotent: each artifact is created only if absent, so re-running reports
+   * "already present" and changes nothing.
+   *
+   * @param string $tenantId
+   *   The canonical tenant id (lowercase [a-z0-9_], e.g. "aarhus_mtm"). This
+   *   becomes the Domain id, so it must already be in sanitized form - the
+   *   runtime derives the profile id from the Domain id and a mismatch would
+   *   break CPR encryption.
+   * @param string $label
+   *   The human-readable tenant name (e.g. "Aarhus - Teknik og Miljoe").
+   * @param string $hostname
+   *   The hostname that routes to this tenant (e.g. mtm.aarhus.aabenforms.dk).
+   *
+   * @return array
+   *   A result array with keys: tenant_id, hostname, env_variable, created
+   *   (string[]), existing (string[]), warnings (string[]).
+   *
+   * @throws \InvalidArgumentException
+   *   When the tenant id is empty or not already sanitized, or the hostname is
+   *   empty.
+   * @throws \RuntimeException
+   *   When the hostname is already registered to a different tenant.
+   */
+  public function provision(string $tenantId, string $label, string $hostname): array {
+    $tenantId = $this->assertCanonicalId($tenantId);
+    $hostname = trim($hostname);
+    if ($hostname === '') {
+      throw new \InvalidArgumentException('A hostname is required to provision a tenant.');
+    }
+    if (trim($label) === '') {
+      throw new \InvalidArgumentException('A label is required to provision a tenant.');
+    }
+
+    $created = [];
+    $existing = [];
+
+    $this->provisionDomain($tenantId, $label, $hostname, $created, $existing);
+    $this->provisionKey($tenantId, $label, $created, $existing);
+    $this->provisionProfile($tenantId, $label, $created, $existing);
+
+    $envVariable = $this->envVariable($tenantId);
+    $warnings = [];
+    if ((string) getenv($envVariable) === '') {
+      $warnings[] = sprintf(
+        'Set %s (base64 of 32 random bytes) in the host environment and restart before CPR can be stored for this tenant.',
+        $envVariable,
+      );
+    }
+
+    if ($created !== []) {
+      $this->logger->info('Provisioned tenant @id: @changes', [
+        '@id' => $tenantId,
+        '@changes' => implode('; ', $created),
+      ]);
+    }
+
+    return [
+      'tenant_id' => $tenantId,
+      'hostname' => $hostname,
+      'env_variable' => $envVariable,
+      'created' => $created,
+      'existing' => $existing,
+      'warnings' => $warnings,
+    ];
+  }
+
+  /**
+   * Reports the provisioning state of a tenant without changing anything.
+   *
+   * @param string $tenantId
+   *   The tenant id.
+   *
+   * @return array
+   *   Keys: tenant_id, env_variable, domain (bool), key (bool), profile
+   *   (bool), env_set (bool), complete (bool). "complete" is TRUE when all
+   *   three config entities exist AND the key env variable is set.
+   */
+  public function describe(string $tenantId): array {
+    $tenantId = $this->assertCanonicalId($tenantId);
+    $domain = $this->storage('domain')->load($tenantId) !== NULL;
+    $key = $this->storage('key')->load($this->keyId($tenantId)) !== NULL;
+    $profile = $this->storage('encryption_profile')->load($this->profileId($tenantId)) !== NULL;
+    $envVariable = $this->envVariable($tenantId);
+    $envSet = (string) getenv($envVariable) !== '';
+    return [
+      'tenant_id' => $tenantId,
+      'env_variable' => $envVariable,
+      'domain' => $domain,
+      'key' => $key,
+      'profile' => $profile,
+      'env_set' => $envSet,
+      'complete' => $domain && $key && $profile && $envSet,
+    ];
+  }
+
+  /**
+   * Load-or-create the Domain record for the tenant.
+   */
+  private function provisionDomain(string $tenantId, string $label, string $hostname, array &$created, array &$existing): void {
+    $storage = $this->storage('domain');
+    if ($storage->load($tenantId) !== NULL) {
+      $existing[] = 'domain.record.' . $tenantId;
+      return;
+    }
+    // Guard against a hostname already registered to a different tenant, which
+    // would otherwise surface as an opaque ConfigValueException on save.
+    if (method_exists($storage, 'loadByHostname')) {
+      $clash = $storage->loadByHostname($hostname);
+      if ($clash !== NULL) {
+        throw new \RuntimeException(sprintf(
+          'The hostname %s is already registered to tenant %s.',
+          $hostname,
+          $clash->id(),
+        ));
+      }
+    }
+    try {
+      $storage->create([
+        'id' => $tenantId,
+        'hostname' => $hostname,
+        'name' => $label,
+        'scheme' => 'https',
+        'status' => 1,
+      ])->save();
+    }
+    catch (ConfigValueException $e) {
+      throw new \RuntimeException(sprintf(
+        'Could not create the domain for tenant %s: %s',
+        $tenantId,
+        $e->getMessage(),
+      ), 0, $e);
+    }
+    $created[] = 'domain.record.' . $tenantId;
+  }
+
+  /**
+   * Load-or-create the per-tenant CPR key (env provider, no secret in config).
+   */
+  private function provisionKey(string $tenantId, string $label, array &$created, array &$existing): void {
+    $storage = $this->storage('key');
+    $keyId = $this->keyId($tenantId);
+    if ($storage->load($keyId) !== NULL) {
+      $existing[] = 'key.key.' . $keyId;
+      return;
+    }
+    $storage->create([
+      'id' => $keyId,
+      'label' => 'CPR ' . $label,
+      'description' => 'Per-tenant CPR encryption key, read from the ' . $this->envVariable($tenantId) . ' environment variable.',
+      'key_type' => 'encryption',
+      'key_type_settings' => ['key_size' => 256],
+      'key_provider' => 'env',
+      'key_provider_settings' => [
+        'env_variable' => $this->envVariable($tenantId),
+        'base64_encoded' => TRUE,
+        'strip_line_breaks' => TRUE,
+      ],
+      'key_input' => 'none',
+      'key_input_settings' => [],
+    ])->save();
+    $created[] = 'key.key.' . $keyId;
+  }
+
+  /**
+   * Load-or-create the per-tenant encryption profile CprAccess resolves.
+   */
+  private function provisionProfile(string $tenantId, string $label, array &$created, array &$existing): void {
+    $storage = $this->storage('encryption_profile');
+    $profileId = $this->profileId($tenantId);
+    if ($storage->load($profileId) !== NULL) {
+      $existing[] = 'encrypt.profile.' . $profileId;
+      return;
+    }
+    $storage->create([
+      'id' => $profileId,
+      'label' => 'AabenForms AES-256 ' . $label,
+      'encryption_method' => 'real_aes',
+      'encryption_method_configuration' => ['mode' => 'cbc'],
+      'encryption_key' => $this->keyId($tenantId),
+    ])->save();
+    $created[] = 'encrypt.profile.' . $profileId;
+  }
+
+  /**
+   * Validates and returns the canonical tenant id.
+   */
+  private function assertCanonicalId(string $tenantId): string {
+    $tenantId = trim($tenantId);
+    $canonical = preg_replace('/[^a-z0-9_]/', '', strtolower($tenantId));
+    if ($tenantId === '' || $tenantId !== $canonical) {
+      throw new \InvalidArgumentException(sprintf(
+        'Tenant id "%s" is invalid; use lowercase letters, digits and underscores only (e.g. aarhus_mtm).',
+        $tenantId,
+      ));
+    }
+    return $tenantId;
+  }
+
+  /**
+   * The key id for a tenant.
+   */
+  private function keyId(string $tenantId): string {
+    return 'cpr_' . $tenantId;
+  }
+
+  /**
+   * The encryption profile id for a tenant (matches CprAccess::tenantProfile).
+   */
+  private function profileId(string $tenantId): string {
+    return self::PROFILE_PREFIX . '_' . $tenantId;
+  }
+
+  /**
+   * The environment variable holding a tenant's CPR key material.
+   */
+  private function envVariable(string $tenantId): string {
+    return self::ENV_PREFIX . strtoupper($tenantId);
+  }
+
+  /**
+   * Returns a config-entity storage handler.
+   */
+  private function storage(string $entityTypeId): EntityStorageInterface {
+    return $this->entityTypeManager->getStorage($entityTypeId);
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantProvisionerTest.php
+++ b/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantProvisionerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_tenant\Kernel;
+
+use Drupal\aabenforms_tenant\Service\TenantProvisioner;
+use Drupal\domain\Entity\Domain;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Proves one-command tenant provisioning wires up CprAccess isolation.
+ *
+ * The provisioner is only correct if the config it creates matches what the
+ * runtime derives: the Domain id must equal the tenant discriminator, and the
+ * encryption profile id must equal CprAccess::tenantProfile(). This test drives
+ * the real provisioner (with the production `env` key provider) and then proves
+ * CPR round-trips for the tenant and CANNOT be revealed by another - so a green
+ * test means a provisioned tenant genuinely isolates CPR.
+ *
+ * @group aabenforms_tenant
+ * @covers \Drupal\aabenforms_tenant\Service\TenantProvisioner
+ */
+class TenantProvisionerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system', 'user', 'field', 'text', 'options', 'node',
+    'key', 'encrypt', 'real_aes',
+    'domain', 'domain_access',
+    'modeler_api', 'eca', 'webform',
+    'aabenforms_core', 'aabenforms_tenant',
+  ];
+
+  /**
+   * The tenant provisioner under test.
+   *
+   * @var \Drupal\aabenforms_tenant\Service\TenantProvisioner
+   */
+  private TenantProvisioner $provisioner;
+
+  /**
+   * Env variables set during a test, cleared in tearDown.
+   *
+   * @var string[]
+   */
+  private array $envVars = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('domain');
+    $this->installConfig(['system', 'field']);
+    $this->provisioner = $this->container->get('aabenforms_tenant.tenant_provisioner');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    foreach ($this->envVars as $name) {
+      putenv($name);
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * Provisioning creates the Domain, key and profile with the exact ids.
+   */
+  public function testProvisionCreatesArtifacts(): void {
+    $result = $this->provisioner->provision(
+      'aarhus_mtm',
+      'Aarhus - Teknik og Miljoe',
+      'mtm.aarhus.aabenforms.test',
+    );
+
+    $this->assertSame('aarhus_mtm', $result['tenant_id']);
+    $this->assertSame('AABENFORMS_CPR_KEY_AARHUS_MTM', $result['env_variable']);
+    $this->assertContains('domain.record.aarhus_mtm', $result['created']);
+    $this->assertContains('key.key.cpr_aarhus_mtm', $result['created']);
+    $this->assertContains('encrypt.profile.aabenforms_aes256_aarhus_mtm', $result['created']);
+
+    $domain = $this->container->get('entity_type.manager')->getStorage('domain')->load('aarhus_mtm');
+    $this->assertNotNull($domain);
+    $this->assertSame('mtm.aarhus.aabenforms.test', $domain->getHostname());
+
+    $key = $this->container->get('entity_type.manager')->getStorage('key')->load('cpr_aarhus_mtm');
+    $this->assertNotNull($key);
+    $this->assertSame('env', $key->get('key_provider'));
+    $this->assertSame('AABENFORMS_CPR_KEY_AARHUS_MTM', $key->get('key_provider_settings')['env_variable']);
+
+    $profile = $this->container->get('entity_type.manager')->getStorage('encryption_profile')->load('aabenforms_aes256_aarhus_mtm');
+    $this->assertNotNull($profile);
+    $this->assertSame('real_aes', $profile->get('encryption_method'));
+    $this->assertSame('cpr_aarhus_mtm', $profile->get('encryption_key'));
+
+    // The env var is not set, so the operator is warned.
+    $this->assertNotEmpty($result['warnings']);
+  }
+
+  /**
+   * A provisioned tenant round-trips CPR; another tenant cannot reveal it.
+   */
+  public function testProvisionEnablesCprIsolation(): void {
+    $this->provisionWithKey('aarhus_mtm', 'Aarhus - Teknik og Miljoe', 'mtm.aarhus.test');
+    $this->provisionWithKey('aarhus_mbu', 'Aarhus - Boern og Unge', 'mbu.aarhus.test');
+    $cpr = $this->container->get('aabenforms_core.cpr_access');
+
+    $this->setActiveDomain('aarhus_mtm');
+    $ciphertext = $cpr->protect('2506924015');
+    $this->assertStringStartsWith('AFENC2:aarhus_mtm:', $ciphertext);
+    $this->assertSame('2506924015', $cpr->reveal($ciphertext), 'Same-tenant reveal works.');
+
+    // From another magistrat the wrong key is used, so the reveal fails.
+    $this->setActiveDomain('aarhus_mbu');
+    $this->assertSame('', $cpr->reveal($ciphertext), 'Cross-tenant CPR decrypt fails.');
+  }
+
+  /**
+   * Re-running provisioning creates nothing and reports the artifacts existing.
+   */
+  public function testProvisionIsIdempotent(): void {
+    $this->provisioner->provision('odense', 'Odense Kommune', 'odense.test');
+    $second = $this->provisioner->provision('odense', 'Odense Kommune', 'odense.test');
+
+    $this->assertSame([], $second['created'], 'A second provision creates nothing.');
+    $this->assertContains('domain.record.odense', $second['existing']);
+    $this->assertContains('key.key.cpr_odense', $second['existing']);
+    $this->assertContains('encrypt.profile.aabenforms_aes256_odense', $second['existing']);
+  }
+
+  /**
+   * A hostname already owned by another tenant is rejected clearly.
+   */
+  public function testDuplicateHostnameRejected(): void {
+    $this->provisioner->provision('aarhus', 'Aarhus Kommune', 'shared.test');
+    $this->expectException(\RuntimeException::class);
+    $this->provisioner->provision('odense', 'Odense Kommune', 'shared.test');
+  }
+
+  /**
+   * A non-canonical tenant id is rejected before anything is created.
+   */
+  public function testInvalidTenantIdRejected(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->provisioner->provision('Aarhus.MTM', 'Aarhus', 'x.test');
+  }
+
+  /**
+   * Provisions a tenant and sets its CPR key env var to real key material.
+   */
+  private function provisionWithKey(string $tenantId, string $label, string $hostname): void {
+    $envVar = 'AABENFORMS_CPR_KEY_' . strtoupper($tenantId);
+    putenv($envVar . '=' . base64_encode(random_bytes(32)));
+    $this->envVars[] = $envVar;
+    $this->provisioner->provision($tenantId, $label, $hostname);
+  }
+
+  /**
+   * Sets the active domain (the "current tenant").
+   */
+  private function setActiveDomain(string $id): void {
+    $this->container->get('domain.negotiator')->setActiveDomain(Domain::load($id));
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantProvisionerTest.php
+++ b/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantProvisionerTest.php
@@ -73,6 +73,10 @@ class TenantProvisionerTest extends KernelTestBase {
    * Provisioning creates the Domain, key and profile with the exact ids.
    */
   public function testProvisionCreatesArtifacts(): void {
+    // Ensure a clean env for the "warns when key unset" assertion below; a
+    // local multi-tenant demo may export this variable into the test process.
+    putenv('AABENFORMS_CPR_KEY_AARHUS_MTM');
+    $this->envVars[] = 'AABENFORMS_CPR_KEY_AARHUS_MTM';
     $result = $this->provisioner->provision(
       'aarhus_mtm',
       'Aarhus - Teknik og Miljoe',


### PR DESCRIPTION
## What

Stand up a tenant (kommune **or magistrat**) in one command:

```bash
drush aabenforms:tenant:provision aarhus_mtm "Aarhus - Teknik og Miljoe" \
  --hostname=mtm.aarhus.aabenforms.dk
```

This creates the three config entities a tenant needs so cases + CPR are
isolated, in the exact shape the runtime expects:

1. **Domain** `domain.record.<id>` - so `TenantResolver::getCurrentTenantId()`
   resolves it and `aabenforms_tenant` stamps/filters `tenant_id`.
2. **Key** `key.key.cpr_<id>` - `env` provider `AABENFORMS_CPR_KEY_<TENANT>`.
3. **EncryptionProfile** `aabenforms_aes256_<id>` - built the same way
   `CprAccess::tenantProfile()` derives it, so CPR encryption lines up instead
   of failing closed.

All idempotent (load-or-create), so re-running is safe.

## Why

Provisioning by hand is fragile: the profile id must match
`CprAccess::tenantProfile()` exactly, or CPR encryption fails closed
(submissions rejected); a shared key silently breaks cross-tenant isolation.
And a tenant need not be a whole kommune - in a magistratsstyre like Aarhus,
each magistrat is its own subdomain tenant.

## Design decisions

- **Key material = `env` provider, one variable per tenant** - the provisioner
  creates only config, never secret material. Key stays off git and off the
  database (a DB dump alone can never yield plaintext CPR). Command reports the
  variable to set and warns while it is empty.
- **Granularity = one Domain per magistrat on its own hostname** - works with
  the current hostname-based resolver unchanged. Sub-path resolution is noted
  as a future extension.

## Finesse

- Admin **Provision tenant** form at `/admin/config/aabenforms/tenant/provision`
  (local action on the tenant settings page).
- **Tenants** dashboard card: hidden in single-tenant demo mode, `warning`
  badge when any tenant is missing its key/profile, tracks pending key env vars.
- `--dry-run` previews what would be created.

## Verification

- 14 `aabenforms_tenant` kernel tests green (133 assertions), incl. a new
  `TenantProvisionerTest` that ties provisioning to a live `CprAccess`
  protect/reveal round-trip and proves a second tenant cannot decrypt the
  first's CPR.
- phpcs clean under the CI standard (`--standard=Drupal`); PHPStan consistent
  with the module baseline (tolerant in CI).
- Live on DDEV: dry-run, provision, idempotent re-run, and a CPR round-trip
  under `AFENC2:aarhus_mtm:` with the env key set. Verification entities cleaned
  up (demo returns to 0 domains).
- Fixes README/CLAUDE docs that referenced a non-existent `drush domain:create`.

Stacked on #182 (base `feature/high-fixes-resilience`); retargets to main when
that merges.
