### PR TITLE
Bind users to their tenant and enforce it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,14 @@ ddev drush aabenforms:tenant:provision odense "Odense Kommune" \
 # 127.0.0.1 odense.aabenforms.ddev.site
 ```
 
+Isolation follows the host by default. To pin a caseworker to their own
+kommune (so they cannot see another tenant even by visiting its host), bind
+them via the `domain_access` "Domain Access" field (`field_domain_access`) on
+`/user/{id}/edit`, or auto-bind from a login claim mapped under
+`/admin/config/aabenforms/tenant`. A bound user gets an empty inbox, denied
+records, and a 403 on foreign-host case pages; unbound users and
+`bypass tenant isolation` operators are unaffected.
+
 ## Workflow Development
 
 The visual editor is the **Workflow Modeler** provided by `drupal/modeler` (React Flow /

--- a/web/modules/custom/aabenforms_core/README.md
+++ b/web/modules/custom/aabenforms_core/README.md
@@ -105,6 +105,22 @@ Optional tenant-specific integration configuration is stored at:
 - `aabenforms_core.tenant.aarhus_mtm`
 - `aabenforms_core.tenant.aarhus_mbu`
 
+#### Per-user tenant binding
+
+By default isolation follows the host: a caseworker sees whichever tenant's data
+belongs to the host they are on. To pin a caseworker to their own kommune so they
+can never see another tenant (even by visiting its host), bind them to one or
+more tenants. The binding reuses the `domain_access` **Domain Access** field
+(`field_domain_access`) already on `/user/{id}/edit` - the same pattern the OS2
+`os2udoglaer` project uses. A bound caseworker gets an empty inbox, denied
+records, and a 403 on the case pages of any host that is not theirs; unbound
+users keep the host-based behavior and `bypass tenant isolation` operators see
+across.
+
+Bindings can be set manually on the user form, or auto-applied at login: under
+`/admin/config/aabenforms/tenant` map a login claim (e.g. `cvr`) to a tenant id.
+A CVR claim identifies a whole kommune, so magistrat-level binding stays manual.
+
 ## Usage
 
 ### ServiceplatformenClient

--- a/web/modules/custom/aabenforms_core/src/Identity/VerifiedIdentity.php
+++ b/web/modules/custom/aabenforms_core/src/Identity/VerifiedIdentity.php
@@ -56,6 +56,9 @@ final class VerifiedIdentity {
    *   The asserting IdP entity id / issuer, when known.
    * @param int|null $authTime
    *   The authentication instant as a Unix timestamp, when known.
+   * @param string|null $cvr
+   *   The organisation CVR, when a business/employee (NemLog-in Erhverv) login
+   *   issues it. Used for tenant auto-binding (kommune-granularity).
    */
   public function __construct(
     public readonly string $cpr,
@@ -69,6 +72,7 @@ final class VerifiedIdentity {
     public readonly ?string $email = NULL,
     public readonly ?string $issuer = NULL,
     public readonly ?int $authTime = NULL,
+    public readonly ?string $cvr = NULL,
   ) {}
 
   /**
@@ -129,6 +133,7 @@ final class VerifiedIdentity {
       'birthdate' => $this->birthdate,
       'email' => $this->email,
       'issuer' => $this->issuer,
+      'cvr' => $this->cvr,
     ];
     foreach ($optional as $key => $value) {
       if ($value !== NULL && $value !== '') {
@@ -163,6 +168,7 @@ final class VerifiedIdentity {
       email: $session['email'] ?? NULL,
       issuer: $session['issuer'] ?? NULL,
       authTime: isset($session['authenticated_at']) ? (int) $session['authenticated_at'] : NULL,
+      cvr: $session['cvr'] ?? NULL,
     );
   }
 

--- a/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSamlAuthenticator.php
+++ b/web/modules/custom/aabenforms_nemlogin/src/Service/NemloginSamlAuthenticator.php
@@ -44,6 +44,14 @@ class NemloginSamlAuthenticator implements IdentityProviderInterface {
   public const ATTR_ALIAS = 'https://data.gov.dk/model/core/eid/alias';
 
   /**
+   * NemLog-in Erhverv (professional) CVR attribute (OIOSAML 3), when present.
+   *
+   * Only issued for a business/employee login; used for tenant auto-binding at
+   * kommune granularity. Enrollment-dependent - absent for citizen MitID.
+   */
+  public const ATTR_CVR = 'https://data.gov.dk/model/core/eid/professional/cvr';
+
+  /**
    * NSIS Level-of-Assurance attribute and its value URIs (OIOSAML 3).
    */
   public const ATTR_NSIS_LOA = 'https://data.gov.dk/concept/core/nsis/loa';
@@ -213,6 +221,7 @@ class NemloginSamlAuthenticator implements IdentityProviderInterface {
       email: $this->first($attributes, self::ATTR_EMAIL) ?: NULL,
       issuer: (string) ($this->configFactory->get('aabenforms_nemlogin.settings')->get('idp_entity_id') ?: '') ?: NULL,
       authTime: NULL,
+      cvr: $this->first($attributes, self::ATTR_CVR) ?: NULL,
     );
   }
 

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.module
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.module
@@ -87,6 +87,15 @@ function aabenforms_tenant_entity_access(EntityInterface $entity, $operation, Ac
   if ($owner === '' || $account->hasPermission('bypass tenant isolation')) {
     return AccessResult::neutral()->cachePerPermissions();
   }
+  // Per-user binding: a user bound to a set of tenants (via field_domain_access)
+  // may never see a row owned by a tenant outside that set, on any host.
+  $bound = _aabenforms_tenant_user_domains($account);
+  if ($bound !== NULL && !in_array($owner, $bound, TRUE)) {
+    return AccessResult::forbidden('User is not a member of this tenant.')
+      ->cachePerPermissions()
+      ->addCacheContexts(['user', 'url.site'])
+      ->addCacheableDependency($entity);
+  }
   $current = \Drupal::service('aabenforms_core.tenant_resolver')->getCurrentTenantId();
   if ($current !== NULL && $owner !== $current) {
     return AccessResult::forbidden('Cross-tenant access denied.')
@@ -133,6 +142,13 @@ function _aabenforms_tenant_scope_query(AlterableInterface $query, string $entit
   if ($current === NULL) {
     return;
   }
+  // Per-user binding: a bound user on a host whose tenant is not in their set
+  // sees nothing (empty inbox / JSON:API listing).
+  $bound = _aabenforms_tenant_user_domains(\Drupal::currentUser());
+  if ($bound !== NULL && !in_array($current, $bound, TRUE)) {
+    $query->where('1 = 0');
+    return;
+  }
   $base = \Drupal::entityTypeManager()->getStorage($entity_type_id)->getEntityType()->getBaseTable();
   $alias = NULL;
   foreach ($query->getTables() as $a => $info) {
@@ -152,6 +168,35 @@ function _aabenforms_tenant_scope_query(AlterableInterface $query, string $entit
 }
 
 /**
+ * Returns the tenant (domain) ids a user is bound to, or NULL if unbound.
+ *
+ * The binding reuses the domain_access `field_domain_access` field on the user
+ * (a multi-value reference to the same Domain entities that back tenants), so a
+ * caseworker is pinned to their kommune/magistrat. An unbound user (empty or
+ * absent field) keeps the host-based behavior, and platform operators bypass
+ * isolation entirely via the `bypass tenant isolation` permission.
+ *
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   The account to resolve.
+ *
+ * @return string[]|null
+ *   The bound domain ids, or NULL when the user is not bound to any tenant.
+ */
+function _aabenforms_tenant_user_domains(AccountInterface $account): ?array {
+  $uid = (int) $account->id();
+  if ($uid <= 0) {
+    return NULL;
+  }
+  $user = \Drupal::entityTypeManager()->getStorage('user')->load($uid);
+  if ($user === NULL || !$user->hasField('field_domain_access')) {
+    return NULL;
+  }
+  $ids = array_column($user->get('field_domain_access')->getValue(), 'target_id');
+  $ids = array_values(array_filter(array_map('strval', $ids), static fn (string $v): bool => $v !== ''));
+  return $ids === [] ? NULL : $ids;
+}
+
+/**
  * Implements hook_help().
  */
 function aabenforms_tenant_help(string $route_name, RouteMatchInterface $route_match): ?string {
@@ -160,7 +205,7 @@ function aabenforms_tenant_help(string $route_name, RouteMatchInterface $route_m
       return '<p>' . t('Multi-tenancy support and employee role provisioning for ÅbenForms.') . '</p>';
 
     case 'aabenforms_tenant.settings':
-      return '<p>' . t('Map an OIDC claim from MitID/NemLogin to the AabenForms employee role. When a citizen logs in and the claim is present, the role is granted automatically so they can submit HR webforms.') . '</p>';
+      return '<p>' . t('Map an OIDC claim to the AabenForms employee role, and bind users to their tenant(s) at login. When a user logs in, a matching employee claim grants the role, and a matching tenant-binding claim adds the mapped kommune to their Domain Access so they only see their own tenant.') . '</p>';
   }
   return NULL;
 }
@@ -168,15 +213,27 @@ function aabenforms_tenant_help(string $route_name, RouteMatchInterface $route_m
 /**
  * Implements hook_user_login().
  *
- * Reads MitID/NemLogin claims from the most recent OIDC session and
- * grants the aabenforms_employee role when the configured claim
- * matches. Empty employee_claim_field disables provisioning. The role
- * persists on the user account; revocation isn't automated yet.
+ * Two independent, additive login actions: grant the aabenforms_employee role
+ * from a claim, and bind the user to their tenant(s) from a claim map.
  */
 function aabenforms_tenant_user_login($account): void {
   if (!$account instanceof UserInterface) {
     return;
   }
+  _aabenforms_tenant_provision_employee_role($account);
+  _aabenforms_tenant_autobind_tenants($account);
+}
+
+/**
+ * Grants the aabenforms_employee role when the configured claim matches.
+ *
+ * Empty employee_claim_field disables provisioning. The role persists on the
+ * account; revocation isn't automated yet.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The logging-in user.
+ */
+function _aabenforms_tenant_provision_employee_role(UserInterface $account): void {
   if ($account->hasRole('aabenforms_employee')) {
     return;
   }
@@ -210,6 +267,87 @@ function aabenforms_tenant_user_login($account): void {
       ['@uid' => $account->id(), '@field' => $field],
     );
   }
+}
+
+/**
+ * Binds the user to their tenant(s) from the configured claim->tenant map.
+ *
+ * Additive only: appends any mapped, existing Domain the user is not already a
+ * member of to their field_domain_access (reused as tenant membership). An
+ * empty map disables auto-binding. A CVR claim is kommune-granularity.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The logging-in user.
+ */
+function _aabenforms_tenant_autobind_tenants(UserInterface $account): void {
+  if (!$account->hasField('field_domain_access')) {
+    return;
+  }
+  $claims = _aabenforms_tenant_recent_oidc_claims();
+  if ($claims === NULL) {
+    return;
+  }
+  _aabenforms_tenant_apply_binding_map($account, $claims);
+}
+
+/**
+ * Appends the tenants a claim set maps to onto a user's field_domain_access.
+ *
+ * The pure, testable core of auto-binding: given the login claims, resolve the
+ * configured claim value through the tenant_binding map and append each mapped,
+ * existing Domain the user is not already a member of. Additive; never removes.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The user to bind.
+ * @param array $claims
+ *   The login claim set (as returned by _aabenforms_tenant_recent_oidc_claims).
+ *
+ * @return string[]
+ *   The tenant (domain) ids newly added, empty when nothing changed.
+ */
+function _aabenforms_tenant_apply_binding_map(UserInterface $account, array $claims): array {
+  if (!$account->hasField('field_domain_access')) {
+    return [];
+  }
+  $config = \Drupal::config('aabenforms_tenant.settings');
+  $field = (string) $config->get('tenant_binding.claim_field');
+  $map = $config->get('tenant_binding.map') ?: [];
+  if ($field === '' || $map === []) {
+    return [];
+  }
+  $actual = $claims[$field] ?? NULL;
+  if (!is_string($actual) && !is_numeric($actual)) {
+    return [];
+  }
+  $actual = (string) $actual;
+
+  $wanted = [];
+  foreach ($map as $entry) {
+    if ((string) ($entry['claim_value'] ?? '') === $actual && (string) ($entry['tenant_id'] ?? '') !== '') {
+      $wanted[(string) $entry['tenant_id']] = TRUE;
+    }
+  }
+  if ($wanted === []) {
+    return [];
+  }
+  $existing = array_column($account->get('field_domain_access')->getValue(), 'target_id');
+  $domainStorage = \Drupal::entityTypeManager()->getStorage('domain');
+  $added = [];
+  foreach (array_keys($wanted) as $tenantId) {
+    if (in_array($tenantId, $existing, TRUE) || $domainStorage->load($tenantId) === NULL) {
+      continue;
+    }
+    $account->get('field_domain_access')->appendItem(['target_id' => $tenantId]);
+    $added[] = $tenantId;
+  }
+  if ($added !== []) {
+    $account->save();
+    \Drupal::logger('aabenforms_tenant')->info(
+      'Auto-bound uid @uid to tenant(s) @tenants via claim @field.',
+      ['@uid' => $account->id(), '@tenants' => implode(', ', $added), '@field' => $field],
+    );
+  }
+  return $added;
 }
 
 /**

--- a/web/modules/custom/aabenforms_tenant/aabenforms_tenant.services.yml
+++ b/web/modules/custom/aabenforms_tenant/aabenforms_tenant.services.yml
@@ -4,3 +4,13 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@logger.factory'
+  aabenforms_tenant.tenant_membership_access_check:
+    class: Drupal\aabenforms_tenant\Access\TenantMembershipAccessCheck
+    arguments:
+      - '@aabenforms_core.tenant_resolver'
+    tags:
+      - { name: access_check, applies_to: _aabenforms_tenant_member }
+  aabenforms_tenant.route_subscriber:
+    class: Drupal\aabenforms_tenant\Routing\TenantRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/web/modules/custom/aabenforms_tenant/config/install/aabenforms_tenant.settings.yml
+++ b/web/modules/custom/aabenforms_tenant/config/install/aabenforms_tenant.settings.yml
@@ -6,3 +6,9 @@ employee_provisioning:
   employee_claim_field: ''
   employee_claim_match: equals
   employee_claim_value: ''
+# Auto-bind users to tenants at login: when the configured claim value matches a
+# map entry, the mapped tenant (domain) is appended to the user's
+# field_domain_access. Empty map disables auto-binding (manual assignment only).
+tenant_binding:
+  claim_field: cvr
+  map: {  }

--- a/web/modules/custom/aabenforms_tenant/config/schema/aabenforms_tenant.schema.yml
+++ b/web/modules/custom/aabenforms_tenant/config/schema/aabenforms_tenant.schema.yml
@@ -15,3 +15,22 @@ aabenforms_tenant.settings:
         employee_claim_value:
           type: string
           label: 'Expected claim value'
+    tenant_binding:
+      type: mapping
+      label: 'Auto-bind users to tenants at login'
+      mapping:
+        claim_field:
+          type: string
+          label: 'Claim field carrying the tenant discriminator (e.g. cvr)'
+        map:
+          type: sequence
+          label: 'Claim value to tenant id map'
+          sequence:
+            type: mapping
+            mapping:
+              claim_value:
+                type: string
+                label: 'Claim value'
+              tenant_id:
+                type: string
+                label: 'Tenant (domain) id'

--- a/web/modules/custom/aabenforms_tenant/src/Access/TenantMembershipAccessCheck.php
+++ b/web/modules/custom/aabenforms_tenant/src/Access/TenantMembershipAccessCheck.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_tenant\Access;
+
+use Drupal\aabenforms_core\Service\TenantResolver;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Blocks a tenant-bound user from case admin pages on a foreign tenant host.
+ *
+ * Defense-in-depth on top of the data-layer isolation (entity access + query
+ * alter): a caseworker bound to their kommune who lands on another tenant's
+ * host gets a proper "Access denied" page instead of an empty listing. Unbound
+ * users and `bypass tenant isolation` operators are unaffected.
+ */
+final class TenantMembershipAccessCheck implements AccessInterface {
+
+  public function __construct(
+    private readonly TenantResolver $tenantResolver,
+  ) {
+  }
+
+  /**
+   * Checks whether the account may act within the active tenant.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account to check.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Forbidden when the bound user is on a tenant outside their set.
+   */
+  public function access(AccountInterface $account): AccessResultInterface {
+    if ($account->hasPermission('bypass tenant isolation')) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    $bound = _aabenforms_tenant_user_domains($account);
+    if ($bound === NULL) {
+      // Unbound user: host-based behavior, no route-level restriction.
+      return AccessResult::allowed()->addCacheContexts(['user']);
+    }
+    $current = $this->tenantResolver->getCurrentTenantId();
+    if ($current !== NULL && !in_array($current, $bound, TRUE)) {
+      return AccessResult::forbidden('User is not a member of the active tenant.')
+        ->addCacheContexts(['user', 'url.site']);
+    }
+    return AccessResult::allowed()->addCacheContexts(['user', 'url.site']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/src/Form/TenantSettingsForm.php
+++ b/web/modules/custom/aabenforms_tenant/src/Form/TenantSettingsForm.php
@@ -64,6 +64,26 @@ class TenantSettingsForm extends ConfigFormBase {
       '#default_value' => (string) $config->get('employee_provisioning.employee_claim_value'),
     ];
 
+    $form['tenant_binding'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Tenant binding (auto-bind users at login)'),
+      '#open' => FALSE,
+      '#description' => $this->t('When a user logs in, the claim below is matched against the map. Each matching tenant is added to the user\'s Domain Access, so a caseworker is pinned to their kommune. Binding is additive and never removes tenants. A CVR claim identifies a whole kommune, so magistrat-level binding stays manual. Leave the map empty to disable.'),
+    ];
+    $form['tenant_binding']['claim_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Claim field'),
+      '#description' => $this->t('Session claim carrying the tenant discriminator (e.g. <code>cvr</code>, <code>municipality_code</code>).'),
+      '#default_value' => (string) $config->get('tenant_binding.claim_field'),
+    ];
+    $form['tenant_binding']['binding_map'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Claim value to tenant map'),
+      '#description' => $this->t('One mapping per line as <code>claim-value|tenant-id</code>, e.g. <code>12345678|aarhus_mtm</code>.'),
+      '#default_value' => $this->mapToText($config->get('tenant_binding.map') ?: []),
+      '#rows' => 5,
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -75,8 +95,55 @@ class TenantSettingsForm extends ConfigFormBase {
       ->set('employee_provisioning.employee_claim_field', (string) $form_state->getValue('employee_claim_field'))
       ->set('employee_provisioning.employee_claim_match', (string) $form_state->getValue('employee_claim_match'))
       ->set('employee_provisioning.employee_claim_value', (string) $form_state->getValue('employee_claim_value'))
+      ->set('tenant_binding.claim_field', (string) $form_state->getValue('claim_field'))
+      ->set('tenant_binding.map', $this->textToMap((string) $form_state->getValue('binding_map')))
       ->save();
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Renders the stored claim->tenant map as one "value|tenant" line each.
+   *
+   * @param array $map
+   *   The stored map (list of ['claim_value' => ..., 'tenant_id' => ...]).
+   *
+   * @return string
+   *   The textarea representation.
+   */
+  private function mapToText(array $map): string {
+    $lines = [];
+    foreach ($map as $entry) {
+      $value = (string) ($entry['claim_value'] ?? '');
+      $tenant = (string) ($entry['tenant_id'] ?? '');
+      if ($value !== '' && $tenant !== '') {
+        $lines[] = $value . '|' . $tenant;
+      }
+    }
+    return implode("\n", $lines);
+  }
+
+  /**
+   * Parses "value|tenant" lines into the stored map structure.
+   *
+   * @param string $text
+   *   The textarea value.
+   *
+   * @return array
+   *   A list of ['claim_value' => ..., 'tenant_id' => ...].
+   */
+  private function textToMap(string $text): array {
+    $map = [];
+    foreach (preg_split('/\r\n|\r|\n/', $text) ?: [] as $line) {
+      $line = trim($line);
+      if ($line === '' || !str_contains($line, '|')) {
+        continue;
+      }
+      [$value, $tenant] = array_map('trim', explode('|', $line, 2));
+      if ($value !== '' && $tenant !== '') {
+        $map[] = ['claim_value' => $value, 'tenant_id' => $tenant];
+      }
+    }
+    return $map;
   }
 
 }

--- a/web/modules/custom/aabenforms_tenant/src/Routing/TenantRouteSubscriber.php
+++ b/web/modules/custom/aabenforms_tenant/src/Routing/TenantRouteSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_tenant\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Adds the tenant-membership access requirement to the case admin routes.
+ *
+ * Pairs with TenantMembershipAccessCheck so a bound caseworker visiting the
+ * case inbox / edit / delete pages on a foreign tenant host is hard-blocked
+ * with an Access denied page.
+ */
+final class TenantRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * The case admin routes that must enforce tenant membership.
+   */
+  private const GUARDED_ROUTES = [
+    'entity.aabenforms_case.collection',
+    'entity.aabenforms_case.edit_form',
+    'entity.aabenforms_case.delete_form',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection): void {
+    foreach (self::GUARDED_ROUTES as $name) {
+      $route = $collection->get($name);
+      if ($route !== NULL) {
+        $route->setRequirement('_aabenforms_tenant_member', 'TRUE');
+      }
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantUserBindingTest.php
+++ b/web/modules/custom/aabenforms_tenant/tests/src/Kernel/TenantUserBindingTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_tenant\Kernel;
+
+use Drupal\aabenforms_tenant\Access\TenantMembershipAccessCheck;
+use Drupal\domain\Entity\Domain;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Proves per-user tenant binding pins a caseworker to their kommune.
+ *
+ * A user bound to a tenant (via field_domain_access) sees only that tenant's
+ * cases and ONLY on that tenant's host; on a foreign host the inbox is empty,
+ * records are denied, and the route access check hard-blocks the page. Unbound
+ * users keep today's host-based behavior and bypass operators see across.
+ *
+ * @group aabenforms_tenant
+ */
+class TenantUserBindingTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system', 'user', 'field', 'text', 'options', 'node',
+    'key', 'encrypt', 'real_aes',
+    'domain', 'domain_access',
+    'modeler_api', 'eca', 'webform',
+    'aabenforms_core', 'aabenforms_case', 'aabenforms_tenant',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('domain');
+    $this->installEntitySchema('aabenforms_case');
+    $this->installConfig(['system', 'field']);
+    $this->installConfig(['aabenforms_tenant']);
+
+    Domain::create(['id' => 'aarhus', 'hostname' => 'aarhus.test', 'name' => 'Aarhus'])->save();
+    Domain::create(['id' => 'odense', 'hostname' => 'odense.test', 'name' => 'Odense'])->save();
+
+    // Reuse the domain_access per-user domain field as the tenant binding.
+    FieldStorageConfig::create([
+      'field_name' => 'field_domain_access',
+      'entity_type' => 'user',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'domain'],
+      'cardinality' => -1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_domain_access',
+      'entity_type' => 'user',
+      'bundle' => 'user',
+      'label' => 'Domain Access',
+    ])->save();
+
+    $this->setActiveDomain('aarhus');
+  }
+
+  /**
+   * A bound user sees only their tenant, only on their tenant's host.
+   */
+  public function testBoundUserPinnedToTenant(): void {
+    $this->createUser();
+    $worker = $this->createUser(['view aabenforms_case']);
+    $worker->set('field_domain_access', ['aarhus'])->save();
+
+    [$caseA, $caseB] = $this->seedTwoCases();
+
+    // On the foreign host (odense): bound worker sees neither case, empty query.
+    $this->setActiveDomain('odense');
+    $this->assertFalse($caseA->access('view', $worker), 'Aarhus-bound worker cannot view the Aarhus case from Odense host.');
+    $this->assertFalse($caseB->access('view', $worker), 'Aarhus-bound worker cannot view the Odense case.');
+    $this->assertSame([], $this->visibleCaseIds($worker), 'Bound worker on a foreign host sees an empty inbox.');
+
+    // On their own host (aarhus): they see their case, never Odense's.
+    $this->setActiveDomain('aarhus');
+    $this->assertTrue($caseA->access('view', $worker), 'Aarhus-bound worker sees the Aarhus case on the Aarhus host.');
+    $this->assertFalse($caseB->access('view', $worker), 'Aarhus-bound worker never sees the Odense case.');
+    $this->assertSame([$caseA->id()], array_values($this->visibleCaseIds($worker)), 'Bound worker sees only their own tenant case.');
+  }
+
+  /**
+   * An unbound user keeps the host-based behavior; an operator sees across.
+   */
+  public function testUnboundAndOperatorUnaffected(): void {
+    $this->createUser();
+    $unbound = $this->createUser(['view aabenforms_case']);
+    $operator = $this->createUser(['view aabenforms_case', 'bypass tenant isolation']);
+    [$caseA, $caseB] = $this->seedTwoCases();
+
+    // Unbound worker: today's host behavior (sees the current host's tenant).
+    $this->setActiveDomain('aarhus');
+    $this->assertTrue($caseA->access('view', $unbound), 'Unbound worker sees the current host tenant case.');
+    $this->assertFalse($caseB->access('view', $unbound), 'Unbound worker does not see the other host tenant case.');
+
+    // Operator with the bypass permission sees across tenants.
+    $this->assertTrue($caseB->access('view', $operator), 'Bypass operator sees any tenant.');
+  }
+
+  /**
+   * The login binding map appends the mapped tenant to a matching user.
+   */
+  public function testAutoBindFromClaimMap(): void {
+    $this->config('aabenforms_tenant.settings')
+      ->set('tenant_binding.claim_field', 'cvr')
+      ->set('tenant_binding.map', [['claim_value' => '12345678', 'tenant_id' => 'aarhus']])
+      ->save();
+
+    $this->createUser();
+    $user = $this->createUser();
+    $user->set('field_domain_access', [])->save();
+
+    $added = _aabenforms_tenant_apply_binding_map($user, ['cvr' => '12345678']);
+    $this->assertSame(['aarhus'], $added, 'A matching CVR claim binds the mapped tenant.');
+    $bound = array_column($user->get('field_domain_access')->getValue(), 'target_id');
+    $this->assertContains('aarhus', $bound);
+
+    // Idempotent + non-matching claim leaves the binding unchanged.
+    $this->assertSame([], _aabenforms_tenant_apply_binding_map($user, ['cvr' => '12345678']));
+    $this->assertSame([], _aabenforms_tenant_apply_binding_map($user, ['cvr' => '99999999']));
+  }
+
+  /**
+   * The route access check forbids a bound user on a foreign tenant host.
+   */
+  public function testRouteAccessCheckBlocksForeignHost(): void {
+    $this->createUser();
+    $worker = $this->createUser(['view aabenforms_case']);
+    $worker->set('field_domain_access', ['aarhus'])->save();
+    $check = new TenantMembershipAccessCheck($this->container->get('aabenforms_core.tenant_resolver'));
+
+    $this->setActiveDomain('odense');
+    $this->assertTrue($check->access($worker)->isForbidden(), 'Bound worker is blocked on a foreign host route.');
+
+    $this->setActiveDomain('aarhus');
+    $this->assertTrue($check->access($worker)->isAllowed(), 'Bound worker is allowed on their own host route.');
+
+    // Unbound user is never route-blocked.
+    $unbound = $this->createUser(['view aabenforms_case']);
+    $this->setActiveDomain('odense');
+    $this->assertTrue($check->access($unbound)->isAllowed(), 'Unbound worker is not route-blocked.');
+  }
+
+  /**
+   * Seeds one case per tenant (Aarhus, Odense) and returns them.
+   *
+   * @return \Drupal\aabenforms_case\Entity\AabenformsCase[]
+   *   [caseA (aarhus), caseB (odense)].
+   */
+  private function seedTwoCases(): array {
+    $storage = \Drupal::entityTypeManager()->getStorage('aabenforms_case');
+    $this->setActiveDomain('aarhus');
+    $caseA = $storage->create(['title' => 'Sag A', 'case_type' => 'byggesag']);
+    $caseA->save();
+    $this->setActiveDomain('odense');
+    $caseB = $storage->create(['title' => 'Sag B', 'case_type' => 'friplads']);
+    $caseB->save();
+    return [$caseA, $caseB];
+  }
+
+  /**
+   * The case ids visible to an account through an access-checked query.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account to run the query as.
+   *
+   * @return array
+   *   The visible case ids.
+   */
+  private function visibleCaseIds($account): array {
+    $storage = \Drupal::entityTypeManager()->getStorage('aabenforms_case');
+    $switcher = \Drupal::service('account_switcher');
+    $switcher->switchTo($account);
+    $ids = $storage->getQuery()->accessCheck(TRUE)->sort('id')->execute();
+    $switcher->switchBack();
+    return array_values($ids);
+  }
+
+  /**
+   * Sets the active domain (the "current tenant").
+   */
+  private function setActiveDomain(string $id): void {
+    $negotiator = \Drupal::service('domain.negotiator');
+    // Force the lazy one-time negotiation first; otherwise the next
+    // getActiveDomain() re-negotiates and overwrites this explicit domain with
+    // the default one (setActiveDomain does not set the "negotiated" flag).
+    $negotiator->getActiveDomain();
+    $negotiator->setActiveDomain(Domain::load($id));
+    \Drupal::entityTypeManager()->getAccessControlHandler('aabenforms_case')->resetCache();
+  }
+
+}


### PR DESCRIPTION
## What

Pins a caseworker to their own kommune/magistrat. Until now isolation followed
the **host**: `tenant_id` lives on cases/submissions and the current tenant is
the active Domain, but user accounts were not bound to any tenant - so a
caseworker could read another kommune's data just by visiting its host.

## How

**Binding reuses `field_domain_access`** (the `domain_access` multi-value Domain
reference already on `/user/{id}/edit`) - the same pattern the OS2 **os2udoglaer**
project uses. A user is *bound* when that field is non-empty.

**One rule, three enforcement points** (`aabenforms_tenant`):
1. `hook_entity_access` - a bound user is denied any record whose tenant is
   outside their set.
2. query alter - a bound user on a foreign/out-of-set host gets an **empty**
   listing (covers JSON:API `/cases/inbox` and the admin inbox).
3. `TenantMembershipAccessCheck` + `TenantRouteSubscriber` - a hard **403** on
   the case admin routes when a bound user is on a foreign host.

Unbound users keep today's host-based behavior; `bypass tenant isolation`
operators are unaffected.

**Auto-binding at login** (off by default): a configurable `claim -> tenant` map
on the tenant settings form appends the mapped Domain to `field_domain_access`
at login (additive, never removes). CVR is emitted on the OIDC rail already and
now on the NemLog-in SAML rail too (`ATTR_CVR` + optional `VerifiedIdentity::cvr`).

## Honesty caveats
- A CVR claim identifies a whole **kommune**, so auto-bind is kommune-granularity;
  magistrat-level binding stays manual.
- Auto-bind is additive only (no revoke on claim/role loss).
- SAML CVR extraction is enrollment-dependent (attribute name behind a constant).

## Verification
- 18 `aabenforms_tenant` kernel tests green, incl. new `TenantUserBindingTest`
  (bound isolation on entity + query, unbound unchanged, operator bypass,
  auto-bind map, route 403). Identity/SAML unit tests green. phpcs clean under
  `--standard=Drupal`; PHPStan consistent with the module baseline.
- Live on the running multi-tenant demo: a caseworker bound to `aarhus_mtm`
  (`/user/3/edit` Domain Access) sees their case on `aarhus-mtm.ddev.site`
  (HTTP 200) but gets an empty inbox and **403 Access denied** on
  `odense.ddev.site`.

Follows PRs #182 + #183 (both merged). Branch off main.
