### PR TITLE
School/family foundations: custody, co-signature and dual-guardian Digital Post

### DIFF
--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-0101904521-freja.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-0101904521-freja.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>0101904521</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>0101904521</CPR>\n        <FirstName>Freja</FirstName>\n        <LastName>Nielsen</LastName>\n        <BirthDate>1990-01-01</BirthDate>\n      </Person>\n      <Children>\n        <Child>\n          <CPR>0109182345</CPR>\n          <FirstName>Emil</FirstName>\n          <LastName>Nielsen Andersen</LastName>\n          <BirthDate>2018-09-01</BirthDate>\n          <AddressProtection>false</AddressProtection>\n          <Guardians>\n            <Guardian><CPR>0101904521</CPR><GuardianType>3</GuardianType><FullName>Freja Nielsen</FullName><SameAddress>true</SameAddress></Guardian>\n            <Guardian><CPR>0803755210</CPR><GuardianType>4</GuardianType><FullName>Lars Andersen</FullName><SameAddress>false</SameAddress></Guardian>\n          </Guardians>\n        </Child>\n        <Child>\n          <CPR>2005102345</CPR>\n          <FirstName>Oliver</FirstName>\n          <LastName>Nielsen Andersen</LastName>\n          <BirthDate>2010-05-20</BirthDate>\n          <AddressProtection>false</AddressProtection>\n          <Guardians>\n            <Guardian><CPR>0101904521</CPR><GuardianType>3</GuardianType><FullName>Freja Nielsen</FullName><SameAddress>true</SameAddress></Guardian>\n            <Guardian><CPR>0803755210</CPR><GuardianType>4</GuardianType><FullName>Lars Andersen</FullName><SameAddress>false</SameAddress></Guardian>\n          </Guardians>\n        </Child>\n      </Children>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-0109182345-emil.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-0109182345-emil.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>0109182345</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>0109182345</CPR>\n        <FirstName>Emil</FirstName>\n        <LastName>Nielsen Andersen</LastName>\n        <BirthDate>2018-09-01</BirthDate>\n      </Person>\n      <Children/>\n      <Guardians>\n        <Guardian><CPR>0101904521</CPR><GuardianType>3</GuardianType><FullName>Freja Nielsen</FullName><SameAddress>true</SameAddress></Guardian>\n        <Guardian><CPR>0803755210</CPR><GuardianType>4</GuardianType><FullName>Lars Andersen</FullName><SameAddress>false</SameAddress></Guardian>\n      </Guardians>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-0803755210-lars.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-0803755210-lars.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>0803755210</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>0803755210</CPR>\n        <FirstName>Lars</FirstName>\n        <LastName>Andersen</LastName>\n        <BirthDate>1975-03-08</BirthDate>\n      </Person>\n      <Children>\n        <Child>\n          <CPR>0109182345</CPR>\n          <FirstName>Emil</FirstName>\n          <LastName>Nielsen Andersen</LastName>\n          <BirthDate>2018-09-01</BirthDate>\n          <AddressProtection>false</AddressProtection>\n          <Guardians>\n            <Guardian><CPR>0101904521</CPR><GuardianType>3</GuardianType><FullName>Freja Nielsen</FullName><SameAddress>true</SameAddress></Guardian>\n            <Guardian><CPR>0803755210</CPR><GuardianType>4</GuardianType><FullName>Lars Andersen</FullName><SameAddress>false</SameAddress></Guardian>\n          </Guardians>\n        </Child>\n        <Child>\n          <CPR>2005102345</CPR>\n          <FirstName>Oliver</FirstName>\n          <LastName>Nielsen Andersen</LastName>\n          <BirthDate>2010-05-20</BirthDate>\n          <AddressProtection>false</AddressProtection>\n          <Guardians>\n            <Guardian><CPR>0101904521</CPR><GuardianType>3</GuardianType><FullName>Freja Nielsen</FullName><SameAddress>true</SameAddress></Guardian>\n            <Guardian><CPR>0803755210</CPR><GuardianType>4</GuardianType><FullName>Lars Andersen</FullName><SameAddress>false</SameAddress></Guardian>\n          </Guardians>\n        </Child>\n      </Children>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-1203192345-alma.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-1203192345-alma.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>1203192345</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>1203192345</CPR>\n        <FirstName>Alma</FirstName>\n        <LastName>Hansen</LastName>\n        <BirthDate>2019-03-12</BirthDate>\n      </Person>\n      <Children/>\n      <Guardians>\n        <Guardian><CPR>2506924015</CPR><GuardianType>3</GuardianType><FullName>Sofie Hansen</FullName><SameAddress>true</SameAddress></Guardian>\n      </Guardians>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-1502856234-mikkel.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-1502856234-mikkel.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>1502856234</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>1502856234</CPR>\n        <FirstName>Mikkel</FirstName>\n        <LastName>Jensen</LastName>\n        <BirthDate>1985-02-15</BirthDate>\n      </Person>\n      <Children/>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-2005102345-oliver.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-2005102345-oliver.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>2005102345</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>2005102345</CPR>\n        <FirstName>Oliver</FirstName>\n        <LastName>Nielsen Andersen</LastName>\n        <BirthDate>2010-05-20</BirthDate>\n      </Person>\n      <Children/>\n      <Guardians>\n        <Guardian><CPR>0101904521</CPR><GuardianType>3</GuardianType><FullName>Freja Nielsen</FullName><SameAddress>true</SameAddress></Guardian>\n        <Guardian><CPR>0803755210</CPR><GuardianType>4</GuardianType><FullName>Lars Andersen</FullName><SameAddress>false</SameAddress></Guardian>\n      </Guardians>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/.ddev/mocks/wiremock/mappings/sf6006-cpr-2506924015-sofie.json
+++ b/.ddev/mocks/wiremock/mappings/sf6006-cpr-2506924015-sofie.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/sf6006",
+    "bodyPatterns": [
+      {
+        "contains": "<ns:PNR>2506924015</ns:PNR>"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    },
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <FamilyLookupResponse>\n      <Person>\n        <CPR>2506924015</CPR>\n        <FirstName>Sofie</FirstName>\n        <LastName>Hansen</LastName>\n        <BirthDate>1992-06-25</BirthDate>\n      </Person>\n      <Children>\n        <Child>\n          <CPR>1203192345</CPR>\n          <FirstName>Alma</FirstName>\n          <LastName>Hansen</LastName>\n          <BirthDate>2019-03-12</BirthDate>\n          <AddressProtection>false</AddressProtection>\n          <Guardians>\n            <Guardian><CPR>2506924015</CPR><GuardianType>3</GuardianType><FullName>Sofie Hansen</FullName><SameAddress>true</SameAddress></Guardian>\n          </Guardians>\n        </Child>\n      </Children>\n    </FamilyLookupResponse>\n  </soap:Body>\n</soap:Envelope>"
+  }
+}

--- a/config/sync/aabenforms_case.settings.yml
+++ b/config/sync/aabenforms_case.settings.yml
@@ -13,6 +13,9 @@ frister:
   merudgifter:
     unit: hverdage
     amount: 20
+  skoleskift:
+    unit: hverdage
+    amount: 10
   default:
     unit: hverdage
     amount: 28

--- a/config/sync/aabenforms_core.settings.yml
+++ b/config/sync/aabenforms_core.settings.yml
@@ -5,6 +5,7 @@ serviceplatformen:
     SF1520: 'https://exttest.serviceplatformen.dk/service/CPR/CPRBasicInformation/1'
     SF1530: 'https://exttest.serviceplatformen.dk/service/CVR/CVROnline/1'
     SF1601: 'https://exttest.serviceplatformen.dk/service/DigitalPost/1'
+    SF6006: 'https://exttest.serviceplatformen.dk/service/CPR/FamilieLokal/1'
   certificates:
     cert_path: ''
     key_path: ''

--- a/config/sync/aabenforms_esdh.settings.yml
+++ b/config/sync/aabenforms_esdh.settings.yml
@@ -1,0 +1,9 @@
+active_connector: demo
+# SBSYS (SBSIP REST) live transport - all empty until an operator enrolls.
+# The client secret is held in a drupal:key entry named by sbsys_client_secret_key,
+# never in config/sync. sbsys_templates maps a case type to its SBSIP template id.
+sbsys_base_url: ''
+sbsys_token_url: ''
+sbsys_client_id: ''
+sbsys_client_secret_key: ''
+sbsys_templates: {}

--- a/config/sync/aabenforms_workflows.settings.yml
+++ b/config/sync/aabenforms_workflows.settings.yml
@@ -1,7 +1,8 @@
 require_parent_cpr_match: true
 # Webform ids whose parent approvals additionally require REGISTERED custody
 # of the child (CPR registry check via the family lookup).
-custody_gated_forms: []
+custody_gated_forms:
+  - school_transfer
 # MitID demo mode lets a workflow run without a real session. It must ship OFF:
 # with it on, an identity gate cannot be relied on. Exported here (default FALSE)
 # so a `drush cim` cannot silently change it. Even when ON, MitIdValidateAction

--- a/config/sync/aabenforms_workflows.settings.yml
+++ b/config/sync/aabenforms_workflows.settings.yml
@@ -1,4 +1,7 @@
 require_parent_cpr_match: true
+# Webform ids whose parent approvals additionally require REGISTERED custody
+# of the child (CPR registry check via the family lookup).
+custody_gated_forms: []
 # MitID demo mode lets a workflow run without a real session. It must ship OFF:
 # with it on, an identity gate cannot be relied on. Exported here (default FALSE)
 # so a `drush cim` cannot silently change it. Even when ON, MitIdValidateAction

--- a/config/sync/aabenforms_workflows.settings.yml
+++ b/config/sync/aabenforms_workflows.settings.yml
@@ -3,6 +3,8 @@ require_parent_cpr_match: true
 # of the child (CPR registry check via the family lookup).
 custody_gated_forms:
   - school_transfer
+  - ppr_referral
+  - guardian_consent
 # MitID demo mode lets a workflow run without a real session. It must ship OFF:
 # with it on, an identity gate cannot be relied on. Exported here (default FALSE)
 # so a `drush cim` cannot silently change it. Even when ON, MitIdValidateAction

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -6,6 +6,7 @@ module:
   aabenforms_digital_post: 0
   aabenforms_digital_post_eca: 0
   aabenforms_digital_post_session_inbox: 0
+  aabenforms_institution: 0
   aabenforms_kombit: 0
   aabenforms_mitid: 0
   aabenforms_nemlogin: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -6,6 +6,7 @@ module:
   aabenforms_digital_post: 0
   aabenforms_digital_post_eca: 0
   aabenforms_digital_post_session_inbox: 0
+  aabenforms_esdh: 0
   aabenforms_institution: 0
   aabenforms_kombit: 0
   aabenforms_mitid: 0

--- a/config/sync/eca.eca.guardian_consent_flow.yml
+++ b/config/sync/eca.eca.guardian_consent_flow.yml
@@ -1,0 +1,100 @@
+uuid: 2b7d4e9f-6a1c-4d3f-8b8e-0f2a7c9d1e3f
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_digital_post_eca
+    - aabenforms_institution
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: guardian_consent_flow
+id: guardian_consent_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission guardian_consent'
+    successors:
+      -
+        id: resolve_employee
+        condition: ''
+conditions:
+  gate_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[consent_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[consent_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  resolve_employee:
+    label: 'Bind fagperson fra login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[current-user:mail]'
+      result_token: consent_employee_id
+    successors:
+      -
+        id: institution_lookup
+        condition: gate_employee_ok
+      -
+        id: deny_external
+        condition: gate_employee_deny
+  deny_external:
+    label: 'Afvis: kun for fagpersoner'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: guardian_consent_denied
+      step_label: 'Kun for fagpersoner'
+      message: 'Anmodninger om samtykke kan kun oprettes af skolens eller institutionens medarbejdere.'
+    successors: {  }
+  institution_lookup:
+    label: 'Slå institution op (institutionsregister)'
+    plugin: aabenforms_institution_lookup
+    configuration:
+      institution_number_token: '[webform_submission:values:institution_number:raw]'
+      result_token: consent_institution
+    successors:
+      -
+        id: consent_invite
+        condition: ''
+  consent_invite:
+    label: 'Send samtykkeanmodning (Digital Post)'
+    plugin: aabenforms_send_cosign_invitation
+    configuration:
+      parent_number: '1'
+      cpr_field: parent1_cpr
+      email_field: parent1_email
+      child_name_field: child_name
+      subject_template: 'Samtykke: anmodning fra dit barns institution'
+    successors:
+      -
+        id: audit_requested
+        condition: ''
+  audit_requested:
+    label: 'Samtykke anmodet'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: guardian_consent_requested
+      additional_data_token: '[webform_submission:values:topic:raw]'
+      message_template: 'Samtykkeanmodning sendt til forældremyndighedsindehaveren via Digital Post (én indehaver er tilstrækkelig ved hverdagsbeslutninger, jf. forældreansvarslovens §3).'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.guardian_consent_revocation_flow.yml
+++ b/config/sync/eca.eca.guardian_consent_revocation_flow.yml
@@ -1,0 +1,45 @@
+uuid: 4d9f6a1b-8c3e-4f5b-8d0a-2b4c9e1f3a5b
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: guardian_consent_revocation_flow
+id: guardian_consent_revocation_flow
+weight: null
+template: null
+events:
+  on_update:
+    plugin: 'content_entity:update'
+    configuration:
+      type: 'webform_submission guardian_consent'
+    successors:
+      -
+        id: audit_revoked
+        condition: gate_withdrawn
+conditions:
+  gate_withdrawn:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:consent_status:raw]'
+      right: withdrawn
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  audit_revoked:
+    label: 'Samtykke trukket tilbage (GDPR)'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: guardian_consent_withdrawn
+      additional_data_token: '[webform_submission:values:topic:raw]'
+      message_template: 'Samtykket er trukket tilbage på indehaverens anmodning. Tilbagetrækningen er dokumenteret med tidspunkt, og institutionen skal ophøre med den samtykkebaserede behandling.'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.guardian_consent_revocation_flow.yml
+++ b/config/sync/eca.eca.guardian_consent_revocation_flow.yml
@@ -40,6 +40,6 @@ actions:
     configuration:
       event_type: guardian_consent_withdrawn
       additional_data_token: '[webform_submission:values:topic:raw]'
-      message_template: 'Samtykket er trukket tilbage på indehaverens anmodning. Tilbagetrækningen er dokumenteret med tidspunkt, og institutionen skal ophøre med den samtykkebaserede behandling.'
+      message_template: 'Samtykket er trukket tilbage (registreres ved hver gemning, mens status er trukket tilbage - loggen er tilfoejende bevis, ikke en taeller) på indehaverens anmodning. Tilbagetrækningen er dokumenteret med tidspunkt, og institutionen skal ophøre med den samtykkebaserede behandling.'
       status: success
     successors: {  }

--- a/config/sync/eca.eca.guardian_consent_signed_flow.yml
+++ b/config/sync/eca.eca.guardian_consent_signed_flow.yml
@@ -18,12 +18,20 @@ events:
     plugin: 'content_entity:custom'
     configuration:
       event_id: parent1_approved
-      type: 'webform_submission guardian_consent'
     successors:
       -
         id: audit_signed
-        condition: ''
-conditions: {  }
+        condition: gate_this_form
+conditions:
+  gate_this_form:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:webform:id]'
+      right: guardian_consent
+      operator: equal
+      type: value
+      case: false
 gateways: {  }
 actions:
   audit_signed:

--- a/config/sync/eca.eca.guardian_consent_signed_flow.yml
+++ b/config/sync/eca.eca.guardian_consent_signed_flow.yml
@@ -1,0 +1,37 @@
+uuid: 3c8e5f0a-7b2d-4e4a-9c9f-1a3b8d0e2f4a
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: guardian_consent_signed_flow
+id: guardian_consent_signed_flow
+weight: null
+template: null
+events:
+  on_signed:
+    plugin: 'content_entity:custom'
+    configuration:
+      event_id: parent1_approved
+      type: 'webform_submission guardian_consent'
+    successors:
+      -
+        id: audit_signed
+        condition: ''
+conditions: {  }
+gateways: {  }
+actions:
+  audit_signed:
+    label: 'Samtykke registreret (MitID-underskrevet)'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: guardian_consent_signed
+      additional_data_token: ''
+      message_template: 'Forældremyndighedsindehaveren har underskrevet samtykket med MitID (identitet kontrolleret mod CPR). Samtykket er dokumenteret og kan trækkes tilbage.'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.ppr_consent_join_flow.yml
+++ b/config/sync/eca.eca.ppr_consent_join_flow.yml
@@ -1,0 +1,99 @@
+uuid: 1a6c3d8e-5f0b-4c2e-9a7d-9e1f6b8c0d2e
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - aabenforms_digital_post_eca
+    - aabenforms_kombit
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: ppr_consent_join_flow
+id: ppr_consent_join_flow
+weight: null
+template: null
+events:
+  on_update:
+    plugin: 'content_entity:update'
+    configuration:
+      type: 'webform_submission ppr_referral'
+    successors:
+      -
+        id: find_case
+        condition: gate_join_both
+      -
+        id: find_case
+        condition: gate_join_sole
+conditions:
+  gate_join_both:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:parent1_status:raw][webform_submission:values:parent2_status:raw]'
+      right: completecomplete
+      operator: equal
+      type: value
+      case: false
+  gate_join_sole:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:parent1_status:raw][webform_submission:values:parent2_cpr:raw]'
+      right: complete
+      operator: equal
+      type: value
+      case: false
+  gate_transition_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[ppr_join_transition]'
+      right: success
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  find_case:
+    label: 'Find sagen for indstillingen'
+    plugin: aabenforms_case_find
+    configuration:
+      result_token: ppr_case_id
+    successors:
+      -
+        id: transition_oplyst
+        condition: ''
+  transition_oplyst:
+    label: 'Oplys sag (alle samtykker modtaget)'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[ppr_case_id]'
+      target_status: oplyst
+      log_message: 'Alle forældremyndighedsindehavere har samtykket med MitID (forældremyndighed kontrolleret i CPR-registret).'
+      result_token: ppr_join_transition
+    successors:
+      -
+        id: sf2900_distribute
+        condition: gate_transition_ok
+  sf2900_distribute:
+    label: 'Fordel til PPR (SF2900 fordelingskomponent)'
+    plugin: aabenforms_case_sf2900_distribute
+    configuration:
+      case_id_token: '[ppr_case_id]'
+    successors:
+      -
+        id: audit_distributed
+        condition: ''
+  audit_distributed:
+    label: 'Indstilling sendt til PPR'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: ppr_referral_distributed
+      additional_data_token: ''
+      message_template: 'Samtykke komplet. Indstillingen er fordelt til PPR via fordelingskomponenten; kopi går til Børn og Familie (tværgående mønster).'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.ppr_consent_join_flow.yml
+++ b/config/sync/eca.eca.ppr_consent_join_flow.yml
@@ -42,8 +42,8 @@ conditions:
     plugin: eca_scalar
     configuration:
       negate: false
-      left: '[webform_submission:values:parent1_status:raw][webform_submission:values:parent2_cpr:raw]'
-      right: complete
+      left: '[webform_submission:values:parent1_status:raw][webform_submission:values:guardian_count:raw]'
+      right: complete1
       operator: equal
       type: value
       case: false

--- a/config/sync/eca.eca.ppr_referral_flow.yml
+++ b/config/sync/eca.eca.ppr_referral_flow.yml
@@ -53,12 +53,21 @@ conditions:
       operator: equal
       type: value
       case: false
-  gate_guardians_fail:
+  gate_guardians_pupil:
     plugin: eca_scalar
     configuration:
-      negate: true
+      negate: false
       left: '[ppr_guardians_status]'
-      right: guardians
+      right: pupil
+      operator: equal
+      type: value
+      case: false
+  gate_guardians_none:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[ppr_guardians_status]'
+      right: none
       operator: equal
       type: value
       case: false
@@ -119,13 +128,25 @@ actions:
     configuration:
       child_cpr_token: '[webform_submission:values:child_cpr:raw]'
       result_token: ppr_guardians
+      persist_count_field: guardian_count
     successors:
       -
         id: open_case
         condition: gate_guardians_ok
       -
+        id: deny_pupil_15
+        condition: gate_guardians_pupil
+      -
         id: deny_no_guardians
-        condition: gate_guardians_fail
+        condition: gate_guardians_none
+  deny_pupil_15:
+    label: 'Afvis: den unge er fyldt 15 (eget samtykke)'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: ppr_referral_pupil_15
+      step_label: 'Digital samtykkeindhentning ikke understøttet'
+      message: 'Den unge er fyldt 15 år og modtager selv Digital Post. Samtykke til PPR skal indhentes direkte hos den unge - kontakt PPR om den videre proces.'
+    successors: {  }
   deny_no_guardians:
     label: 'Afvis: forældremyndighed kunne ikke fastlægges'
     plugin: aabenforms_workflow_deny

--- a/config/sync/eca.eca.ppr_referral_flow.yml
+++ b/config/sync/eca.eca.ppr_referral_flow.yml
@@ -1,0 +1,193 @@
+uuid: 0f5b2c7d-4e9a-4b1d-8f6c-8d0e5a7b9c1d
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - aabenforms_digital_post_eca
+    - aabenforms_institution
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: ppr_referral_flow
+id: ppr_referral_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission ppr_referral'
+    successors:
+      -
+        id: resolve_employee
+        condition: ''
+conditions:
+  gate_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[ppr_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[ppr_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_guardians_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[ppr_guardians_status]'
+      right: guardians
+      operator: equal
+      type: value
+      case: false
+  gate_guardians_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[ppr_guardians_status]'
+      right: guardians
+      operator: equal
+      type: value
+      case: false
+  gate_two_guardians:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[ppr_guardians_count]'
+      right: '2'
+      operator: equal
+      type: numeric
+      case: false
+  gate_one_guardian:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[ppr_guardians_count]'
+      right: '2'
+      operator: equal
+      type: numeric
+      case: false
+gateways: {  }
+actions:
+  resolve_employee:
+    label: 'Bind fagperson fra login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[current-user:mail]'
+      result_token: ppr_employee_id
+    successors:
+      -
+        id: institution_lookup
+        condition: gate_employee_ok
+      -
+        id: deny_external
+        condition: gate_employee_deny
+  deny_external:
+    label: 'Afvis: kun for fagpersoner'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: ppr_referral_denied
+      step_label: 'Kun for fagpersoner'
+      message: 'Indstilling til PPR kan kun indsendes af registrerede fagpersoner. Forældre henvises til at kontakte skolen eller dagtilbuddet.'
+    successors: {  }
+  institution_lookup:
+    label: 'Slå institution op (institutionsregister)'
+    plugin: aabenforms_institution_lookup
+    configuration:
+      institution_number_token: '[webform_submission:values:institution_number:raw]'
+      result_token: ppr_institution
+    successors:
+      -
+        id: resolve_guardians
+        condition: ''
+  resolve_guardians:
+    label: 'Find forældremyndighedsindehavere (CPR-registret)'
+    plugin: aabenforms_resolve_guardians
+    configuration:
+      child_cpr_token: '[webform_submission:values:child_cpr:raw]'
+      result_token: ppr_guardians
+    successors:
+      -
+        id: open_case
+        condition: gate_guardians_ok
+      -
+        id: deny_no_guardians
+        condition: gate_guardians_fail
+  deny_no_guardians:
+    label: 'Afvis: forældremyndighed kunne ikke fastlægges'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: ppr_referral_no_guardians
+      step_label: 'Forældremyndighed ikke fastlagt'
+      message: 'Forældremyndighedsindehaverne kunne ikke fastlægges i CPR-registret. Indstillingen kan ikke behandles digitalt - kontakt PPR direkte.'
+    successors: {  }
+  open_case:
+    label: 'Åbn sag (PPR-indstilling)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: ppr_referral
+      case_id_token: case_id
+    successors:
+      -
+        id: journal_case
+        condition: ''
+  journal_case:
+    label: 'Journalisér sag (SF1470)'
+    plugin: aabenforms_case_journal
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
+      -
+        id: consent_invite_1
+        condition: ''
+  consent_invite_1:
+    label: 'Samtykke: indehaver 1 (parallel, Digital Post)'
+    plugin: aabenforms_send_cosign_invitation
+    configuration:
+      parent_number: '1'
+      cpr_field: parent1_cpr
+      email_field: parent1_email
+      child_name_field: child_name
+      subject_template: 'Samtykke: indstilling af dit barn til PPR'
+    successors:
+      -
+        id: consent_invite_2
+        condition: gate_two_guardians
+      -
+        id: audit_awaiting
+        condition: gate_one_guardian
+  consent_invite_2:
+    label: 'Samtykke: indehaver 2 (parallel, Digital Post)'
+    plugin: aabenforms_send_cosign_invitation
+    configuration:
+      parent_number: '2'
+      cpr_field: parent2_cpr
+      email_field: parent2_email
+      child_name_field: child_name
+      subject_template: 'Samtykke: indstilling af dit barn til PPR'
+    successors:
+      -
+        id: audit_awaiting
+        condition: ''
+  audit_awaiting:
+    label: 'Afventer forældresamtykke'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: ppr_awaiting_consent
+      additional_data_token: '[ppr_guardians_count]'
+      message_template: 'Parallelle samtykkeanmodninger sendt til forældremyndighedsindehaverne via Digital Post. Indstillingen sendes til PPR, når alle har samtykket.'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.skoleskift_cosign_flow.yml
+++ b/config/sync/eca.eca.skoleskift_cosign_flow.yml
@@ -1,0 +1,56 @@
+uuid: 8d3f0a5b-2c7e-4f9b-8d4a-6b8c3e5f7a9b
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: skoleskift_cosign_flow
+id: skoleskift_cosign_flow
+weight: null
+template: null
+events:
+  on_cosign:
+    plugin: 'content_entity:custom'
+    configuration:
+      event_id: parent2_approved
+      type: 'webform_submission school_transfer'
+    successors:
+      -
+        id: find_case
+        condition: ''
+conditions:
+  gate_case_found:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[skoleskift_case_id_status]'
+      right: found
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  find_case:
+    label: 'Find sagen for ansøgningen'
+    plugin: aabenforms_case_find
+    configuration:
+      result_token: skoleskift_case_id
+    successors:
+      -
+        id: audit_cosign
+        condition: gate_case_found
+  audit_cosign:
+    label: 'Medunderskrift modtaget - klar til skoleleders vurdering'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: skoleskift_cosign_complete
+      additional_data_token: ''
+      message_template: 'Den anden forældremyndighedsindehaver har medunderskrevet med MitID (identitet og forældremyndighed kontrolleret). Sagen er klar til skoleleders vurdering.'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.skoleskift_cosign_flow.yml
+++ b/config/sync/eca.eca.skoleskift_cosign_flow.yml
@@ -19,12 +19,20 @@ events:
     plugin: 'content_entity:custom'
     configuration:
       event_id: parent2_approved
-      type: 'webform_submission school_transfer'
     successors:
       -
         id: find_case
-        condition: ''
+        condition: gate_this_form
 conditions:
+  gate_this_form:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:webform:id]'
+      right: school_transfer
+      operator: equal
+      type: value
+      case: false
   gate_case_found:
     plugin: eca_scalar
     configuration:

--- a/config/sync/eca.eca.skoleskift_decision_flow.yml
+++ b/config/sync/eca.eca.skoleskift_decision_flow.yml
@@ -23,10 +23,10 @@ events:
       type: 'webform_submission school_transfer'
     successors:
       -
-        id: find_case
+        id: resolve_caseworker
         condition: gate_approved
       -
-        id: find_case
+        id: resolve_caseworker
         condition: gate_rejected
 conditions:
   gate_approved:
@@ -47,12 +47,21 @@ conditions:
       operator: equal
       type: value
       case: false
-  gate_case_found:
+  gate_caseworker_ok:
     plugin: eca_scalar
     configuration:
       negate: false
-      left: '[skoleskift_case_id_status]'
-      right: found
+      left: '[skoleskift_caseworker_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_caseworker_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[skoleskift_caseworker_status]'
+      right: verified
       operator: equal
       type: value
       case: false
@@ -94,6 +103,27 @@ conditions:
       case: false
 gateways: {  }
 actions:
+  resolve_caseworker:
+    label: 'Bekræft at afgørelsen træffes af en sagsbehandler'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[current-user:mail]'
+      result_token: skoleskift_caseworker
+    successors:
+      -
+        id: find_case
+        condition: gate_caseworker_ok
+      -
+        id: deny_unauthorised_decision
+        condition: gate_caseworker_deny
+  deny_unauthorised_decision:
+    label: 'Afvis: afgørelse kræver sagsbehandler'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: skoleskift_unauthorised_decision
+      step_label: 'Afgørelse afvist'
+      message: 'En afgørelse kan kun træffes af en sagsbehandler. Statusfeltet blev ændret uden for sagsbehandlingen, og der er ikke truffet nogen afgørelse.'
+    successors: {  }
   find_case:
     label: 'Find sagen for ansøgningen'
     plugin: aabenforms_case_find

--- a/config/sync/eca.eca.skoleskift_decision_flow.yml
+++ b/config/sync/eca.eca.skoleskift_decision_flow.yml
@@ -1,0 +1,200 @@
+uuid: 9e4a1b6c-3d8f-4a0c-9e5b-7c9d4f6a8b0c
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - aabenforms_digital_post_eca
+    - aabenforms_esdh
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: skoleskift_decision_flow
+id: skoleskift_decision_flow
+weight: null
+template: null
+events:
+  on_update:
+    plugin: 'content_entity:update'
+    configuration:
+      type: 'webform_submission school_transfer'
+    successors:
+      -
+        id: find_case
+        condition: gate_approved
+      -
+        id: find_case
+        condition: gate_rejected
+conditions:
+  gate_approved:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:caseworker_status:raw]'
+      right: approved
+      operator: equal
+      type: value
+      case: false
+  gate_rejected:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:caseworker_status:raw]'
+      right: rejected
+      operator: equal
+      type: value
+      case: false
+  gate_case_found:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[skoleskift_case_id_status]'
+      right: found
+      operator: equal
+      type: value
+      case: false
+  gate_decide_approved:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[skoleskift_case_id_status][webform_submission:values:caseworker_status:raw]'
+      right: foundapproved
+      operator: equal
+      type: value
+      case: false
+  gate_decide_rejected:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[skoleskift_case_id_status][webform_submission:values:caseworker_status:raw]'
+      right: foundrejected
+      operator: equal
+      type: value
+      case: false
+  gate_recipients_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[post_recipients_status]'
+      right: none
+      operator: equal
+      type: value
+      case: false
+  gate_recipients_none:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[post_recipients_status]'
+      right: none
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  find_case:
+    label: 'Find sagen for ansøgningen'
+    plugin: aabenforms_case_find
+    configuration:
+      result_token: skoleskift_case_id
+    successors:
+      -
+        id: decide_bevilget
+        condition: gate_decide_approved
+      -
+        id: decide_afslag
+        condition: gate_decide_rejected
+  decide_bevilget:
+    label: 'Afgørelse: skoleskift bevilget'
+    plugin: aabenforms_case_decide
+    configuration:
+      case_id_token: '[skoleskift_case_id]'
+      afgoerelse_type: medhold
+      klagevejledning: ''
+      klagefrist_uger: 4
+    successors:
+      -
+        id: resolve_recipients
+        condition: ''
+  decide_afslag:
+    label: 'Afgørelse: afslag på skoleskift'
+    plugin: aabenforms_case_decide
+    configuration:
+      case_id_token: '[skoleskift_case_id]'
+      afgoerelse_type: afslag
+      klagevejledning: 'Du kan klage over afgørelsen. Klagen skal være modtaget senest 4 uger efter, du har fået afgørelsen.'
+      klagefrist_uger: 4
+    successors:
+      -
+        id: resolve_recipients
+        condition: ''
+  resolve_recipients:
+    label: 'Find modtagere (begge forældremyndighedsindehavere)'
+    plugin: aabenforms_resolve_guardians
+    configuration:
+      child_cpr_token: '[webform_submission:values:child_cpr:raw]'
+      result_token: post_recipients
+    successors:
+      -
+        id: letter_recipient_1
+        condition: gate_recipients_ok
+      -
+        id: audit_no_recipients
+        condition: gate_recipients_none
+  audit_no_recipients:
+    label: 'Ingen modtagere - manuel forsendelse'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: skoleskift_no_recipients
+      additional_data_token: ''
+      message_template: 'Modtagerne af afgørelsesbrevet kunne ikke fastlægges i CPR-registret. Brevet skal sendes manuelt, og sagen forbliver åben.'
+      status: failure
+    successors: {  }
+  letter_recipient_1:
+    label: 'Send afgørelsesbrev (indehaver 1)'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[post_recipients_1]'
+      recipient_type: cpr
+      sender_cvr_token: ''
+      subject_template: 'Afgørelse: skoleskift'
+      body_template: '<p>Der er truffet afgørelse i sagen om skoleskift for dit barn. Afgørelsen med begrundelse og klagevejledning fremgår af sagen.</p>'
+      type: 'Digital Post'
+      result_token: skoleskift_letter_1
+    successors:
+      -
+        id: letter_recipient_2
+        condition: ''
+  letter_recipient_2:
+    label: 'Send afgørelsesbrev (indehaver 2)'
+    plugin: aabenforms_digital_post_send
+    configuration:
+      recipient_token: '[post_recipients_2]'
+      recipient_type: cpr
+      sender_cvr_token: ''
+      subject_template: 'Afgørelse: skoleskift'
+      body_template: '<p>Der er truffet afgørelse i sagen om skoleskift for dit barn. Afgørelsen med begrundelse og klagevejledning fremgår af sagen.</p>'
+      type: 'Digital Post'
+      result_token: skoleskift_letter_2
+    successors:
+      -
+        id: set_klagefrist
+        condition: ''
+  set_klagefrist:
+    label: 'Start klagefrist (breve afsendt)'
+    plugin: aabenforms_case_set_klagefrist
+    configuration:
+      case_id_token: '[skoleskift_case_id]'
+      klagefrist_uger: 4
+    successors:
+      -
+        id: esdh_journal
+        condition: ''
+  esdh_journal:
+    label: 'Arkivér i ESDH'
+    plugin: aabenforms_case_esdh_journal
+    configuration:
+      case_id_token: '[skoleskift_case_id]'
+    successors: {  }

--- a/config/sync/eca.eca.skoleskift_flow.yml
+++ b/config/sync/eca.eca.skoleskift_flow.yml
@@ -1,0 +1,233 @@
+uuid: 7c2e9f4a-1b6d-4e8a-9c3f-5a7b2d4e6f8a
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - aabenforms_digital_post_eca
+    - aabenforms_institution
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: skoleskift_flow
+id: skoleskift_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission school_transfer'
+    successors:
+      -
+        id: mitid_validate
+        condition: ''
+conditions:
+  gate_mitid_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[skoleskift_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_mitid_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[skoleskift_mitid_valid_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_custody_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[skoleskift_custody]'
+      right: 'true'
+      operator: equal
+      type: value
+      case: false
+  gate_custody_fail:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[skoleskift_custody]'
+      right: 'true'
+      operator: equal
+      type: value
+      case: false
+  gate_sole:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:custody_status:raw]'
+      right: sole
+      operator: equal
+      type: value
+      case: false
+  gate_joint_agreed:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:custody_status:raw]'
+      right: joint_agreed
+      operator: equal
+      type: value
+      case: false
+  gate_joint_disagreed:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[webform_submission:values:custody_status:raw]'
+      right: joint_disagreed
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  mitid_validate:
+    label: 'Validér MitID-session'
+    plugin: aabenforms_mitid_validate
+    configuration:
+      workflow_id_token: workflow_id_skoleskift
+      result_token: skoleskift_mitid_valid
+      session_data_token: skoleskift_session
+    successors:
+      -
+        id: custody_verify
+        condition: gate_mitid_ok
+      -
+        id: deny_identity
+        condition: gate_mitid_deny
+  deny_identity:
+    label: 'Afvis: identitet ikke bekræftet'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: skoleskift_denied
+      step_label: 'Identitet ikke bekræftet'
+      message: 'Ansøgningen blev ikke behandlet, fordi din identitet ikke kunne bekræftes med MitID. Log ind med MitID og prøv igen.'
+    successors: {  }
+  custody_verify:
+    label: 'Kontrollér forældremyndighed (CPR-registret)'
+    plugin: aabenforms_custody_verify
+    configuration:
+      adult_cpr_token: '[webform_submission:values:applicant_cpr:raw]'
+      child_cpr_token: '[webform_submission:values:child_cpr:raw]'
+      result_token: skoleskift_custody
+    successors:
+      -
+        id: open_case
+        condition: gate_custody_ok
+      -
+        id: deny_custody
+        condition: gate_custody_fail
+  deny_custody:
+    label: 'Afvis: ingen registreret forældremyndighed'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: skoleskift_no_custody
+      step_label: 'Forældremyndighed ikke bekræftet'
+      message: 'Ansøgningen blev ikke behandlet, fordi CPR-registret ikke bekræfter, at du har forældremyndighed over barnet. Kontakt Pladsanvisningen, hvis du mener, det er en fejl.'
+    successors: {  }
+  open_case:
+    label: 'Åbn sag (skoleskift)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: skoleskift
+      case_id_token: case_id
+    successors:
+      -
+        id: journal_case
+        condition: ''
+  journal_case:
+    label: 'Journalisér sag (SF1470)'
+    plugin: aabenforms_case_journal
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
+      -
+        id: institution_lookup
+        condition: ''
+  institution_lookup:
+    label: 'Slå ønsket skole op (institutionsregister)'
+    plugin: aabenforms_institution_lookup
+    configuration:
+      institution_number_token: '[webform_submission:values:target_school:raw]'
+      result_token: target_institution
+    successors:
+      -
+        id: transition_oplyst
+        condition: ''
+  transition_oplyst:
+    label: 'Oplys sag'
+    plugin: aabenforms_case_transition
+    configuration:
+      case_id_token: '[case_id]'
+      target_status: oplyst
+      log_message: 'Sag oplyst: identitet og forældremyndighed bekræftet i CPR-registret, skole slået op.'
+    successors:
+      -
+        id: audit_ready_sole
+        condition: gate_sole
+      -
+        id: cosign_invite
+        condition: gate_joint_agreed
+      -
+        id: partshoering_manual
+        condition: gate_joint_disagreed
+  audit_ready_sole:
+    label: 'Klar til skoleleders vurdering (eneforældremyndighed)'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: skoleskift_awaiting_review
+      additional_data_token: '[target_institution_leader_email]'
+      message_template: 'Eneforældremyndighed bekræftet i CPR. Sagen er klar til vurdering hos skolelederen på den ønskede skole.'
+      status: success
+    successors: {  }
+  cosign_invite:
+    label: 'Send medunderskrift til den anden indehaver (Digital Post)'
+    plugin: aabenforms_send_cosign_invitation
+    configuration:
+      parent_number: '2'
+      cpr_field: parent2_cpr
+      email_field: parent2_email
+      child_name_field: child_name
+      subject_template: 'Medunderskrift: ansøgning om skoleskift'
+    successors:
+      -
+        id: audit_awaiting_cosign
+        condition: ''
+  audit_awaiting_cosign:
+    label: 'Afventer medunderskrift (14 dage)'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: skoleskift_awaiting_cosign
+      additional_data_token: ''
+      message_template: 'Den anden forældremyndighedsindehaver er bedt om medunderskrift via Digital Post. Sagen afventer svar i op til 14 dage.'
+      status: success
+    successors: {  }
+  partshoering_manual:
+    label: 'Åbn partshøring (uenighed om skoleskift)'
+    plugin: aabenforms_case_partshoering
+    configuration:
+      case_id_token: '[case_id]'
+      state: afventer
+    successors:
+      -
+        id: audit_manual
+        condition: ''
+  audit_manual:
+    label: 'Manuel behandling (FOB 2025-9)'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: skoleskift_manual_handling
+      additional_data_token: ''
+      message_template: 'Kendt uenighed mellem forældremyndighedsindehavere. Skoleskift kan ikke gennemføres mod den anden indehavers vilje (FOB 2025-9); sagen overgår til manuel behandling med partshøring.'
+      status: success
+    successors: {  }

--- a/config/sync/eca.eca.underretning_professional_flow.yml
+++ b/config/sync/eca.eca.underretning_professional_flow.yml
@@ -1,0 +1,126 @@
+uuid: 5e0a7b2c-9d4f-4a6c-9e1b-3c5d0f2a4b6c
+langcode: da
+status: true
+dependencies:
+  module:
+    - aabenforms_case
+    - aabenforms_esdh
+    - aabenforms_institution
+    - aabenforms_kombit
+    - aabenforms_workflows
+    - eca_content
+    - modeler_api
+third_party_settings:
+  modeler_api:
+    modeler_id: workflow_modeler
+    label: underretning_professional_flow
+id: underretning_professional_flow
+weight: null
+template: null
+events:
+  on_submission:
+    plugin: 'content_entity:insert'
+    configuration:
+      type: 'webform_submission underretning_professional'
+    successors:
+      -
+        id: resolve_employee
+        condition: ''
+conditions:
+  gate_employee_ok:
+    plugin: eca_scalar
+    configuration:
+      negate: false
+      left: '[und_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+  gate_employee_deny:
+    plugin: eca_scalar
+    configuration:
+      negate: true
+      left: '[und_employee_id_status]'
+      right: verified
+      operator: equal
+      type: value
+      case: false
+gateways: {  }
+actions:
+  resolve_employee:
+    label: 'Bind fagperson fra login'
+    plugin: aabenforms_resolve_employee
+    configuration:
+      submitted_employee_id_token: '[current-user:mail]'
+      result_token: und_employee_id
+    successors:
+      -
+        id: institution_lookup
+        condition: gate_employee_ok
+      -
+        id: deny_external
+        condition: gate_employee_deny
+  deny_external:
+    label: 'Afvis: brug borgerindgangen'
+    plugin: aabenforms_workflow_deny
+    configuration:
+      event_type: underretning_professional_denied
+      step_label: 'Kun for fagpersoner'
+      message: 'Denne indgang er til fagpersoner med skærpet underretningspligt. Borgere kan underrette via den almindelige underretningsformular.'
+    successors: {  }
+  institution_lookup:
+    label: 'Slå institution op (institutionsregister)'
+    plugin: aabenforms_institution_lookup
+    configuration:
+      institution_number_token: '[webform_submission:values:institution_number:raw]'
+      result_token: und_institution
+    successors:
+      -
+        id: open_case
+        condition: ''
+  open_case:
+    label: 'Åbn sag (underretning, 24-timers frist)'
+    plugin: aabenforms_case_open
+    configuration:
+      case_type: underretning
+      case_id_token: case_id
+    successors:
+      -
+        id: journal_case
+        condition: ''
+  journal_case:
+    label: 'Journalisér sag (SF1470)'
+    plugin: aabenforms_case_journal
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
+      -
+        id: esdh_journal
+        condition: ''
+  esdh_journal:
+    label: 'Arkivér i ESDH (familieafdelingens indgang)'
+    plugin: aabenforms_case_esdh_journal
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
+      -
+        id: sf2900_distribute
+        condition: ''
+  sf2900_distribute:
+    label: 'Fordel til familieafdelingen (SF2900)'
+    plugin: aabenforms_case_sf2900_distribute
+    configuration:
+      case_id_token: '[case_id]'
+    successors:
+      -
+        id: audit_received
+        condition: ''
+  audit_received:
+    label: 'Underretning modtaget og fordelt'
+    plugin: aabenforms_audit_log
+    configuration:
+      event_type: underretning_professional_received
+      additional_data_token: '[und_institution_leader_email]'
+      message_template: 'Underretning fra fagperson modtaget, journaliseret og fordelt til familieafdelingen (ingen DUBU-API findes; ESDH/fordeling er den korrekte landingszone). Forældre orienteres ikke af underretteren. 24-timers fristen løber.'
+      status: success
+    successors: {  }

--- a/config/sync/webform.webform.guardian_consent.yml
+++ b/config/sync/webform.webform.guardian_consent.yml
@@ -1,0 +1,247 @@
+uuid: 5b0c3d4e-6f7a-4b8c-9d0e-2f3a4b5c6d7e
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: guardian_consent
+title: 'Samtykke fra forældremyndighedsindehaver'
+description: 'Skolen indhenter et MitID-underskrevet samtykke fra en forældremyndighedsindehaver (hverdagsbeslutning, én indehaver er tilstrækkelig, jf. forældreansvarslovens §3). Erstatter PDF-blanketter. Samtykket kan trækkes tilbage.'
+categories: {  }
+elements: |
+  topic:
+    '#type': textfield
+    '#title': 'Hvad gives der samtykke til'
+    '#required': true
+    '#description': 'F.eks. deltagelse i lejrskole eller deling af oplysninger med PPR.'
+  institution_number:
+    '#type': select
+    '#title': 'Institution'
+    '#required': true
+    '#options':
+      '751101': 'Frederiksbjerg Skole'
+      '751102': 'Katrinebjergskolen'
+      '751103': 'Møllevangskolen'
+      '751104': 'Risskov Skole'
+      '751105': 'Skåde Skole'
+      '751201': 'Børnehuset Solstrålen'
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  child_cpr:
+    '#type': cpr_field
+    '#title': 'Barnets CPR-nummer'
+    '#required': true
+  details:
+    '#type': textarea
+    '#title': 'Uddybning'
+    '#rows': 3
+  parent1_cpr:
+    '#type': cpr_field
+    '#title': 'Forældremyndighedsindehavers CPR'
+    '#required': true
+    '#description': 'Indehaveren modtager anmodningen om samtykke i Digital Post og underskriver med MitID.'
+  parent1_email:
+    '#type': email
+    '#title': 'E-mail (reserve)'
+  parent1_status:
+    '#type': hidden
+    '#default_value': pending
+  parent2_status:
+    '#type': hidden
+    '#default_value': complete
+  caseworker_status:
+    '#type': hidden
+    '#default_value': pending
+  consent_status:
+    '#type': hidden
+    '#default_value': requested
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Anmodningen om samtykke er sendt til forældremyndighedsindehaveren via Digital Post.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.ppr_referral.yml
+++ b/config/sync/webform.webform.ppr_referral.yml
@@ -1,0 +1,256 @@
+uuid: 4a9b2c3d-5e6f-4a7b-8c9d-1e2f3a4b5c6d
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: ppr_referral
+title: 'Indstilling til PPR'
+description: 'Skole eller dagtilbud indstiller et barn til Pædagogisk Psykologisk Rådgivning. Begge forældremyndighedsindehavere samtykker parallelt med MitID via Digital Post, hvorefter sagen fordeles til PPR.'
+categories: {  }
+elements: |
+  referring_name:
+    '#type': textfield
+    '#title': 'Dit navn (fagperson)'
+    '#required': true
+  institution_number:
+    '#type': select
+    '#title': 'Institution'
+    '#required': true
+    '#options':
+      '751101': 'Frederiksbjerg Skole'
+      '751102': 'Katrinebjergskolen'
+      '751103': 'Møllevangskolen'
+      '751104': 'Risskov Skole'
+      '751105': 'Skåde Skole'
+      '751201': 'Børnehuset Solstrålen'
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  child_cpr:
+    '#type': cpr_field
+    '#title': 'Barnets CPR-nummer'
+    '#required': true
+    '#description': 'Forældremyndighedsindehaverne kontrolleres i CPR-registret, og begge skal samtykke.'
+  concern:
+    '#type': textarea
+    '#title': 'Beskrivelse af bekymringen og barnets udfordringer'
+    '#required': true
+    '#rows': 5
+  actions_taken:
+    '#type': textarea
+    '#title': 'Indsatser der allerede er afprøvet'
+    '#required': true
+    '#rows': 3
+  parent1_cpr:
+    '#type': cpr_field
+    '#title': 'Forældremyndighedsindehaver 1 - CPR'
+    '#required': true
+  parent1_email:
+    '#type': email
+    '#title': 'Indehaver 1 - e-mail (reserve)'
+  parent2_cpr:
+    '#type': cpr_field
+    '#title': 'Forældremyndighedsindehaver 2 - CPR'
+    '#description': 'Udelades ved eneforældremyndighed.'
+  parent2_email:
+    '#type': email
+    '#title': 'Indehaver 2 - e-mail (reserve)'
+  parent1_status:
+    '#type': hidden
+    '#default_value': pending
+  parent2_status:
+    '#type': hidden
+    '#default_value': pending
+  caseworker_status:
+    '#type': hidden
+    '#default_value': pending
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Indstillingen er registreret. Den sendes til PPR, når begge forældremyndighedsindehavere har samtykket.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.ppr_referral.yml
+++ b/config/sync/webform.webform.ppr_referral.yml
@@ -61,6 +61,9 @@ elements: |
   parent2_email:
     '#type': email
     '#title': 'Indehaver 2 - e-mail (reserve)'
+  guardian_count:
+    '#type': hidden
+    '#default_value': '0'
   parent1_status:
     '#type': hidden
     '#default_value': pending

--- a/config/sync/webform.webform.school_transfer.yml
+++ b/config/sync/webform.webform.school_transfer.yml
@@ -1,0 +1,278 @@
+uuid: 3f8a1b2c-4d5e-4f6a-8b9c-0d1e2f3a4b5c
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: school_transfer
+title: 'Ansøgning om skoleskift'
+description: 'En forælder søger om at flytte sit barn til en anden folkeskole. MitID-gated med registerbaseret kontrol af forældremyndighed (FOB 2025-9), medunderskrift fra den anden forældremyndighedsindehaver, skoleleder-vurdering og afgørelsesbrev til begge indehavere via Digital Post.'
+categories: {  }
+elements: |
+  workflow_id:
+    '#type': hidden
+  applicant_cpr:
+    '#type': cpr_field
+    '#title': 'Dit CPR-nummer'
+    '#required': true
+    '#description': 'Udfyldes automatisk fra MitID. Krypteres ved modtagelse.'
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  child_cpr:
+    '#type': cpr_field
+    '#title': 'Barnets CPR-nummer'
+    '#required': true
+    '#description': 'Forældremyndighed kontrolleres i CPR-registret.'
+  current_school:
+    '#type': select
+    '#title': 'Nuværende skole'
+    '#required': true
+    '#options':
+      '751101': 'Frederiksbjerg Skole'
+      '751102': 'Katrinebjergskolen'
+      '751103': 'Møllevangskolen'
+      '751104': 'Risskov Skole'
+      '751105': 'Skåde Skole'
+  target_school:
+    '#type': select
+    '#title': 'Ønsket skole'
+    '#required': true
+    '#options':
+      '751101': 'Frederiksbjerg Skole'
+      '751102': 'Katrinebjergskolen'
+      '751103': 'Møllevangskolen'
+      '751104': 'Risskov Skole'
+      '751105': 'Skåde Skole'
+  reason:
+    '#type': textarea
+    '#title': 'Begrundelse for ønsket om skoleskift'
+    '#required': true
+    '#rows': 4
+  custody_status:
+    '#type': radios
+    '#title': 'Forældremyndighed'
+    '#required': true
+    '#options':
+      sole: 'Jeg har forældremyndigheden alene'
+      joint_agreed: 'Fælles forældremyndighed - den anden indehaver er enig i skoleskiftet'
+      joint_disagreed: 'Fælles forældremyndighed - den anden indehaver er uenig, eller jeg ved det ikke'
+    '#description': 'Ved fælles forældremyndighed er skolevalg en væsentlig beslutning, som begge indehavere skal være enige om.'
+  parent2_cpr:
+    '#type': cpr_field
+    '#title': 'Den anden forældremyndighedsindehavers CPR-nummer'
+    '#states':
+      visible:
+        ':input[name="custody_status"]':
+          value: joint_agreed
+      required:
+        ':input[name="custody_status"]':
+          value: joint_agreed
+    '#description': 'Den anden indehaver modtager en anmodning om medunderskrift i Digital Post.'
+  parent2_email:
+    '#type': email
+    '#title': 'Den anden indehavers e-mail (reserve)'
+    '#states':
+      visible:
+        ':input[name="custody_status"]':
+          value: joint_agreed
+    '#description': 'Bruges kun hvis Digital Post ikke kan leveres.'
+  parent1_status:
+    '#type': hidden
+    '#default_value': complete
+  parent2_status:
+    '#type': hidden
+    '#default_value': pending
+  caseworker_status:
+    '#type': hidden
+    '#default_value': pending
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Ansøgningen om skoleskift er modtaget. Du får svar via Digital Post.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.underretning_professional.yml
+++ b/config/sync/webform.webform.underretning_professional.yml
@@ -36,10 +36,14 @@ elements: |
     '#type': textfield
     '#title': 'Barnets navn'
     '#required': true
-  child_birthdate_or_cpr:
+  child_cpr:
+    '#type': cpr_field
+    '#title': 'Barnets CPR-nummer'
+    '#description': 'Krypteres ved modtagelse. Udfyldes hvis kendt.'
+  child_birthdate:
     '#type': textfield
-    '#title': 'Barnets fødselsdato eller CPR-nummer'
-    '#required': true
+    '#title': 'Barnets fødselsdato (hvis CPR ikke kendes)'
+    '#description': 'Format: DD-MM-ÅÅÅÅ.'
   concern:
     '#type': textarea
     '#title': 'Hvad er du bekymret for?'

--- a/config/sync/webform.webform.underretning_professional.yml
+++ b/config/sync/webform.webform.underretning_professional.yml
@@ -1,0 +1,279 @@
+uuid: 6c1d4e5f-7a8b-4c9d-0e1f-3a4b5c6d7e8f
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: underretning_professional
+title: 'Underretning fra fagperson (skærpet underretningspligt)'
+description: 'Fagpersoners underretning efter barnets lov. 24-timers frist, kvittering til underretteren, levering til familieafdelingen via ESDH og fordelingskomponent. Forældre orienteres ikke af underretteren.'
+categories: {  }
+elements: |
+  reporter_name:
+    '#type': textfield
+    '#title': 'Dit navn (fagperson)'
+    '#required': true
+  reporter_email:
+    '#type': email
+    '#title': 'Din e-mail (kvittering)'
+    '#required': true
+  institution_number:
+    '#type': select
+    '#title': 'Institution'
+    '#required': true
+    '#options':
+      '751101': 'Frederiksbjerg Skole'
+      '751102': 'Katrinebjergskolen'
+      '751103': 'Møllevangskolen'
+      '751104': 'Risskov Skole'
+      '751105': 'Skåde Skole'
+      '751201': 'Børnehuset Solstrålen'
+  child_name:
+    '#type': textfield
+    '#title': 'Barnets navn'
+    '#required': true
+  child_birthdate_or_cpr:
+    '#type': textfield
+    '#title': 'Barnets fødselsdato eller CPR-nummer'
+    '#required': true
+  concern:
+    '#type': textarea
+    '#title': 'Hvad er du bekymret for?'
+    '#required': true
+    '#rows': 6
+    '#description': 'Beskriv konkrete observationer. Forældrene orienteres IKKE via denne underretning.'
+  acute:
+    '#type': radios
+    '#title': 'Er situationen akut?'
+    '#required': true
+    '#options':
+      yes_acute: 'Ja - barnet er i akut fare'
+      not_acute: 'Nej'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: message
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: 'Tak. Din underretning er modtaget og behandles inden for 24 timer. Du modtager en kvittering.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  receipt_to_reporter:
+    id: email
+    handler_id: receipt_to_reporter
+    label: 'Kvittering til underretteren'
+    notes: 'Statutory receipt: the professional reporter gets a confirmation with the 24-hour deadline.'
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      states:
+        - completed
+      to_mail: '[webform_submission:values:reporter_email:raw]'
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: _default
+      from_options: {  }
+      from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: 'Kvittering: din underretning er modtaget'
+      body: |
+        <p>Kære [webform_submission:values:reporter_name]</p>
+        <p>Din underretning vedrørende [webform_submission:values:child_name] er modtaget og behandles inden for 24 timer.</p>
+        <p>Denne kvittering er dokumentation for, at du har opfyldt din skærpede underretningspligt.</p>
+      excluded_elements: {  }
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+variants: {  }

--- a/web/modules/custom/aabenforms_case/config/install/aabenforms_case.settings.yml
+++ b/web/modules/custom/aabenforms_case/config/install/aabenforms_case.settings.yml
@@ -11,6 +11,9 @@ frister:
   merudgifter:
     unit: hverdage
     amount: 20
+  skoleskift:
+    unit: hverdage
+    amount: 10
   default:
     unit: hverdage
     amount: 28

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/FindCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/FindCaseAction.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_case\Plugin\Action;
+
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Find the case opened for the current submission.
+ *
+ * Cross-event flows (a co-signature arriving days later, a caseworker
+ * decision on submission update) run in a fresh token environment where the
+ * [case_id] written by the original insert flow no longer exists. This
+ * action re-resolves the case from the submission reference so downstream
+ * case actions (transition, decide, journal) can run in any event context.
+ */
+#[Action(
+  id: 'aabenforms_case_find',
+  label: new TranslatableMarkup('Find Case for Submission'),
+  type: 'entity',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Resolves the case opened for the current webform submission and writes its id to a token.'),
+  version_introduced: '2.1.0',
+)]
+class FindCaseAction extends CaseActionBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'result_token' => 'case_id',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Token receiving the case id. A companion &lt;name&gt;_status carries found or not_found.'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $resultToken = (string) $this->configuration['result_token'];
+    $submission = $this->getSubmission();
+
+    if ($submission === NULL) {
+      $this->setTokenValue($resultToken, '');
+      $this->setTokenValue($resultToken . '_status', 'not_found');
+      $this->recordStep('Find Case', 'Skipped - no webform submission in scope', 'skipped');
+      return;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('aabenforms_case');
+    $ids = $storage->getQuery()
+      ->condition('submission_ref', $submission->id())
+      ->accessCheck(FALSE)
+      ->sort('id', 'DESC')
+      ->range(0, 1)
+      ->execute();
+
+    if ($ids === []) {
+      $this->log('No case found for submission {sid}', ['sid' => $submission->id()], 'warning');
+      $this->setTokenValue($resultToken, '');
+      $this->setTokenValue($resultToken . '_status', 'not_found');
+      $this->recordStep('Find Case', 'No case is registered for this submission', 'failed');
+      return;
+    }
+
+    $caseId = (string) reset($ids);
+    $this->setTokenValue($resultToken, $caseId);
+    $this->setTokenValue($resultToken . '_status', 'found');
+    $this->recordStep('Find Case', sprintf('Case #%s resolved for the submission', $caseId));
+  }
+
+}

--- a/web/modules/custom/aabenforms_case/src/Plugin/Action/TransitionCaseAction.php
+++ b/web/modules/custom/aabenforms_case/src/Plugin/Action/TransitionCaseAction.php
@@ -38,6 +38,7 @@ class TransitionCaseAction extends CaseActionBase {
       'case_id_token' => 'case_id',
       'target_status' => '',
       'log_message' => 'Status ændret.',
+      'result_token' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -68,6 +69,13 @@ class TransitionCaseAction extends CaseActionBase {
       '#required' => TRUE,
     ];
 
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name (optional)'),
+      '#description' => $this->t("When set, the token receives 'success' or 'failed' so a flow can gate follow-up actions on the transition actually happening (idempotent joins)."),
+      '#default_value' => $this->configuration['result_token'],
+    ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -78,6 +86,7 @@ class TransitionCaseAction extends CaseActionBase {
     $this->configuration['case_id_token'] = $form_state->getValue('case_id_token');
     $this->configuration['target_status'] = $form_state->getValue('target_status');
     $this->configuration['log_message'] = $form_state->getValue('log_message');
+    $this->configuration['result_token'] = (string) $form_state->getValue('result_token');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -91,6 +100,7 @@ class TransitionCaseAction extends CaseActionBase {
       $logMessage = (string) ($this->configuration['log_message'] ?? 'Status ændret.');
 
       if ($caseId === '' || $target === '') {
+        $this->setOutcome('failed');
         $this->recordStep('Sagsovergang', 'Mangler sags-id eller målstatus.', 'failed');
         return;
       }
@@ -98,6 +108,7 @@ class TransitionCaseAction extends CaseActionBase {
       $storage = $this->entityTypeManager->getStorage('aabenforms_case');
       $case = $storage->load($caseId);
       if (!$case instanceof AabenformsCase) {
+        $this->setOutcome('failed');
         $this->recordStep('Sagsovergang', sprintf('Sag #%s ikke fundet.', $caseId), 'failed');
         return;
       }
@@ -110,6 +121,7 @@ class TransitionCaseAction extends CaseActionBase {
           'to' => $target,
           'id' => $caseId,
         ], 'warning');
+        $this->setOutcome('failed');
         $this->recordStep(
           'Sagsovergang afvist',
           sprintf('Ulovlig overgang %s -> %s.', $current, $target),
@@ -126,6 +138,7 @@ class TransitionCaseAction extends CaseActionBase {
       $case->setRevisionUserId((int) $this->currentUser->id());
       $case->save();
 
+      $this->setOutcome('success');
       $this->recordStep('Sagsovergang', sprintf('Sag #%s: %s -> %s.', $caseId, $current, $target));
       $this->auditLogger->log(
         'case_transition',
@@ -136,7 +149,21 @@ class TransitionCaseAction extends CaseActionBase {
       );
     }
     catch (\Throwable $e) {
+      $this->setOutcome('failed');
       $this->handleError($e, 'Transition case');
+    }
+  }
+
+  /**
+   * Writes the transition outcome to the optional result token.
+   *
+   * @param string $outcome
+   *   Either 'success' or 'failed'.
+   */
+  protected function setOutcome(string $outcome): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken, $outcome);
     }
   }
 

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -377,7 +377,7 @@ function aabenforms_core_protect_decision_fields(WebformSubmissionInterface $sub
   }
 
   $account = \Drupal::currentUser();
-  if ($account->hasPermission('administer aabenforms workflows') || $account->hasRole('aabenforms_employee')) {
+  if ($account->hasPermission('administer aabenforms decision state') || $account->hasRole('aabenforms_employee')) {
     return;
   }
 
@@ -389,6 +389,13 @@ function aabenforms_core_protect_decision_fields(WebformSubmissionInterface $sub
   // Only guard the CREATE path from a browser/API client. Updates from the
   // citizen approval flow are made by server-side code after the identity,
   // CPR and custody gates have run.
+  //
+  // This is only sufficient because no client-driven UPDATE path exists:
+  // jsonapi.settings ships read_only, and the decision-bearing webforms ship
+  // `draft: none` with prepopulate off, so a citizen cannot re-open a stored
+  // submission and post a new caseworker_status. Both of those are settings
+  // rather than code, so ProtectDecisionFieldsTest asserts them; if either
+  // changes, this guard has to cover updates too.
   if (!$submission->isNew()) {
     return;
   }

--- a/web/modules/custom/aabenforms_core/aabenforms_core.module
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.module
@@ -342,4 +342,73 @@ function aabenforms_core_webform_submission_presave(WebformSubmissionInterface $
       $submission->setElementData($key, $cprAccess->protect($value));
     }
   }
+
+  aabenforms_core_protect_decision_fields($submission);
+}
+
+/**
+ * Keeps decision-state fields out of the submitter's hands.
+ *
+ * Workflow state lives in hidden webform elements (parent<N>_status,
+ * caseworker_status, consent_status) that ECA flows gate on: a caseworker
+ * approval triggers a binding afgoerelse with decision letters. "Hidden" is
+ * a rendering hint, NOT an access control - the API controller and the form
+ * both accept whatever the client posts - so without this guard a citizen
+ * could submit caseworker_status=approved and have the municipality issue a
+ * decision with no review at all.
+ *
+ * The rule: only an authenticated employee (or the CLI/cron, where flows and
+ * drush act on the platform's behalf) may set these fields to a non-default
+ * value. Everyone else has them forced back to the element default. The
+ * legitimate citizen path is untouched, because parent approvals are written
+ * server-side by ParentApprovalForm after the MitID + CPR + custody gates,
+ * running as the same anonymous session but through code, not payload - so
+ * the guard exempts only what the form itself sets on an already-persisted
+ * submission (see $submission->isNew()).
+ *
+ * @param \Drupal\webform\WebformSubmissionInterface $submission
+ *   The submission being saved.
+ */
+function aabenforms_core_protect_decision_fields(WebformSubmissionInterface $submission): void {
+  // Server-side actors (drush, cron, queue workers) are trusted: ECA flows and
+  // the approval form run there and legitimately advance workflow state.
+  if (PHP_SAPI === 'cli') {
+    return;
+  }
+
+  $account = \Drupal::currentUser();
+  if ($account->hasPermission('administer aabenforms workflows') || $account->hasRole('aabenforms_employee')) {
+    return;
+  }
+
+  $webform = $submission->getWebform();
+  if ($webform === NULL) {
+    return;
+  }
+
+  // Only guard the CREATE path from a browser/API client. Updates from the
+  // citizen approval flow are made by server-side code after the identity,
+  // CPR and custody gates have run.
+  if (!$submission->isNew()) {
+    return;
+  }
+
+  $guarded = 0;
+  foreach ($webform->getElementsInitializedAndFlattened() as $key => $element) {
+    if ($key !== 'caseworker_status' && $key !== 'consent_status' && !preg_match('/^parent\d+_status$/', $key)) {
+      continue;
+    }
+    $default = $element['#default_value'] ?? '';
+    if ((string) $submission->getElementData($key) !== (string) $default) {
+      $submission->setElementData($key, $default);
+      $guarded++;
+    }
+  }
+
+  if ($guarded > 0) {
+    \Drupal::logger('aabenforms_core')->warning(
+      'Blocked @count submitter-supplied decision-state field(s) on webform @form; reset to defaults.',
+      ['@count' => $guarded, '@form' => $webform->id()]
+    );
+  }
 }

--- a/web/modules/custom/aabenforms_core/aabenforms_core.permissions.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.permissions.yml
@@ -14,3 +14,8 @@ access employee webform api:
   title: 'Submit AabenForms employee (HR) webforms'
   description: 'Restricts the HR-bundle webforms (hr_onboarding, mileage_expense, phone_declaration) to authenticated users whose MitID/NemLogin claim matches the configured employee mapping.'
   restrict access: true
+
+administer aabenforms decision state:
+  title: 'Set AabenForms decision state directly'
+  description: 'Allows a submission to carry decision-state values (caseworker_status, consent_status, parent<N>_status) straight from the request. Without it those fields are forced back to their element default on create, because a citizen who could set caseworker_status=approved would have the municipality issue a binding decision with no review. Grant only to caseworkers.'
+  restrict access: true

--- a/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.services.yml
@@ -73,3 +73,17 @@ services:
     arguments:
       - '@database'
       - '@datetime.time'
+
+  aabenforms_core.demo_family_repository:
+    class: Drupal\aabenforms_core\Family\DemoFamilyRepository
+
+  aabenforms_core.family_lookup:
+    class: Drupal\aabenforms_core\Family\Sf6006FamilyLookup
+    arguments:
+      - '@aabenforms_core.serviceplatformen_client'
+      - '@config.factory'
+      - '@aabenforms_core.demo_family_repository'
+      - '@logger.factory'
+
+  Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface:
+    alias: aabenforms_core.family_lookup

--- a/web/modules/custom/aabenforms_core/config/install/aabenforms_core.settings.yml
+++ b/web/modules/custom/aabenforms_core/config/install/aabenforms_core.settings.yml
@@ -5,6 +5,7 @@ serviceplatformen:
     SF1520: 'https://exttest.serviceplatformen.dk/service/CPR/CPRBasicInformation/1'
     SF1530: 'https://exttest.serviceplatformen.dk/service/CVR/CVROnline/1'
     SF1601: 'https://exttest.serviceplatformen.dk/service/DigitalPost/1'
+    SF6006: 'https://exttest.serviceplatformen.dk/service/CPR/FamilieLokal/1'
   certificates:
     cert_path: ''
     key_path: ''

--- a/web/modules/custom/aabenforms_core/config/schema/aabenforms_core.schema.yml
+++ b/web/modules/custom/aabenforms_core/config/schema/aabenforms_core.schema.yml
@@ -27,6 +27,9 @@ aabenforms_core.settings:
             SF1601:
               type: string
               label: 'Digital Post service URL (SF1601)'
+            SF6006:
+              type: string
+              label: 'Familie+ CPR lookup service URL (SF6006)'
         certificates:
           type: mapping
           label: 'Client certificates'

--- a/web/modules/custom/aabenforms_core/src/Family/DemoFamilyRepository.php
+++ b/web/modules/custom/aabenforms_core/src/Family/DemoFamilyRepository.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_core\Family;
+
+/**
+ * Canonical demo family scenarios for custody-aware flows.
+ *
+ * Extends the demo persona set (see aabenforms_mitid DemoPersonas; the adult
+ * CPRs below are the same synthetic numbers) with the three family
+ * constellations every school/family flow must handle:
+ *
+ * - Shared custody, separated parents: Freja Nielsen and Lars Andersen hold
+ *   joint custody of Emil (born 2018). Lars lives at another address, so
+ *   decision letters must go out twice (the 21 March 2022 Digital Post rule)
+ *   and co-signature flows have a real second signer.
+ * - Sole custody: Sofie Hansen is the only custody holder of Alma (born
+ *   2019). Flows must skip the co-guardian branch entirely.
+ * - Pupil aged 15+: Emil's brother Oliver (born 2010) is over 15, so Digital
+ *   Post about Oliver goes to Oliver himself, not the parents.
+ * - No children: Mikkel Jensen has none, exercising the empty branch.
+ *
+ * This is demo/test scaffolding only: it backs the family lookup service when
+ * no Serviceplatformen certificate is provisioned, and the WireMock SF6006
+ * mappings in .ddev/mocks/wiremock mirror exactly this data.
+ */
+final class DemoFamilyRepository {
+
+  private const FREJA = '0101904521';
+
+  private const LARS = '0803755210';
+
+  private const SOFIE = '2506924015';
+
+  /**
+   * Demo children keyed by the child's CPR.
+   */
+  private const CHILDREN = [
+    // Shared custody, parents at different addresses, child under 15.
+    '0109182345' => [
+      'cpr' => '0109182345',
+      'first_name' => 'Emil',
+      'last_name' => 'Nielsen Andersen',
+      'full_name' => 'Emil Nielsen Andersen',
+      'birth_date' => '2018-09-01',
+      'protection' => FALSE,
+      'guardians' => [
+        [
+          'cpr' => self::FREJA,
+          'type' => GuardianType::MOTHER,
+          'full_name' => 'Freja Nielsen',
+          'same_address' => TRUE,
+        ],
+        [
+          'cpr' => self::LARS,
+          'type' => GuardianType::FATHER,
+          'full_name' => 'Lars Andersen',
+          'same_address' => FALSE,
+        ],
+      ],
+    ],
+    // Shared custody, pupil aged 15+ (Digital Post goes to the pupil).
+    '2005102345' => [
+      'cpr' => '2005102345',
+      'first_name' => 'Oliver',
+      'last_name' => 'Nielsen Andersen',
+      'full_name' => 'Oliver Nielsen Andersen',
+      'birth_date' => '2010-05-20',
+      'protection' => FALSE,
+      'guardians' => [
+        [
+          'cpr' => self::FREJA,
+          'type' => GuardianType::MOTHER,
+          'full_name' => 'Freja Nielsen',
+          'same_address' => TRUE,
+        ],
+        [
+          'cpr' => self::LARS,
+          'type' => GuardianType::FATHER,
+          'full_name' => 'Lars Andersen',
+          'same_address' => FALSE,
+        ],
+      ],
+    ],
+    // Sole custody.
+    '1203192345' => [
+      'cpr' => '1203192345',
+      'first_name' => 'Alma',
+      'last_name' => 'Hansen',
+      'full_name' => 'Alma Hansen',
+      'birth_date' => '2019-03-12',
+      'protection' => FALSE,
+      'guardians' => [
+        [
+          'cpr' => self::SOFIE,
+          'type' => GuardianType::MOTHER,
+          'full_name' => 'Sofie Hansen',
+          'same_address' => TRUE,
+        ],
+      ],
+    ],
+  ];
+
+  /**
+   * Returns the children the given adult holds custody of.
+   *
+   * @param string $parentCpr
+   *   The adult's CPR number.
+   *
+   * @return array[]
+   *   Child records (see FamilyRelationsLookupInterface::childrenOf()).
+   */
+  public function childrenOf(string $parentCpr): array {
+    $children = [];
+    foreach (self::CHILDREN as $child) {
+      foreach ($child['guardians'] as $guardian) {
+        if ($guardian['cpr'] === $parentCpr && GuardianType::isCustodial($guardian['type'])) {
+          $children[] = $child;
+          break;
+        }
+      }
+    }
+    return $children;
+  }
+
+  /**
+   * Returns the custody holders of the given child.
+   *
+   * @param string $childCpr
+   *   The child's CPR number.
+   *
+   * @return array[]
+   *   Guardian records, empty when the CPR is not a known demo child.
+   */
+  public function guardiansOf(string $childCpr): array {
+    return self::CHILDREN[$childCpr]['guardians'] ?? [];
+  }
+
+  /**
+   * Returns the child's birth date, or NULL when unknown.
+   *
+   * @param string $childCpr
+   *   The child's CPR number.
+   *
+   * @return \DateTimeImmutable|null
+   *   The birth date, or NULL.
+   */
+  public function birthDateOf(string $childCpr): ?\DateTimeImmutable {
+    $date = self::CHILDREN[$childCpr]['birth_date'] ?? NULL;
+    return $date === NULL ? NULL : new \DateTimeImmutable($date);
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Family/FamilyRelationsLookupInterface.php
+++ b/web/modules/custom/aabenforms_core/src/Family/FamilyRelationsLookupInterface.php
@@ -79,6 +79,18 @@ interface FamilyRelationsLookupInterface {
   public function hasCustody(string $adultCpr, string $childCpr): bool;
 
   /**
+   * Whether lookups are currently answered from demo data, not the registry.
+   *
+   * Consumers MUST use this to label their outputs honestly: a workflow step
+   * or audit row claiming "confirmed against the CPR registry" when the
+   * answer came from demo fixtures would fabricate an evidence trail.
+   *
+   * @return bool
+   *   TRUE when demo data is in use.
+   */
+  public function isDemoMode(): bool;
+
+  /**
    * Returns the child's birth date, or NULL when unknown.
    *
    * Used by recipient resolution (Digital Post under-15 rule) so the age

--- a/web/modules/custom/aabenforms_core/src/Family/FamilyRelationsLookupInterface.php
+++ b/web/modules/custom/aabenforms_core/src/Family/FamilyRelationsLookupInterface.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_core\Family;
+
+/**
+ * Looks up family relations and custody (foraeldremyndighed) from CPR data.
+ *
+ * This interface deliberately isolates the transport: the current
+ * implementation speaks Serviceplatformen SF6006 (Familie+ CPR opslag), but
+ * CPR services on the shared municipal infrastructure are being phased out
+ * towards Datafordeleren (deadline 31/12/2027). Consumers must depend on this
+ * interface only, so the migration is a service swap, not a refactor.
+ *
+ * Custody semantics: a child record is only returned for an adult who is a
+ * registered custody holder of that child (guardian type codes in
+ * GuardianType). This mirrors the reference behaviour of the OS2 ecosystem's
+ * SF1520 extended lookup (os2web_datalookup hasGuardian()).
+ *
+ * All CPR parameters and return values are plaintext CPR digit strings; the
+ * caller is responsible for decrypting stored CPRs (CprAccess) before calling
+ * and for never persisting the returned CPRs unencrypted.
+ */
+interface FamilyRelationsLookupInterface {
+
+  /**
+   * Returns the children the given adult holds custody of.
+   *
+   * @param string $parentCpr
+   *   The adult's CPR number (10 digits, no hyphen).
+   *
+   * @return array[]
+   *   A list of child records, each with keys:
+   *   - cpr (string): the child's CPR number.
+   *   - first_name (string), last_name (string), full_name (string).
+   *   - birth_date (string): ISO 8601 date (YYYY-MM-DD).
+   *   - protection (bool): TRUE when the child has name/address protection.
+   *   - guardians (array[]): all custody holders of this child, each with
+   *     keys cpr (string), type (int, GuardianType code), full_name (string),
+   *     same_address (bool, whether the guardian shares the child's address).
+   *   Children for whom the adult is NOT a registered custody holder are
+   *   never included.
+   *
+   * @throws \Drupal\aabenforms_core\Exception\ServiceplatformenException
+   *   When the underlying registry lookup fails.
+   */
+  public function childrenOf(string $parentCpr): array;
+
+  /**
+   * Returns the custody holders of the given child.
+   *
+   * @param string $childCpr
+   *   The child's CPR number (10 digits, no hyphen).
+   *
+   * @return array[]
+   *   A list of guardian records (see childrenOf() guardians key), empty when
+   *   the CPR is unknown or has no registered custody holders.
+   *
+   * @throws \Drupal\aabenforms_core\Exception\ServiceplatformenException
+   *   When the underlying registry lookup fails.
+   */
+  public function guardiansOf(string $childCpr): array;
+
+  /**
+   * Whether the adult is a registered custody holder of the child.
+   *
+   * Fail-closed: implementations must return FALSE when either CPR is
+   * unknown, malformed, or the registry cannot confirm custody.
+   *
+   * @param string $adultCpr
+   *   The adult's CPR number.
+   * @param string $childCpr
+   *   The child's CPR number.
+   *
+   * @return bool
+   *   TRUE only when the registry confirms custody.
+   */
+  public function hasCustody(string $adultCpr, string $childCpr): bool;
+
+  /**
+   * Returns the child's birth date, or NULL when unknown.
+   *
+   * Used by recipient resolution (Digital Post under-15 rule) so the age
+   * boundary is computed from registry data, not parsed out of the CPR
+   * number (whose century encoding is ambiguous).
+   *
+   * @param string $childCpr
+   *   The child's CPR number.
+   *
+   * @return \DateTimeImmutable|null
+   *   The birth date, or NULL when the CPR is unknown.
+   */
+  public function birthDateOf(string $childCpr): ?\DateTimeImmutable;
+
+}

--- a/web/modules/custom/aabenforms_core/src/Family/GuardianType.php
+++ b/web/modules/custom/aabenforms_core/src/Family/GuardianType.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_core\Family;
+
+/**
+ * CPR guardian (custody holder) relation type codes.
+ *
+ * The codes follow the CPR registry semantics as exposed through the
+ * Serviceplatformen family lookups and mirrored by the OS2 ecosystem
+ * (os2web_datalookup): mother = 3, father = 4, other guardian 1 = 5,
+ * other guardian 2 = 6.
+ */
+final class GuardianType {
+
+  public const MOTHER = 3;
+
+  public const FATHER = 4;
+
+  public const OTHER_GUARDIAN_1 = 5;
+
+  public const OTHER_GUARDIAN_2 = 6;
+
+  /**
+   * All codes that denote a custody-holding relation.
+   *
+   * @return int[]
+   *   The valid guardian type codes.
+   */
+  public static function all(): array {
+    return [
+      self::MOTHER,
+      self::FATHER,
+      self::OTHER_GUARDIAN_1,
+      self::OTHER_GUARDIAN_2,
+    ];
+  }
+
+  /**
+   * Whether a relation type code denotes custody.
+   *
+   * @param int $type
+   *   The relation type code.
+   *
+   * @return bool
+   *   TRUE when the code is a custody-holding relation.
+   */
+  public static function isCustodial(int $type): bool {
+    return in_array($type, self::all(), TRUE);
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Family/Sf6006FamilyLookup.php
+++ b/web/modules/custom/aabenforms_core/src/Family/Sf6006FamilyLookup.php
@@ -51,15 +51,23 @@ class Sf6006FamilyLookup implements FamilyRelationsLookupInterface {
     }
 
     if ($this->demoMode()) {
-      $this->logger->info('Family lookup ran in demo mode (no Serviceplatformen certificate).');
+      $this->logger->warning('Family lookup ran in demo mode (no Serviceplatformen certificate).');
       return $this->demoFamilies->childrenOf($parentCpr);
     }
 
-    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $parentCpr]);
+    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $parentCpr], ['no_cache' => TRUE]);
     $children = [];
     foreach ($result['children'] ?? [] as $child) {
-      foreach ($child['guardians'] ?? [] as $guardian) {
-        if ($guardian['cpr'] === $parentCpr && GuardianType::isCustodial((int) $guardian['type'])) {
+      // The interface promises guardians = custody holders ONLY; the raw
+      // feed may carry non-custodial relation codes, which must never reach
+      // co-sign flows that pick "the other guardian" from this list.
+      $custodial = array_values(array_filter(
+        $child['guardians'] ?? [],
+        static fn (array $g): bool => GuardianType::isCustodial((int) ($g['type'] ?? 0)),
+      ));
+      foreach ($custodial as $guardian) {
+        if ($guardian['cpr'] === $parentCpr) {
+          $child['guardians'] = $custodial;
           $children[] = $child;
           break;
         }
@@ -78,11 +86,11 @@ class Sf6006FamilyLookup implements FamilyRelationsLookupInterface {
     }
 
     if ($this->demoMode()) {
-      $this->logger->info('Family lookup ran in demo mode (no Serviceplatformen certificate).');
+      $this->logger->warning('Family lookup ran in demo mode (no Serviceplatformen certificate).');
       return $this->demoFamilies->guardiansOf($childCpr);
     }
 
-    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $childCpr]);
+    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $childCpr], ['no_cache' => TRUE]);
     $guardians = [];
     foreach ($result['guardians'] ?? [] as $guardian) {
       if (GuardianType::isCustodial((int) ($guardian['type'] ?? 0))) {
@@ -128,7 +136,7 @@ class Sf6006FamilyLookup implements FamilyRelationsLookupInterface {
       return $this->demoFamilies->birthDateOf($childCpr);
     }
 
-    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $childCpr]);
+    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $childCpr], ['no_cache' => TRUE]);
     $date = $result['person']['birth_date'] ?? NULL;
     if (!is_string($date) || $date === '') {
       return NULL;
@@ -139,6 +147,13 @@ class Sf6006FamilyLookup implements FamilyRelationsLookupInterface {
     catch (\Exception) {
       return NULL;
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isDemoMode(): bool {
+    return $this->demoMode();
   }
 
   /**

--- a/web/modules/custom/aabenforms_core/src/Family/Sf6006FamilyLookup.php
+++ b/web/modules/custom/aabenforms_core/src/Family/Sf6006FamilyLookup.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_core\Family;
+
+use Drupal\aabenforms_core\Service\ServiceplatformenClient;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Family/custody lookup backed by Serviceplatformen SF6006 (Familie+).
+ *
+ * Demo fallback: when no Serviceplatformen client certificate is provisioned
+ * (the local/POC case, same signal the CPR lookup action uses), the service
+ * answers from DemoFamilyRepository instead of calling out, and logs that it
+ * did. Once certificates are configured, real SF6006 lookups run without any
+ * config change. The WireMock mappings in .ddev/mocks/wiremock mirror the
+ * demo data, so `wiremock` transport testing and demo mode agree.
+ *
+ * Custody filtering happens here, not in callers: childrenOf() only returns
+ * children the adult actually holds custody of (GuardianType codes), and
+ * hasCustody() is fail-closed.
+ */
+class Sf6006FamilyLookup implements FamilyRelationsLookupInterface {
+
+  /**
+   * The logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  public function __construct(
+    protected ServiceplatformenClient $client,
+    protected ConfigFactoryInterface $configFactory,
+    protected DemoFamilyRepository $demoFamilies,
+    LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->logger = $loggerFactory->get('aabenforms_core');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function childrenOf(string $parentCpr): array {
+    $parentCpr = $this->normalize($parentCpr);
+    if ($parentCpr === '') {
+      return [];
+    }
+
+    if ($this->demoMode()) {
+      $this->logger->info('Family lookup ran in demo mode (no Serviceplatformen certificate).');
+      return $this->demoFamilies->childrenOf($parentCpr);
+    }
+
+    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $parentCpr]);
+    $children = [];
+    foreach ($result['children'] ?? [] as $child) {
+      foreach ($child['guardians'] ?? [] as $guardian) {
+        if ($guardian['cpr'] === $parentCpr && GuardianType::isCustodial((int) $guardian['type'])) {
+          $children[] = $child;
+          break;
+        }
+      }
+    }
+    return $children;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function guardiansOf(string $childCpr): array {
+    $childCpr = $this->normalize($childCpr);
+    if ($childCpr === '') {
+      return [];
+    }
+
+    if ($this->demoMode()) {
+      $this->logger->info('Family lookup ran in demo mode (no Serviceplatformen certificate).');
+      return $this->demoFamilies->guardiansOf($childCpr);
+    }
+
+    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $childCpr]);
+    $guardians = [];
+    foreach ($result['guardians'] ?? [] as $guardian) {
+      if (GuardianType::isCustodial((int) ($guardian['type'] ?? 0))) {
+        $guardians[] = $guardian;
+      }
+    }
+    return $guardians;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasCustody(string $adultCpr, string $childCpr): bool {
+    $adultCpr = $this->normalize($adultCpr);
+    $childCpr = $this->normalize($childCpr);
+    if ($adultCpr === '' || $childCpr === '') {
+      return FALSE;
+    }
+    try {
+      foreach ($this->guardiansOf($childCpr) as $guardian) {
+        if (hash_equals($guardian['cpr'], $adultCpr)) {
+          return TRUE;
+        }
+      }
+    }
+    catch (\Exception $e) {
+      // Fail closed: an unavailable registry never grants custody.
+      $this->logger->error('Custody check failed closed: {message}', ['message' => $e->getMessage()]);
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function birthDateOf(string $childCpr): ?\DateTimeImmutable {
+    $childCpr = $this->normalize($childCpr);
+    if ($childCpr === '') {
+      return NULL;
+    }
+
+    if ($this->demoMode()) {
+      return $this->demoFamilies->birthDateOf($childCpr);
+    }
+
+    $result = $this->client->request('SF6006', 'FamilyLookup', ['cpr' => $childCpr]);
+    $date = $result['person']['birth_date'] ?? NULL;
+    if (!is_string($date) || $date === '') {
+      return NULL;
+    }
+    try {
+      return new \DateTimeImmutable($date);
+    }
+    catch (\Exception) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Whether to answer from demo data instead of Serviceplatformen.
+   *
+   * Same signal as the CPR lookup action: no client certificate provisioned
+   * means demo mode. There is deliberately no separate flag to keep the two
+   * lookups from diverging.
+   */
+  protected function demoMode(): bool {
+    $certs = $this->configFactory->get('aabenforms_core.settings')->get('serviceplatformen.certificates') ?? [];
+    return empty($certs['cert_path']) && empty($certs['key_path']);
+  }
+
+  /**
+   * Normalizes a CPR to a bare 10-digit string, or '' when invalid.
+   */
+  protected function normalize(string $cpr): string {
+    $digits = preg_replace('/[^0-9]/', '', $cpr) ?? '';
+    return strlen($digits) === 10 ? $digits : '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/src/Family/Sf6006FamilyLookup.php
+++ b/web/modules/custom/aabenforms_core/src/Family/Sf6006FamilyLookup.php
@@ -22,6 +22,15 @@ use Psr\Log\LoggerInterface;
  * Custody filtering happens here, not in callers: childrenOf() only returns
  * children the adult actually holds custody of (GuardianType codes), and
  * hasCustody() is fail-closed.
+ *
+ * Every SF6006 call passes `no_cache => TRUE`, deliberately. Custody is the
+ * fact these flows gate on: it decides who may apply on a child's behalf, who
+ * must co-sign, and who receives the decision letter. A custody transfer takes
+ * effect the moment the registry records it, so a cached answer would let the
+ * platform act on an arrangement that no longer exists, and the mistake would
+ * land in a binding afgoerelse. The lookups are per-submission and low volume,
+ * so there is nothing to gain by caching them. Do not "optimise" this by
+ * dropping the flag.
  */
 class Sf6006FamilyLookup implements FamilyRelationsLookupInterface {
 

--- a/web/modules/custom/aabenforms_core/src/Service/ServiceplatformenClient.php
+++ b/web/modules/custom/aabenforms_core/src/Service/ServiceplatformenClient.php
@@ -25,6 +25,7 @@ use Psr\Log\LoggerInterface;
  * - SF1520: CPR person lookup
  * - SF1530: CVR company lookup
  * - SF1601: Digital Post (NgDP)
+ * - SF6006: Familie+ CPR lookup (family relations and custody)
  */
 class ServiceplatformenClient {
 
@@ -292,6 +293,7 @@ class ServiceplatformenClient {
       'SF1520' => $this->buildSf1520Envelope($operation, $params),
       'SF1530' => $this->buildSf1530Envelope($operation, $params),
       'SF1601' => $this->buildSf1601Envelope($operation, $params),
+      'SF6006' => $this->buildSf6006Envelope($operation, $params),
       default => throw new \InvalidArgumentException("Unknown service: {$service}"),
     };
   }
@@ -447,6 +449,52 @@ XML;
   }
 
   /**
+   * Builds SOAP envelope for SF6006 (Familie+ CPR lookup).
+   *
+   * @param string $operation
+   *   The operation name.
+   * @param array $params
+   *   Request parameters.
+   *
+   * @return string
+   *   The SOAP envelope XML.
+   */
+  protected function buildSf6006Envelope(string $operation, array $params): string {
+    $config = $this->configFactory->get('aabenforms_core.settings');
+    $username = $config->get('serviceplatformen.username') ?? '';
+    $password = $config->get('serviceplatformen.password') ?? '';
+
+    $cpr = $params['cpr'] ?? '';
+
+    // Escape all values to prevent XML injection.
+    $username = htmlspecialchars($username, ENT_XML1, 'UTF-8');
+    $password = htmlspecialchars($password, ENT_XML1, 'UTF-8');
+    $cpr = htmlspecialchars($cpr, ENT_XML1, 'UTF-8');
+
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:ns="http://serviceplatformen.dk/familielookup/1">
+  <soap:Header>
+    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+      <wsse:UsernameToken>
+        <wsse:Username>{$username}</wsse:Username>
+        <wsse:Password>{$password}</wsse:Password>
+      </wsse:UsernameToken>
+    </wsse:Security>
+  </soap:Header>
+  <soap:Body>
+    <ns:FamilyLookupRequest>
+      <ns:PNR>{$cpr}</ns:PNR>
+    </ns:FamilyLookupRequest>
+  </soap:Body>
+</soap:Envelope>
+XML;
+
+    return $xml;
+  }
+
+  /**
    * Parses SOAP response XML.
    *
    * @param string $xml
@@ -506,6 +554,11 @@ XML;
       // Check for Digital Post response.
       if ($doc->getElementsByTagName('SendMessageResponse')->length > 0) {
         return $this->parseSf1601Response($doc);
+      }
+
+      // Check for family lookup response.
+      if ($doc->getElementsByTagName('FamilyLookupResponse')->length > 0) {
+        return $this->parseSf6006Response($doc);
       }
 
       // Unknown response format.
@@ -633,10 +686,112 @@ XML;
   }
 
   /**
+   * Parses SF6006 (Familie+) response.
+   *
+   * The response describes the requested person plus their family relations:
+   * a Children list (when the person is an adult) and a top-level Guardians
+   * list (the person's own custody holders, when the person is a child).
+   * Each Child carries its own nested Guardians so custody can be verified
+   * per child without follow-up lookups.
+   *
+   * @param \DOMDocument $doc
+   *   The response DOM document.
+   *
+   * @return array
+   *   Parsed family data with keys 'person', 'children' and 'guardians'.
+   */
+  protected function parseSf6006Response(\DOMDocument $doc): array {
+    $data = [
+      'success' => TRUE,
+      'service' => 'SF6006',
+      'person' => [],
+      'children' => [],
+      'guardians' => [],
+    ];
+
+    $response = $doc->getElementsByTagName('FamilyLookupResponse')->item(0);
+    if (!$response instanceof \DOMElement) {
+      return $data;
+    }
+
+    $person = $response->getElementsByTagName('Person')->item(0);
+    if ($person instanceof \DOMElement) {
+      $data['person'] = [
+        'cpr' => $this->childText($person, 'CPR'),
+        'first_name' => $this->childText($person, 'FirstName'),
+        'last_name' => $this->childText($person, 'LastName'),
+        'birth_date' => $this->childText($person, 'BirthDate'),
+      ];
+    }
+
+    foreach ($response->getElementsByTagName('Child') as $child) {
+      $firstName = $this->childText($child, 'FirstName');
+      $lastName = $this->childText($child, 'LastName');
+      $data['children'][] = [
+        'cpr' => $this->childText($child, 'CPR'),
+        'first_name' => $firstName,
+        'last_name' => $lastName,
+        'full_name' => trim("{$firstName} {$lastName}"),
+        'birth_date' => $this->childText($child, 'BirthDate'),
+        'protection' => $this->childText($child, 'AddressProtection') === 'true',
+        'guardians' => $this->parseGuardians($child),
+      ];
+    }
+
+    // Top-level guardians: custody holders of the requested person itself.
+    // Only direct children of the response element count; guardians nested
+    // inside Child elements belong to those children.
+    foreach ($response->childNodes as $node) {
+      if ($node instanceof \DOMElement && $node->tagName === 'Guardians') {
+        $data['guardians'] = $this->parseGuardians($node);
+      }
+    }
+
+    return $data;
+  }
+
+  /**
+   * Parses Guardian elements inside a container element.
+   *
+   * @param \DOMElement $container
+   *   The element holding Guardian children (a Child or Guardians element).
+   *
+   * @return array[]
+   *   Guardian records with cpr, type, full_name and same_address keys.
+   */
+  protected function parseGuardians(\DOMElement $container): array {
+    $guardians = [];
+    foreach ($container->getElementsByTagName('Guardian') as $guardian) {
+      $guardians[] = [
+        'cpr' => $this->childText($guardian, 'CPR'),
+        'type' => (int) $this->childText($guardian, 'GuardianType'),
+        'full_name' => $this->childText($guardian, 'FullName'),
+        'same_address' => $this->childText($guardian, 'SameAddress') !== 'false',
+      ];
+    }
+    return $guardians;
+  }
+
+  /**
+   * Returns the text content of the first named descendant element.
+   *
+   * @param \DOMElement $element
+   *   The element to search within.
+   * @param string $tag
+   *   The descendant tag name.
+   *
+   * @return string
+   *   The text content, or '' when absent.
+   */
+  protected function childText(\DOMElement $element, string $tag): string {
+    return $element->getElementsByTagName($tag)->item(0)?->textContent ?? '';
+  }
+
+  /**
    * Gets the service URL from configuration.
    *
    * @param string $service
-   *   The service name (SF1520, SF1530, SF1601).
+   *   The service name (SF1520, SF1530, SF1601, SF6006).
    *
    * @return string
    *   The service endpoint URL.

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Family/DemoFamilyRepositoryTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Family/DemoFamilyRepositoryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit\Family;
+
+use Drupal\aabenforms_core\Family\DemoFamilyRepository;
+use Drupal\aabenforms_core\Family\GuardianType;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the demo family scenarios backing custody-aware flows.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_core\Family\DemoFamilyRepository
+ * @group aabenforms_core
+ */
+class DemoFamilyRepositoryTest extends UnitTestCase {
+
+  /**
+   * The repository under test.
+   *
+   * @var \Drupal\aabenforms_core\Family\DemoFamilyRepository
+   */
+  protected DemoFamilyRepository $repository;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->repository = new DemoFamilyRepository();
+  }
+
+  /**
+   * Freja holds custody of two children, shared with Lars.
+   *
+   * @covers ::childrenOf
+   */
+  public function testSharedCustodyParentSeesBothChildren(): void {
+    $children = $this->repository->childrenOf('0101904521');
+    $this->assertCount(2, $children);
+
+    $emil = $children[0];
+    $this->assertSame('Emil Nielsen Andersen', $emil['full_name']);
+    $this->assertCount(2, $emil['guardians']);
+
+    $guardianCprs = array_column($emil['guardians'], 'cpr');
+    $this->assertContains('0101904521', $guardianCprs);
+    $this->assertContains('0803755210', $guardianCprs);
+  }
+
+  /**
+   * The separated father sees the same children with a different address.
+   *
+   * @covers ::childrenOf
+   */
+  public function testSeparatedFatherSharesCustodyFromOtherAddress(): void {
+    $children = $this->repository->childrenOf('0803755210');
+    $this->assertCount(2, $children);
+
+    foreach ($children[0]['guardians'] as $guardian) {
+      if ($guardian['cpr'] === '0803755210') {
+        $this->assertSame(GuardianType::FATHER, $guardian['type']);
+        $this->assertFalse($guardian['same_address']);
+      }
+    }
+  }
+
+  /**
+   * Sofie holds sole custody of one child.
+   *
+   * @covers ::childrenOf
+   * @covers ::guardiansOf
+   */
+  public function testSoleCustody(): void {
+    $children = $this->repository->childrenOf('2506924015');
+    $this->assertCount(1, $children);
+    $this->assertSame('Alma Hansen', $children[0]['full_name']);
+
+    $guardians = $this->repository->guardiansOf('1203192345');
+    $this->assertCount(1, $guardians);
+    $this->assertSame('2506924015', $guardians[0]['cpr']);
+  }
+
+  /**
+   * An adult without children gets an empty list.
+   *
+   * @covers ::childrenOf
+   */
+  public function testAdultWithoutChildren(): void {
+    $this->assertSame([], $this->repository->childrenOf('1502856234'));
+  }
+
+  /**
+   * Birth dates support the under-15 Digital Post rule boundary.
+   *
+   * @covers ::birthDateOf
+   */
+  public function testBirthDates(): void {
+    $emil = $this->repository->birthDateOf('0109182345');
+    $this->assertSame('2018-09-01', $emil?->format('Y-m-d'));
+
+    // Oliver is the 15+ scenario: born 2010, over 15 from 2025 on.
+    $oliver = $this->repository->birthDateOf('2005102345');
+    $this->assertSame('2010-05-20', $oliver?->format('Y-m-d'));
+
+    $this->assertNull($this->repository->birthDateOf('9999999999'));
+  }
+
+  /**
+   * Unknown child CPRs yield no guardians.
+   *
+   * @covers ::guardiansOf
+   */
+  public function testUnknownChildHasNoGuardians(): void {
+    $this->assertSame([], $this->repository->guardiansOf('9999999999'));
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/Family/Sf6006FamilyLookupTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/Family/Sf6006FamilyLookupTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit\Family;
+
+use Drupal\aabenforms_core\Exception\ServiceplatformenException;
+use Drupal\aabenforms_core\Family\DemoFamilyRepository;
+use Drupal\aabenforms_core\Family\Sf6006FamilyLookup;
+use Drupal\aabenforms_core\Service\ServiceplatformenClient;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the SF6006 family lookup service.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_core\Family\Sf6006FamilyLookup
+ * @group aabenforms_core
+ */
+class Sf6006FamilyLookupTest extends UnitTestCase {
+
+  /**
+   * Mock Serviceplatformen client.
+   *
+   * @var \Drupal\aabenforms_core\Service\ServiceplatformenClient|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $client;
+
+  /**
+   * Certificate config served to the service; empty means demo mode.
+   *
+   * @var array
+   */
+  protected array $certificates = [];
+
+  /**
+   * The service under test.
+   */
+  protected Sf6006FamilyLookup $lookup;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->client = $this->createMock(ServiceplatformenClient::class);
+
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'serviceplatformen.certificates' ? $this->certificates : NULL
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($settings);
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+
+    $this->lookup = new Sf6006FamilyLookup(
+      $this->client,
+      $configFactory,
+      new DemoFamilyRepository(),
+      $loggerFactory,
+    );
+  }
+
+  /**
+   * Without certificates the service answers from demo data, never SOAP.
+   *
+   * @covers ::childrenOf
+   * @covers ::guardiansOf
+   */
+  public function testDemoModeAnswersFromDemoDataWithoutSoapCall(): void {
+    $this->certificates = [];
+    $this->client->expects($this->never())->method('request');
+
+    $children = $this->lookup->childrenOf('0101904521');
+    $this->assertCount(2, $children);
+
+    $guardians = $this->lookup->guardiansOf('0109182345');
+    $this->assertCount(2, $guardians);
+  }
+
+  /**
+   * With certificates the service calls SF6006 and filters custody.
+   *
+   * @covers ::childrenOf
+   */
+  public function testLiveModeFiltersChildrenToCustodyHolders(): void {
+    $this->certificates = ['cert_path' => '/cert.pem', 'key_path' => '/key.pem'];
+
+    $this->client->expects($this->once())
+      ->method('request')
+      ->with('SF6006', 'FamilyLookup', ['cpr' => '0101904521'])
+      ->willReturn([
+        'children' => [
+          [
+            'cpr' => '0109182345',
+            'full_name' => 'Emil Nielsen Andersen',
+            'guardians' => [
+              ['cpr' => '0101904521', 'type' => 3],
+              ['cpr' => '0803755210', 'type' => 4],
+            ],
+          ],
+          [
+            // A child record where the requester is NOT a custody holder
+            // must be filtered out.
+            'cpr' => '1111111111',
+            'full_name' => 'Other Child',
+            'guardians' => [
+              ['cpr' => '2222222222', 'type' => 3],
+            ],
+          ],
+        ],
+      ]);
+
+    $children = $this->lookup->childrenOf('0101904521');
+    $this->assertCount(1, $children);
+    $this->assertSame('0109182345', $children[0]['cpr']);
+  }
+
+  /**
+   * Custody verification is fail-closed on registry errors.
+   *
+   * @covers ::hasCustody
+   */
+  public function testHasCustodyFailsClosedOnRegistryError(): void {
+    $this->certificates = ['cert_path' => '/cert.pem', 'key_path' => '/key.pem'];
+
+    $this->client->method('request')
+      ->willThrowException(new ServiceplatformenException('down', 'SF6006', 'FamilyLookup', retryable: FALSE, code: 500));
+
+    $this->assertFalse($this->lookup->hasCustody('0101904521', '0109182345'));
+  }
+
+  /**
+   * Custody verification confirms only registered custody holders.
+   *
+   * @covers ::hasCustody
+   */
+  public function testHasCustodyAgainstDemoData(): void {
+    $this->certificates = [];
+
+    // Freja and Lars both hold custody of Emil; Sofie and Mikkel do not.
+    $this->assertTrue($this->lookup->hasCustody('0101904521', '0109182345'));
+    $this->assertTrue($this->lookup->hasCustody('0803755210', '0109182345'));
+    $this->assertFalse($this->lookup->hasCustody('2506924015', '0109182345'));
+    $this->assertFalse($this->lookup->hasCustody('1502856234', '0109182345'));
+  }
+
+  /**
+   * Malformed CPR input fails closed and returns empty results.
+   *
+   * @covers ::childrenOf
+   * @covers ::hasCustody
+   * @covers ::birthDateOf
+   */
+  public function testMalformedInputFailsClosed(): void {
+    $this->certificates = [];
+    $this->assertSame([], $this->lookup->childrenOf('12345'));
+    $this->assertFalse($this->lookup->hasCustody('', '0109182345'));
+    $this->assertFalse($this->lookup->hasCustody('0101904521', 'not-a-cpr'));
+    $this->assertNull($this->lookup->birthDateOf(''));
+  }
+
+  /**
+   * CPR input is normalized (hyphens stripped) before use.
+   *
+   * @covers ::childrenOf
+   */
+  public function testCprNormalization(): void {
+    $this->certificates = [];
+    $children = $this->lookup->childrenOf('010190-4521');
+    $this->assertCount(2, $children);
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/PermissionDeclarationTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/PermissionDeclarationTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit;
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Asserts every permission the custom modules rely on is actually declared.
+ *
+ * Drupal does not complain when a route requires a permission that no module
+ * declares, nor when a role grants one. It simply becomes ungrantable through
+ * /admin/people/permissions, and hasPermission() answers FALSE for everyone
+ * except uid 1. That failure mode is silent and reads as working code, which
+ * is how two of them survived in this codebase: `administer workflows` guarded
+ * eleven routes and was granted by the case_worker role while being declared
+ * nowhere, and the decision-state guard checked a permission that never
+ * existed, so only its role branch did any work.
+ *
+ * This test walks the YAML on disk rather than a booted container, so it stays
+ * a fast unit test and covers modules that are not installed in any given test
+ * fixture.
+ *
+ * @group aabenforms_core
+ */
+class PermissionDeclarationTest extends UnitTestCase {
+
+  /**
+   * Permissions owned by Drupal core or contrib, which we cannot declare.
+   */
+  private const EXTERNAL_PERMISSIONS = [
+    'access administration pages',
+    'access content',
+    'administer eca',
+    'administer modelers',
+    'administer site configuration',
+    'administer users',
+    'administer webform',
+    'edit any webform submission',
+    'view any webform submission',
+  ];
+
+  /**
+   * Absolute path to web/modules/custom.
+   *
+   * This file lives at
+   * custom/aabenforms_core/tests/src/Unit/PermissionDeclarationTest.php, so
+   * four levels up is the custom-modules root. The assertion keeps a future
+   * move from silently turning every glob below into an empty set.
+   */
+  private function customModulesDir(): string {
+    $dir = dirname(__DIR__, 4);
+    $this->assertSame('custom', basename($dir), 'Expected to resolve the custom-modules root; this test file has moved.');
+    return $dir;
+  }
+
+  /**
+   * Every permission declared by a custom module's permissions.yml.
+   *
+   * @return string[]
+   *   The declared permission names.
+   */
+  private function declaredPermissions(): array {
+    $declared = [];
+    foreach (glob($this->customModulesDir() . '/*/*.permissions.yml') ?: [] as $file) {
+      $data = Yaml::decode((string) file_get_contents($file));
+      if (!is_array($data)) {
+        continue;
+      }
+      foreach (array_keys($data) as $name) {
+        // Skip the dynamic-callback form ("permission_callbacks:").
+        if ($name === 'permission_callbacks') {
+          continue;
+        }
+        $declared[] = (string) $name;
+      }
+    }
+    return $declared;
+  }
+
+  /**
+   * Permissions required by custom routing, keyed by the route that wants them.
+   *
+   * @return array<string, string>
+   *   Permission name keyed by "<file>:<route id>".
+   */
+  private function routePermissions(): array {
+    $required = [];
+    foreach (glob($this->customModulesDir() . '/*/*.routing.yml') ?: [] as $file) {
+      $routes = Yaml::decode((string) file_get_contents($file));
+      if (!is_array($routes)) {
+        continue;
+      }
+      foreach ($routes as $routeId => $route) {
+        $permission = $route['requirements']['_permission'] ?? NULL;
+        if (!is_string($permission) || $permission === '') {
+          continue;
+        }
+        // Drupal allows "a+b" (any of) and "a,b" (all of).
+        foreach (preg_split('/[+,]/', $permission) ?: [] as $single) {
+          $single = trim($single);
+          if ($single !== '') {
+            $required[basename($file) . ':' . $routeId] = $single;
+          }
+        }
+      }
+    }
+    return $required;
+  }
+
+  /**
+   * Every permission string passed to hasPermission() in custom PHP.
+   *
+   * @return string[]
+   *   The permission names.
+   */
+  private function codePermissions(): array {
+    $found = [];
+    $iterator = new \RecursiveIteratorIterator(
+      new \RecursiveDirectoryIterator($this->customModulesDir(), \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($iterator as $file) {
+      /** @var \SplFileInfo $file */
+      if (!in_array($file->getExtension(), ['php', 'module', 'inc', 'install'], TRUE)) {
+        continue;
+      }
+      // Tests legitimately reference permissions they create themselves.
+      if (str_contains($file->getPathname(), '/tests/')) {
+        continue;
+      }
+      $source = (string) file_get_contents($file->getPathname());
+      if (preg_match_all("/hasPermission\(\s*'([^']+)'/", $source, $matches)) {
+        foreach ($matches[1] as $permission) {
+          $found[] = $permission;
+        }
+      }
+    }
+    return array_unique($found);
+  }
+
+  /**
+   * Every route permission is declared by a custom module or by core/contrib.
+   */
+  public function testRoutePermissionsAreDeclared(): void {
+    $known = array_merge($this->declaredPermissions(), self::EXTERNAL_PERMISSIONS);
+    $routePermissions = $this->routePermissions();
+
+    $this->assertNotEmpty($routePermissions, 'Expected to find routes guarded by a permission.');
+
+    foreach ($routePermissions as $where => $permission) {
+      $this->assertContains($permission, $known, sprintf(
+        'Route %s requires the permission "%s", which no custom permissions.yml declares and which is not a known core/contrib permission. Declare it, or add it to EXTERNAL_PERMISSIONS if it belongs to core or contrib.',
+        $where,
+        $permission
+      ));
+    }
+  }
+
+  /**
+   * Every hasPermission() check names a permission that exists.
+   */
+  public function testCodePermissionsAreDeclared(): void {
+    $known = array_merge($this->declaredPermissions(), self::EXTERNAL_PERMISSIONS);
+    $codePermissions = $this->codePermissions();
+
+    $this->assertNotEmpty($codePermissions, 'Expected to find hasPermission() calls in custom code.');
+
+    foreach ($codePermissions as $permission) {
+      $this->assertContains($permission, $known, sprintf(
+        'Custom code calls hasPermission("%s"), but no custom permissions.yml declares it. An undeclared permission is FALSE for every user except uid 1, so the check silently does nothing.',
+        $permission
+      ));
+    }
+  }
+
+  /**
+   * Every permission a shipped role grants exists.
+   *
+   * A role granting an undeclared permission cannot be managed through the UI
+   * and is fragile across Drupal minors on config import.
+   */
+  public function testExportedRolesGrantOnlyDeclaredPermissions(): void {
+    $known = array_merge($this->declaredPermissions(), self::EXTERNAL_PERMISSIONS);
+    $configSync = dirname($this->customModulesDir(), 3) . '/config/sync';
+    $roleFiles = glob($configSync . '/user.role.*.yml') ?: [];
+
+    $this->assertNotEmpty($roleFiles, 'Expected exported role config in config/sync.');
+
+    foreach ($roleFiles as $file) {
+      $role = Yaml::decode((string) file_get_contents($file));
+      if (!is_array($role) || ($role['is_admin'] ?? FALSE) === TRUE) {
+        // The admin role holds everything implicitly.
+        continue;
+      }
+      foreach ($role['permissions'] ?? [] as $permission) {
+        // Only assert on permissions that look like ours; core and contrib
+        // ship far more than EXTERNAL_PERMISSIONS can reasonably enumerate.
+        if (!str_contains((string) $permission, 'aabenforms') && $permission !== 'administer workflows') {
+          continue;
+        }
+        $this->assertContains($permission, $known, sprintf(
+          'Role %s grants "%s", which no custom permissions.yml declares.',
+          basename($file),
+          $permission
+        ));
+      }
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_core/tests/src/Unit/ProtectDecisionFieldsTest.php
+++ b/web/modules/custom/aabenforms_core/tests/src/Unit/ProtectDecisionFieldsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_core\Unit;
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Pins the settings the decision-state guard silently depends on.
+ *
+ * The guard aabenforms_core_protect_decision_fields() only covers the CREATE
+ * path: it returns early when $submission->isNew() is FALSE, because the
+ * citizen update is written server-side by ParentApprovalForm after the MitID,
+ * CPR and custody gates have run, and re-clamping there would undo a lawful
+ * approval.
+ *
+ * That is only safe while no client can drive an UPDATE at all. Two settings
+ * make that true today, and neither lives in code:
+ *
+ * 1. jsonapi.settings ships read_only, so PATCH against
+ *    /jsonapi/webform_submission/* is refused outright.
+ * 2. The decision-bearing webforms ship `draft: none` with prepopulate off, so
+ *    a citizen cannot re-open a stored submission through the form either.
+ *
+ * If either changes, a citizen regains a write path to caseworker_status and
+ * the guard has to start covering updates. This test is the tripwire: it fails
+ * loudly at that moment rather than leaving a silent privilege escalation.
+ *
+ * @group aabenforms_core
+ */
+class ProtectDecisionFieldsTest extends UnitTestCase {
+
+  /**
+   * Webforms carrying decision-state elements the guard protects.
+   */
+  private const DECISION_WEBFORMS = [
+    'school_transfer',
+    'ppr_referral',
+    'guardian_consent',
+    'merudgifter',
+    'parent_request_form',
+  ];
+
+  /**
+   * Absolute path to config/sync.
+   */
+  private function configSyncDir(): string {
+    // This file sits at
+    // web/modules/custom/aabenforms_core/tests/src/Unit/, so seven levels up
+    // is the repository root.
+    $root = dirname(__DIR__, 7);
+    $dir = $root . '/config/sync';
+    $this->assertDirectoryExists($dir, 'Expected to resolve config/sync; this test file has moved.');
+    return $dir;
+  }
+
+  /**
+   * JSON:API stays read-only, so no client can PATCH a stored submission.
+   */
+  public function testJsonapiIsReadOnly(): void {
+    $file = $this->configSyncDir() . '/jsonapi.settings.yml';
+    $this->assertFileExists($file);
+
+    $settings = Yaml::decode((string) file_get_contents($file));
+    $this->assertTrue(
+      $settings['read_only'] ?? NULL,
+      'jsonapi.settings must stay read_only. With writes enabled, a citizen could PATCH caseworker_status onto a stored submission, and aabenforms_core_protect_decision_fields() does not guard the update path.'
+    );
+  }
+
+  /**
+   * Decision-bearing webforms offer no citizen-driven update path.
+   */
+  public function testDecisionWebformsDisallowDraftsAndPrepopulate(): void {
+    $checked = 0;
+
+    foreach (self::DECISION_WEBFORMS as $webformId) {
+      $file = $this->configSyncDir() . '/webform.webform.' . $webformId . '.yml';
+      if (!file_exists($file)) {
+        // The list spans several feature branches; skip what is not deployed
+        // here rather than failing on an absence that is not a defect.
+        continue;
+      }
+      $checked++;
+      $webform = Yaml::decode((string) file_get_contents($file));
+      $settings = $webform['settings'] ?? [];
+
+      $this->assertSame('none', $settings['draft'] ?? 'none', sprintf(
+        'Webform %s enables drafts. A draft is a stored submission the citizen can re-open and re-post, which is exactly the update path the decision-state guard does not cover.',
+        $webformId
+      ));
+      $this->assertFalse((bool) ($settings['form_prepopulate'] ?? FALSE), sprintf(
+        'Webform %s enables prepopulate, which lets a client seed element values from the query string, including the decision-state elements.',
+        $webformId
+      ));
+    }
+
+    $this->assertGreaterThan(0, $checked, 'Expected at least one decision-bearing webform in config/sync.');
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.services.yml
+++ b/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.services.yml
@@ -78,6 +78,15 @@ services:
     class: Drupal\aabenforms_digital_post\Audit\CoreAuditEmitter
     arguments: ['@aabenforms_core.audit_logger']
 
+  # Resolves who receives Digital Post about a child: each custody holder
+  # when the child is under 15, the young person directly from 15. Fail-closed.
+  aabenforms_digital_post.guardian_recipient_resolver:
+    class: Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver
+    arguments:
+      - '@aabenforms_core.family_lookup'
+      - '@datetime.time'
+      - '@logger.factory'
+
   # The public entry point.
   aabenforms_digital_post.sender:
     class: Drupal\aabenforms_digital_post\Service\DigitalPostSender

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/CosignInvitationAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/CosignInvitationAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\aabenforms_digital_post_eca\Plugin\Action;
 
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
 use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
 use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
@@ -83,6 +84,13 @@ class CosignInvitationAction extends AabenFormsActionBase {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The family/custody registry lookup.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface
+   */
+  protected FamilyRelationsLookupInterface $familyLookup;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
@@ -92,7 +100,17 @@ class CosignInvitationAction extends AabenFormsActionBase {
     $instance->setCprAccess($container->get('aabenforms_core.cpr_access'));
     $instance->setMailManager($container->get('plugin.manager.mail'));
     $instance->setConfigFactory($container->get('config.factory'));
+    $instance->setFamilyLookup($container->get('aabenforms_core.family_lookup'));
     return $instance;
+  }
+
+  /**
+   * Setter injection for the family/custody lookup.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setFamilyLookup(FamilyRelationsLookupInterface $familyLookup): void {
+    $this->familyLookup = $familyLookup;
   }
 
   /**
@@ -149,6 +167,7 @@ class CosignInvitationAction extends AabenFormsActionBase {
       'cpr_field' => 'parent2_cpr',
       'email_field' => 'parent2_email',
       'child_name_field' => 'child_name',
+      'child_cpr_field' => 'child_cpr',
       'subject_template' => 'Anmodning om medunderskrift',
     ] + parent::defaultConfiguration();
   }
@@ -184,6 +203,12 @@ class CosignInvitationAction extends AabenFormsActionBase {
       '#title' => $this->t('Child name field'),
       '#default_value' => $this->configuration['child_name_field'],
     ];
+    $form['child_cpr_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Child CPR field'),
+      '#description' => $this->t('Webform field holding the child CPR. The co-signer CPR must be a REGISTERED custody holder of this child before any invitation is sent; leave empty to skip the check (not recommended).'),
+      '#default_value' => $this->configuration['child_cpr_field'],
+    ];
     $form['subject_template'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Subject'),
@@ -197,7 +222,7 @@ class CosignInvitationAction extends AabenFormsActionBase {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
-    foreach (['parent_number', 'cpr_field', 'email_field', 'child_name_field', 'subject_template'] as $key) {
+    foreach (['parent_number', 'cpr_field', 'email_field', 'child_name_field', 'child_cpr_field', 'subject_template'] as $key) {
       $this->configuration[$key] = (string) $form_state->getValue($key);
     }
     parent::submitConfigurationForm($form, $form_state);
@@ -221,6 +246,21 @@ class CosignInvitationAction extends AabenFormsActionBase {
     $childName = (string) ($submission->getElementData((string) $this->configuration['child_name_field']) ?? '');
     $cpr = $this->cprAccess->reveal((string) ($submission->getElementData((string) $this->configuration['cpr_field']) ?? ''));
     $cpr = $cpr ? (preg_replace('/[^0-9]/', '', $cpr) ?? '') : '';
+
+    // Never let a citizen-typed CPR address an official letter about a named
+    // child: the recipient must be a REGISTERED custody holder. Without this,
+    // anyone could make the municipality send Digital Post naming someone's
+    // child to any CPR in Denmark (and could address the co-sign link to
+    // themselves to self-approve).
+    if ($cpr !== '' && !$this->recipientHoldsCustody($submission, $cpr)) {
+      $this->recordStep(
+        'Co-sign Invitation',
+        'Blocked - the named co-signer is not a registered custody holder of the child',
+        'failed',
+      );
+      $this->log('Co-sign invitation blocked: recipient is not a registered custody holder', [], 'warning');
+      return;
+    }
 
     if ($cpr !== '') {
       try {
@@ -299,6 +339,43 @@ class CosignInvitationAction extends AabenFormsActionBase {
     }
     else {
       $this->recordStep('Co-sign Invitation', 'Failed - email fallback did not send', 'failed');
+    }
+  }
+
+  /**
+   * Whether the intended recipient holds registered custody of the child.
+   *
+   * Fail-closed: an unknown child CPR, an unreachable registry, or a
+   * recipient outside the registered custody-holder set all return FALSE.
+   * Returns TRUE only when the check is disabled by configuration (no child
+   * CPR field configured), which the config form marks as not recommended.
+   *
+   * @param object $submission
+   *   The webform submission.
+   * @param string $recipientCpr
+   *   The normalised recipient CPR.
+   *
+   * @return bool
+   *   TRUE when the invitation may be sent.
+   */
+  protected function recipientHoldsCustody(object $submission, string $recipientCpr): bool {
+    $childCprField = (string) ($this->configuration['child_cpr_field'] ?? '');
+    if ($childCprField === '') {
+      return TRUE;
+    }
+    $childCpr = $this->cprAccess->reveal((string) ($submission->getElementData($childCprField) ?? ''));
+    $childCpr = $childCpr ? (preg_replace('/[^0-9]/', '', $childCpr) ?? '') : '';
+    if ($childCpr === '') {
+      return FALSE;
+    }
+    try {
+      return $this->familyLookup->hasCustody($recipientCpr, $childCpr);
+    }
+    catch (\Throwable $e) {
+      $this->log('Custody check for co-sign recipient failed closed: {message}', [
+        'message' => $e->getMessage(),
+      ], 'error');
+      return FALSE;
     }
   }
 

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/CosignInvitationAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/CosignInvitationAction.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post_eca\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Recipient;
+use Drupal\aabenforms_digital_post\DigitalPost\Sender;
+use Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface;
+use Drupal\aabenforms_workflows\Plugin\Action\AabenFormsActionBase;
+use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Send a co-signature (medunderskrift) invitation.
+ *
+ * The Digital Post generalization of the parent-approval invitation,
+ * following the national co-sign template (borger.dk Omsorgs- og
+ * ansvarserklaering): the co-signer receives a Digital Post message with a
+ * secure link, authenticates with MitID, and approves within 14 days. The
+ * link reuses the ENTIRE existing parent-approval machinery (token service,
+ * controller, MitID step-up, CPR gate + opt-in custody gate), so any webform
+ * carrying the parent<N>_cpr / parent<N>_status field convention gets
+ * co-signing without new plumbing.
+ *
+ * Channel selection mirrors the forloeb convention: a CPR recipient gets
+ * Digital Post; when no CPR is present (or the send is skipped in demo), the
+ * email fallback uses the existing parent_approval mail template.
+ */
+#[Action(
+  id: 'aabenforms_send_cosign_invitation',
+  label: new TranslatableMarkup('Send Co-sign Invitation'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Sends a co-signature invitation with a secure MitID approval link via Digital Post (CPR) with email fallback.'),
+  version_introduced: '2.1.0',
+)]
+class CosignInvitationAction extends AabenFormsActionBase {
+
+  /**
+   * The Digital Post sender service.
+   *
+   * @var \Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface
+   */
+  protected DigitalPostSenderInterface $sender;
+
+  /**
+   * The approval token service.
+   *
+   * @var \Drupal\aabenforms_workflows\Service\ApprovalTokenService
+   */
+  protected ApprovalTokenService $approvalTokenService;
+
+  /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * The mail manager (email fallback channel).
+   *
+   * @var \Drupal\Core\Mail\MailManagerInterface
+   */
+  protected MailManagerInterface $mailManager;
+
+  /**
+   * The config factory (default sender CVR).
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->setSender($container->get('aabenforms_digital_post.sender'));
+    $instance->setApprovalTokenService($container->get('aabenforms_workflows.approval_token'));
+    $instance->setCprAccess($container->get('aabenforms_core.cpr_access'));
+    $instance->setMailManager($container->get('plugin.manager.mail'));
+    $instance->setConfigFactory($container->get('config.factory'));
+    return $instance;
+  }
+
+  /**
+   * Setter injection for the config factory.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setConfigFactory(ConfigFactoryInterface $configFactory): void {
+    $this->configFactory = $configFactory;
+  }
+
+  /**
+   * Setter injection for the Digital Post sender.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setSender(DigitalPostSenderInterface $sender): void {
+    $this->sender = $sender;
+  }
+
+  /**
+   * Setter injection for the approval token service.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setApprovalTokenService(ApprovalTokenService $service): void {
+    $this->approvalTokenService = $service;
+  }
+
+  /**
+   * Setter injection for the CPR access helper.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setCprAccess(CprAccess $cprAccess): void {
+    $this->cprAccess = $cprAccess;
+  }
+
+  /**
+   * Setter injection for the mail manager.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setMailManager(MailManagerInterface $mailManager): void {
+    $this->mailManager = $mailManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'parent_number' => '2',
+      'cpr_field' => 'parent2_cpr',
+      'email_field' => 'parent2_email',
+      'child_name_field' => 'child_name',
+      'subject_template' => 'Anmodning om medunderskrift',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['parent_number'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Co-signer slot'),
+      '#description' => $this->t('Which parent<N> field set and approval slot the invitation is for.'),
+      '#options' => ['1' => $this->t('Slot 1'), '2' => $this->t('Slot 2')],
+      '#default_value' => $this->configuration['parent_number'],
+      '#required' => TRUE,
+    ];
+    $form['cpr_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Co-signer CPR field'),
+      '#description' => $this->t('Webform field holding the co-signer CPR (Digital Post channel). Leave the value empty on the submission to fall back to email.'),
+      '#default_value' => $this->configuration['cpr_field'],
+      '#required' => TRUE,
+    ];
+    $form['email_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Fallback email field'),
+      '#description' => $this->t('Webform field holding the co-signer email, used when no CPR is present or the Digital Post send fails.'),
+      '#default_value' => $this->configuration['email_field'],
+      '#required' => TRUE,
+    ];
+    $form['child_name_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Child name field'),
+      '#default_value' => $this->configuration['child_name_field'],
+    ];
+    $form['subject_template'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Subject'),
+      '#default_value' => $this->configuration['subject_template'],
+      '#required' => TRUE,
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    foreach (['parent_number', 'cpr_field', 'email_field', 'child_name_field', 'subject_template'] as $key) {
+      $this->configuration[$key] = (string) $form_state->getValue($key);
+    }
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $submission = $this->getSubmission();
+    if ($submission === NULL) {
+      $this->recordStep('Co-sign Invitation', 'Skipped - no webform submission in scope', 'skipped');
+      $this->log('Co-sign invitation skipped: no submission resolved', [], 'warning');
+      return;
+    }
+
+    $slot = (int) $this->configuration['parent_number'];
+    $token = $this->approvalTokenService->generateToken((int) $submission->id(), $slot);
+    $approvalUrl = $this->buildApprovalUrl($slot, (int) $submission->id(), $token);
+
+    $childName = (string) ($submission->getElementData((string) $this->configuration['child_name_field']) ?? '');
+    $cpr = $this->cprAccess->reveal((string) ($submission->getElementData((string) $this->configuration['cpr_field']) ?? ''));
+    $cpr = $cpr ? (preg_replace('/[^0-9]/', '', $cpr) ?? '') : '';
+
+    if ($cpr !== '') {
+      try {
+        $result = $this->sender->send(new DigitalPost(
+          recipient: Recipient::cpr($cpr),
+          sender: Sender::fromConfig($this->configFactory),
+          subject: (string) $this->configuration['subject_template'],
+          body: $this->buildLetterBody($childName, $approvalUrl),
+          type: DigitalPost::TYPE_DIGITAL_POST,
+          meta: [
+            'transaction_id' => 'cosign_' . substr(hash('sha256', $submission->uuid() . ':' . $this->getPluginId() . ':' . $slot), 0, 40),
+          ],
+        ));
+        if ($result->isSuccess() || $result->isPending()) {
+          $this->recordStep('Co-sign Invitation Sent', 'Secure co-signature link sent via Digital Post (14-day window)');
+          return;
+        }
+        $this->log('Co-sign Digital Post failed ({reason}); falling back to email', [
+          'reason' => (string) $result->reasonCode,
+        ], 'warning');
+      }
+      catch (\Throwable $e) {
+        $this->log('Co-sign Digital Post error; falling back to email: {message}', [
+          'message' => $e->getMessage(),
+        ], 'warning');
+      }
+    }
+
+    $this->sendEmailFallback($submission, $slot, $childName, $approvalUrl, $cpr === '');
+  }
+
+  /**
+   * Sends the invitation via the email fallback channel.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface|object $submission
+   *   The webform submission.
+   * @param int $slot
+   *   The co-signer slot.
+   * @param string $childName
+   *   The child's name for the template.
+   * @param string $approvalUrl
+   *   The secure approval URL.
+   * @param bool $noCpr
+   *   Whether the fallback ran because no CPR was present (vs a failed send).
+   */
+  protected function sendEmailFallback(object $submission, int $slot, string $childName, string $approvalUrl, bool $noCpr): void {
+    $email = (string) ($submission->getElementData((string) $this->configuration['email_field']) ?? '');
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+      $this->recordStep('Co-sign Invitation', 'Failed - no valid Digital Post recipient or fallback email on the submission', 'failed');
+      $this->log('Co-sign invitation failed: no channel available for slot {slot}', ['slot' => $slot], 'error');
+      return;
+    }
+
+    $result = $this->mailManager->mail(
+      'aabenforms_workflows',
+      'parent_approval',
+      $email,
+      'en',
+      [
+        'parent_number' => $slot,
+        'child_name' => $childName,
+        'request_details' => '',
+        'approval_url' => $approvalUrl,
+        'deadline' => date('d-m-Y', strtotime('+14 days')),
+        'submission_id' => $submission->id(),
+      ],
+      NULL,
+      TRUE,
+    );
+
+    if (!empty($result['result'])) {
+      $this->recordStep(
+        'Co-sign Invitation Sent',
+        $noCpr ? 'Secure co-signature link sent via email (no CPR on submission)' : 'Secure co-signature link sent via email (Digital Post unavailable)',
+      );
+    }
+    else {
+      $this->recordStep('Co-sign Invitation', 'Failed - email fallback did not send', 'failed');
+    }
+  }
+
+  /**
+   * Builds the absolute approval URL for the co-signer link.
+   *
+   * Protected so unit tests can override it - Url::fromRoute needs the
+   * routed container which unit tests do not bootstrap.
+   *
+   * @param int $slot
+   *   The co-signer slot.
+   * @param int $submissionId
+   *   The submission id.
+   * @param string $token
+   *   The signed approval token.
+   *
+   * @return string
+   *   The absolute URL.
+   */
+  protected function buildApprovalUrl(int $slot, int $submissionId, string $token): string {
+    return Url::fromRoute('aabenforms_workflows.parent_approval', [
+      'parent_number' => $slot,
+      'submission_id' => $submissionId,
+      'token' => $token,
+    ], ['absolute' => TRUE])->toString();
+  }
+
+  /**
+   * Builds the Danish Digital Post letter body.
+   *
+   * @param string $childName
+   *   The child's name, or ''.
+   * @param string $approvalUrl
+   *   The secure approval URL.
+   *
+   * @return string
+   *   HTML body for the MeMo message.
+   */
+  protected function buildLetterBody(string $childName, string $approvalUrl): string {
+    $regarding = $childName !== ''
+      ? sprintf('<p>Der er indsendt en anmodning, som vedroerer %s, og som kraever din medunderskrift som foraeldremyndighedsindehaver.</p>', htmlspecialchars($childName, ENT_QUOTES, 'UTF-8'))
+      : '<p>Der er indsendt en anmodning, som kraever din medunderskrift som foraeldremyndighedsindehaver.</p>';
+    return $regarding
+      . sprintf('<p>Aabn linket og log ind med MitID for at se anmodningen og afgive din beslutning:</p><p><a href="%s">Se og underskriv anmodningen</a></p>', htmlspecialchars($approvalUrl, ENT_QUOTES, 'UTF-8'))
+      . '<p>Linket er gyldigt i 14 dage. Reagerer du ikke inden fristen, behandles sagen manuelt af kommunen.</p>';
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/ResolveGuardiansAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/ResolveGuardiansAction.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post_eca\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_digital_post\DigitalPost\RecipientResolution;
+use Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver;
+use Drupal\aabenforms_workflows\Plugin\Action\AabenFormsActionBase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Resolve Digital Post recipients for post about a child.
+ *
+ * Writes indexed recipient tokens so a flow can wire one Send Digital Post
+ * action per slot: `<result>_1` and `<result>_2` hold the recipient CPRs
+ * ('' when the slot is unused - the send action skips empty recipients).
+ * The `<result>_status` companion carries which rule applied ('guardians',
+ * 'pupil' or 'none') so a gate can branch to manual handling on 'none'.
+ */
+#[Action(
+  id: 'aabenforms_resolve_guardians',
+  label: new TranslatableMarkup('Resolve Digital Post Recipients for Child'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Resolves who receives Digital Post about a child: each custody holder when under 15, the young person from 15. Fail-closed.'),
+  version_introduced: '2.1.0',
+)]
+class ResolveGuardiansAction extends AabenFormsActionBase {
+
+  /**
+   * The largest number of indexed recipient tokens written.
+   *
+   * CPR custody supports at most two custody holders at a time; two send
+   * slots therefore cover the legal reality. Should the registry ever return
+   * more, the surplus is logged and dropped rather than silently ignored.
+   */
+  protected const MAX_RECIPIENT_SLOTS = 2;
+
+  /**
+   * The guardian recipient resolver.
+   *
+   * @var \Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver
+   */
+  protected GuardianRecipientResolver $resolver;
+
+  /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->setResolver($container->get('aabenforms_digital_post.guardian_recipient_resolver'));
+    $instance->setCprAccess($container->get('aabenforms_core.cpr_access'));
+    return $instance;
+  }
+
+  /**
+   * Setter injection for the resolver.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setResolver(GuardianRecipientResolver $resolver): void {
+    $this->resolver = $resolver;
+  }
+
+  /**
+   * Setter injection for the CPR access helper.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setCprAccess(CprAccess $cprAccess): void {
+    $this->cprAccess = $cprAccess;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'child_cpr_token' => 'child_cpr',
+      'result_token' => 'post_recipients',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['child_cpr_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Child CPR token name'),
+      '#description' => $this->t('Token containing the child CPR the post concerns.'),
+      '#default_value' => $this->configuration['child_cpr_token'],
+      '#required' => TRUE,
+    ];
+
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Base token name. Writes &lt;name&gt; (full resolution), &lt;name&gt;_status (guardians/pupil/none), &lt;name&gt;_count, and &lt;name&gt;_1 / &lt;name&gt;_2 (recipient CPRs, empty when unused).'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['child_cpr_token'] = $form_state->getValue('child_cpr_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $childCpr = $this->getTokenValue($this->configuration['child_cpr_token'], '');
+    $childCpr = $this->cprAccess->reveal((string) $childCpr);
+
+    $resolution = $this->resolver->resolveForChild((string) $childCpr);
+    $resultToken = (string) $this->configuration['result_token'];
+
+    $cprs = $resolution->cprs();
+    if (count($cprs) > self::MAX_RECIPIENT_SLOTS) {
+      $this->log('Recipient resolution returned {count} recipients; only the first {max} slots are written', [
+        'count' => count($cprs),
+        'max' => self::MAX_RECIPIENT_SLOTS,
+      ], 'warning');
+    }
+
+    $this->setTokenValue($resultToken, [
+      'rule' => $resolution->rule,
+      'reason' => $resolution->reason,
+      'recipients' => $resolution->recipients,
+    ]);
+    $this->setTokenValue($resultToken . '_status', $resolution->rule);
+    $this->setTokenValue($resultToken . '_count', (string) count($cprs));
+    for ($slot = 1; $slot <= self::MAX_RECIPIENT_SLOTS; $slot++) {
+      $this->setTokenValue($resultToken . '_' . $slot, $cprs[$slot - 1] ?? '');
+    }
+
+    switch ($resolution->rule) {
+      case RecipientResolution::RULE_GUARDIANS:
+        $this->recordStep(
+          'Digital Post Recipients Resolved',
+          sprintf('Child is under 15: post goes to %d registered custody holder(s)', count($cprs)),
+        );
+        break;
+
+      case RecipientResolution::RULE_PUPIL:
+        $this->recordStep(
+          'Digital Post Recipients Resolved',
+          'The young person is 15 or older and receives the post directly',
+        );
+        break;
+
+      default:
+        $this->log('Recipient resolution failed closed: {reason}', [
+          'reason' => $resolution->reason,
+        ], 'warning');
+        $this->recordStep(
+          'Digital Post Recipients Resolved',
+          'No recipient could be determined - manual handling required. ' . $resolution->reason,
+          'failed',
+        );
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/ResolveGuardiansAction.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/src/Plugin/Action/ResolveGuardiansAction.php
@@ -92,6 +92,7 @@ class ResolveGuardiansAction extends AabenFormsActionBase {
     return [
       'child_cpr_token' => 'child_cpr',
       'result_token' => 'post_recipients',
+      'persist_count_field' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -115,6 +116,13 @@ class ResolveGuardiansAction extends AabenFormsActionBase {
       '#required' => TRUE,
     ];
 
+    $form['persist_count_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Persist recipient count to field'),
+      '#description' => $this->t('Optional webform element key that receives the resolved recipient count. Later events run in a fresh token scope, so a join flow that must know how many custody holders the REGISTRY found needs it stored on the submission rather than re-derived from staff-typed fields.'),
+      '#default_value' => $this->configuration['persist_count_field'],
+    ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -124,7 +132,31 @@ class ResolveGuardiansAction extends AabenFormsActionBase {
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     $this->configuration['child_cpr_token'] = $form_state->getValue('child_cpr_token');
     $this->configuration['result_token'] = $form_state->getValue('result_token');
+    $this->configuration['persist_count_field'] = (string) $form_state->getValue('persist_count_field');
     parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * Stores the resolved recipient count on the submission, when configured.
+   *
+   * @param int $count
+   *   The number of resolved recipients.
+   */
+  protected function persistCount(int $count): void {
+    $field = (string) ($this->configuration['persist_count_field'] ?? '');
+    if ($field === '') {
+      return;
+    }
+    $submission = $this->getSubmission();
+    if ($submission === NULL) {
+      return;
+    }
+    if ((string) $submission->getElementData($field) === (string) $count) {
+      // Already stored: avoid a redundant save (and a redundant update event).
+      return;
+    }
+    $submission->setElementData($field, (string) $count);
+    $submission->resave();
   }
 
   /**
@@ -155,6 +187,8 @@ class ResolveGuardiansAction extends AabenFormsActionBase {
     for ($slot = 1; $slot <= self::MAX_RECIPIENT_SLOTS; $slot++) {
       $this->setTokenValue($resultToken . '_' . $slot, $cprs[$slot - 1] ?? '');
     }
+
+    $this->persistCount(count($cprs));
 
     switch ($resolution->rule) {
       case RecipientResolution::RULE_GUARDIANS:

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/CosignInvitationActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/CosignInvitationActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\aabenforms_digital_post_eca\Unit\Plugin\Action;
 
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
 use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
 use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
@@ -96,6 +97,16 @@ class CosignInvitationActionTest extends UnitTestCase {
       public ?WebformSubmissionInterface $testSubmission = NULL;
 
       /**
+       * Replaces the plugin configuration for a test case.
+       *
+       * @param array $configuration
+       *   The configuration to apply.
+       */
+      public function setTestConfiguration(array $configuration): void {
+        $this->configuration = $configuration;
+      }
+
+      /**
        * {@inheritdoc}
        */
       protected function buildApprovalUrl(int $slot, int $submissionId, string $token): string {
@@ -139,6 +150,8 @@ class CosignInvitationActionTest extends UnitTestCase {
     $configFactory = $this->createMock(ConfigFactoryInterface::class);
     $configFactory->method('get')->willReturn($settings);
     $this->action->setConfigFactory($configFactory);
+
+    $this->action->setFamilyLookup($this->createMock(FamilyRelationsLookupInterface::class));
   }
 
   /**
@@ -254,6 +267,106 @@ class CosignInvitationActionTest extends UnitTestCase {
     $this->collector->expects($this->once())
       ->method('addStep')
       ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+  }
+
+  /**
+   * A recipient outside the registered custody-holder set is blocked.
+   *
+   * Without this guard a citizen could make the municipality send Digital
+   * Post naming their child to any CPR - including their own, to self-approve.
+   *
+   * @covers ::execute
+   * @covers ::recipientHoldsCustody
+   */
+  public function testNonCustodyRecipientIsBlocked(): void {
+    $this->action->setTestConfiguration([
+      'parent_number' => '2',
+      'cpr_field' => 'parent2_cpr',
+      'email_field' => 'parent2_email',
+      'child_name_field' => 'child_name',
+      'child_cpr_field' => 'child_cpr',
+      'subject_template' => 'Anmodning om medunderskrift',
+    ]);
+    $this->action->testSubmission = $this->submission([
+      'parent2_cpr' => '1502856234',
+      'parent2_email' => 'stranger@example.dk',
+      'child_cpr' => '0109182345',
+    ]);
+
+    $familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+    $familyLookup->method('hasCustody')->willReturn(FALSE);
+    $this->action->setFamilyLookup($familyLookup);
+
+    $this->sender->expects($this->never())->method('send');
+    $this->mailManager->expects($this->never())->method('mail');
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+  }
+
+  /**
+   * A registered custody holder still receives the invitation.
+   *
+   * @covers ::execute
+   * @covers ::recipientHoldsCustody
+   */
+  public function testCustodyHolderRecipientIsAllowed(): void {
+    $this->action->setTestConfiguration([
+      'parent_number' => '2',
+      'cpr_field' => 'parent2_cpr',
+      'email_field' => 'parent2_email',
+      'child_name_field' => 'child_name',
+      'child_cpr_field' => 'child_cpr',
+      'subject_template' => 'Anmodning om medunderskrift',
+    ]);
+    $this->action->testSubmission = $this->submission([
+      'parent2_cpr' => '0803755210',
+      'parent2_email' => 'lars@example.dk',
+      'child_cpr' => '0109182345',
+    ]);
+
+    $familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+    $familyLookup->expects($this->once())
+      ->method('hasCustody')
+      ->with('0803755210', '0109182345')
+      ->willReturn(TRUE);
+    $this->action->setFamilyLookup($familyLookup);
+
+    $this->sender->expects($this->once())->method('send')->willReturn(Result::success('tx-9'));
+
+    $this->action->execute();
+  }
+
+  /**
+   * A registry failure during the custody check blocks the send.
+   *
+   * @covers ::recipientHoldsCustody
+   */
+  public function testCustodyCheckFailsClosedOnRegistryError(): void {
+    $this->action->setTestConfiguration([
+      'parent_number' => '2',
+      'cpr_field' => 'parent2_cpr',
+      'email_field' => 'parent2_email',
+      'child_name_field' => 'child_name',
+      'child_cpr_field' => 'child_cpr',
+      'subject_template' => 'Anmodning om medunderskrift',
+    ]);
+    $this->action->testSubmission = $this->submission([
+      'parent2_cpr' => '0803755210',
+      'parent2_email' => 'lars@example.dk',
+      'child_cpr' => '0109182345',
+    ]);
+
+    $familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+    $familyLookup->method('hasCustody')->willThrowException(new \RuntimeException('registry down'));
+    $this->action->setFamilyLookup($familyLookup);
+
+    $this->sender->expects($this->never())->method('send');
+    $this->mailManager->expects($this->never())->method('mail');
 
     $this->action->execute();
   }

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/CosignInvitationActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/CosignInvitationActionTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_digital_post_eca\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_digital_post\DigitalPost\DigitalPost;
+use Drupal\aabenforms_digital_post\DigitalPost\Result;
+use Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface;
+use Drupal\aabenforms_digital_post_eca\Plugin\Action\CosignInvitationAction;
+use Drupal\aabenforms_workflows\Service\ApprovalTokenService;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * Tests the co-sign invitation channel selection and failure honesty.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post_eca\Plugin\Action\CosignInvitationAction
+ * @group aabenforms_digital_post_eca
+ */
+class CosignInvitationActionTest extends UnitTestCase {
+
+  /**
+   * Mocked Digital Post sender.
+   *
+   * @var \Drupal\aabenforms_digital_post\Service\DigitalPostSenderInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $sender;
+
+  /**
+   * Mocked mail manager.
+   *
+   * @var \Drupal\Core\Mail\MailManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $mailManager;
+
+  /**
+   * Mocked execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $collector;
+
+  /**
+   * The action under test (URL builder overridden for unit scope).
+   *
+   * @var \Drupal\aabenforms_digital_post_eca\Plugin\Action\CosignInvitationAction
+   */
+  protected CosignInvitationAction $action;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $tokenService = $this->createMock(TokenInterface::class);
+    $tokenService->method('getTokenData')->willReturn(NULL);
+
+    // Anonymous subclass: Url::fromRoute needs a bootstrapped container, so
+    // the URL builder is overridden with a deterministic stub.
+    $this->action = new class(
+      [
+        'parent_number' => '2',
+        'cpr_field' => 'parent2_cpr',
+        'email_field' => 'parent2_email',
+        'child_name_field' => 'child_name',
+        'subject_template' => 'Anmodning om medunderskrift',
+      ],
+      'aabenforms_send_cosign_invitation',
+      [],
+      $this->createMock(EntityTypeManagerInterface::class),
+      $tokenService,
+      $this->createMock(AccountProxyInterface::class),
+      $this->createMock(TimeInterface::class),
+      $this->createMock(EcaState::class),
+      $this->createMock(LoggerChannelInterface::class),
+    ) extends CosignInvitationAction {
+
+      /**
+       * The submission injected by the test.
+       *
+       * @var \Drupal\webform\WebformSubmissionInterface|null
+       */
+      public ?WebformSubmissionInterface $testSubmission = NULL;
+
+      /**
+       * {@inheritdoc}
+       */
+      protected function buildApprovalUrl(int $slot, int $submissionId, string $token): string {
+        return sprintf('https://example.dk/parent-approval/%d/%d/%s', $slot, $submissionId, $token);
+      }
+
+      /**
+       * {@inheritdoc}
+       */
+      protected function getSubmission($entity = NULL): ?WebformSubmissionInterface {
+        return $this->testSubmission;
+      }
+
+    };
+
+    $this->collector = $this->createMock(WorkflowExecutionCollector::class);
+    $this->action->setExecutionCollector($this->collector);
+
+    $this->sender = $this->createMock(DigitalPostSenderInterface::class);
+    $this->action->setSender($this->sender);
+
+    $tokenSvc = $this->createMock(ApprovalTokenService::class);
+    $tokenSvc->method('generateToken')->willReturn('signed-token');
+    $this->action->setApprovalTokenService($tokenSvc);
+
+    $cprAccess = $this->createMock(CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $this->action->setCprAccess($cprAccess);
+
+    $this->mailManager = $this->createMock(MailManagerInterface::class);
+    $this->action->setMailManager($this->mailManager);
+
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')->willReturnCallback(
+      static fn ($key) => match ($key) {
+        'sender_cvr' => '55133018',
+        'sender_name' => 'Demo Kommune',
+        default => NULL,
+      }
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($settings);
+    $this->action->setConfigFactory($configFactory);
+  }
+
+  /**
+   * Builds a submission mock with the given element data.
+   *
+   * @param array $data
+   *   Element data keyed by field name.
+   *
+   * @return \Drupal\webform\WebformSubmissionInterface
+   *   The mock.
+   */
+  protected function submission(array $data): WebformSubmissionInterface {
+    $submission = $this->createMock(WebformSubmissionInterface::class);
+    $submission->method('getElementData')
+      ->willReturnCallback(static fn (string $field) => $data[$field] ?? NULL);
+    $submission->method('id')->willReturn(42);
+    $submission->method('uuid')->willReturn('uuid-42');
+    return $submission;
+  }
+
+  /**
+   * A CPR-bearing co-signer gets the invitation via Digital Post.
+   *
+   * @covers ::execute
+   */
+  public function testCprRecipientGetsDigitalPost(): void {
+    $this->action->testSubmission = $this->submission([
+      'parent2_cpr' => '0803755210',
+      'parent2_email' => 'lars@example.dk',
+      'child_name' => 'Emil',
+    ]);
+
+    $this->sender->expects($this->once())
+      ->method('send')
+      ->with($this->callback(function (DigitalPost $post): bool {
+        return $post->recipient->identifier === '0803755210'
+          && str_contains($post->body, 'medunderskrift')
+          && str_contains($post->body, 'https://example.dk/parent-approval/2/42/signed-token')
+          && str_starts_with($post->meta['transaction_id'], 'cosign_');
+      }))
+      ->willReturn(Result::success('tx-1'));
+
+    $this->mailManager->expects($this->never())->method('mail');
+
+    $this->action->execute();
+  }
+
+  /**
+   * A pending (live accepted) send counts as delivered, no email fallback.
+   *
+   * @covers ::execute
+   */
+  public function testPendingSendCountsAsSent(): void {
+    $this->action->testSubmission = $this->submission([
+      'parent2_cpr' => '0803755210',
+      'parent2_email' => 'lars@example.dk',
+    ]);
+    $this->sender->method('send')->willReturn(Result::pending('tx-2'));
+    $this->mailManager->expects($this->never())->method('mail');
+
+    $this->action->execute();
+  }
+
+  /**
+   * Without a CPR the invitation falls back to email.
+   *
+   * @covers ::execute
+   */
+  public function testNoCprFallsBackToEmail(): void {
+    $this->action->testSubmission = $this->submission([
+      'parent2_email' => 'lars@example.dk',
+      'child_name' => 'Emil',
+    ]);
+
+    $this->sender->expects($this->never())->method('send');
+    $this->mailManager->expects($this->once())
+      ->method('mail')
+      ->with('aabenforms_workflows', 'parent_approval', 'lars@example.dk')
+      ->willReturn(['result' => TRUE]);
+
+    $this->action->execute();
+  }
+
+  /**
+   * A failed Digital Post send falls back to email.
+   *
+   * @covers ::execute
+   */
+  public function testFailedSendFallsBackToEmail(): void {
+    $this->action->testSubmission = $this->submission([
+      'parent2_cpr' => '0803755210',
+      'parent2_email' => 'lars@example.dk',
+    ]);
+    $this->sender->method('send')
+      ->willReturn(Result::failure('tx-3', Result::REASON_RECIPIENT_UNKNOWN, 'unknown'));
+    $this->mailManager->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => TRUE]);
+
+    $this->action->execute();
+  }
+
+  /**
+   * No CPR and no valid email records a failed step, never a sent one.
+   *
+   * @covers ::execute
+   */
+  public function testNoChannelRecordsFailedStep(): void {
+    $this->action->testSubmission = $this->submission([]);
+
+    $this->sender->expects($this->never())->method('send');
+    $this->mailManager->expects($this->never())->method('mail');
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+  }
+
+  /**
+   * A missing submission records a skipped step.
+   *
+   * @covers ::execute
+   */
+  public function testMissingSubmissionSkips(): void {
+    $this->action->testSubmission = NULL;
+
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'skipped');
+
+    $this->action->execute();
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/ResolveGuardiansActionTest.php
+++ b/web/modules/custom/aabenforms_digital_post/modules/aabenforms_digital_post_eca/tests/src/Unit/Plugin/Action/ResolveGuardiansActionTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_digital_post_eca\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_digital_post\DigitalPost\RecipientResolution;
+use Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver;
+use Drupal\aabenforms_digital_post_eca\Plugin\Action\ResolveGuardiansAction;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the ResolveGuardiansAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post_eca\Plugin\Action\ResolveGuardiansAction
+ * @group aabenforms_digital_post_eca
+ */
+class ResolveGuardiansActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_digital_post_eca\Plugin\Action\ResolveGuardiansAction
+   */
+  protected ResolveGuardiansAction $action;
+
+  /**
+   * Mock resolver.
+   *
+   * @var \Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $resolver;
+
+  /**
+   * Mock execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $collector;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')
+      ->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')
+      ->willReturnCallback(function ($name, $value) use ($tokenServices) {
+        $this->tokenStorage[$name] = $value;
+        return $tokenServices;
+      });
+
+    $this->action = new ResolveGuardiansAction(
+      ['child_cpr_token' => 'child_cpr', 'result_token' => 'post_recipients'],
+      'aabenforms_resolve_guardians',
+      [],
+      $this->createMock(EntityTypeManagerInterface::class),
+      $tokenServices,
+      $this->createMock(AccountProxyInterface::class),
+      $this->createMock(TimeInterface::class),
+      $this->createMock(EcaState::class),
+      $this->createMock(LoggerChannelInterface::class),
+    );
+    $this->collector = $this->createMock(WorkflowExecutionCollector::class);
+    $this->action->setExecutionCollector($this->collector);
+
+    $this->resolver = $this->createMock(GuardianRecipientResolver::class);
+    $this->action->setResolver($this->resolver);
+
+    $cprAccess = $this->createMock(CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+    $this->action->setCprAccess($cprAccess);
+  }
+
+  /**
+   * Two guardians fill both send slots and status is 'guardians'.
+   *
+   * @covers ::execute
+   */
+  public function testTwoGuardiansFillBothSlots(): void {
+    $this->tokenStorage['child_cpr'] = '0109182345';
+    $this->resolver->method('resolveForChild')->willReturn(new RecipientResolution(
+      RecipientResolution::RULE_GUARDIANS,
+      'Under 15.',
+      [
+        ['cpr' => '0101904521', 'full_name' => 'Freja Nielsen', 'role' => 'guardian'],
+        ['cpr' => '0803755210', 'full_name' => 'Lars Andersen', 'role' => 'guardian'],
+      ],
+    ));
+
+    $this->action->execute();
+
+    $this->assertSame('guardians', $this->tokenStorage['post_recipients_status']);
+    $this->assertSame('2', $this->tokenStorage['post_recipients_count']);
+    $this->assertSame('0101904521', $this->tokenStorage['post_recipients_1']);
+    $this->assertSame('0803755210', $this->tokenStorage['post_recipients_2']);
+  }
+
+  /**
+   * A sole guardian leaves the second slot empty so send #2 skips.
+   *
+   * @covers ::execute
+   */
+  public function testSoleGuardianLeavesSecondSlotEmpty(): void {
+    $this->tokenStorage['child_cpr'] = '1203192345';
+    $this->resolver->method('resolveForChild')->willReturn(new RecipientResolution(
+      RecipientResolution::RULE_GUARDIANS,
+      'Under 15.',
+      [
+        ['cpr' => '2506924015', 'full_name' => 'Sofie Hansen', 'role' => 'guardian'],
+      ],
+    ));
+
+    $this->action->execute();
+
+    $this->assertSame('2506924015', $this->tokenStorage['post_recipients_1']);
+    $this->assertSame('', $this->tokenStorage['post_recipients_2']);
+    $this->assertSame('1', $this->tokenStorage['post_recipients_count']);
+  }
+
+  /**
+   * A 15+ pupil occupies slot 1 with status 'pupil'.
+   *
+   * @covers ::execute
+   */
+  public function testPupilRule(): void {
+    $this->tokenStorage['child_cpr'] = '2005102345';
+    $this->resolver->method('resolveForChild')->willReturn(new RecipientResolution(
+      RecipientResolution::RULE_PUPIL,
+      '15 or older.',
+      [
+        ['cpr' => '2005102345', 'full_name' => '', 'role' => 'pupil'],
+      ],
+    ));
+
+    $this->action->execute();
+
+    $this->assertSame('pupil', $this->tokenStorage['post_recipients_status']);
+    $this->assertSame('2005102345', $this->tokenStorage['post_recipients_1']);
+    $this->assertSame('', $this->tokenStorage['post_recipients_2']);
+  }
+
+  /**
+   * RULE_NONE records a failed step and empties every slot.
+   *
+   * @covers ::execute
+   */
+  public function testNoneRuleRecordsFailedStep(): void {
+    $this->tokenStorage['child_cpr'] = '9999999999';
+    $this->resolver->method('resolveForChild')->willReturn(new RecipientResolution(
+      RecipientResolution::RULE_NONE,
+      'Birth date unknown.',
+      [],
+    ));
+
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+
+    $this->assertSame('none', $this->tokenStorage['post_recipients_status']);
+    $this->assertSame('0', $this->tokenStorage['post_recipients_count']);
+    $this->assertSame('', $this->tokenStorage['post_recipients_1']);
+    $this->assertSame('', $this->tokenStorage['post_recipients_2']);
+  }
+
+  /**
+   * The full resolution rides the base result token for auditing.
+   *
+   * @covers ::execute
+   */
+  public function testFullResolutionOnBaseToken(): void {
+    $this->tokenStorage['child_cpr'] = '0109182345';
+    $recipients = [
+      ['cpr' => '0101904521', 'full_name' => 'Freja Nielsen', 'role' => 'guardian'],
+    ];
+    $this->resolver->method('resolveForChild')->willReturn(new RecipientResolution(
+      RecipientResolution::RULE_GUARDIANS,
+      'Under 15.',
+      $recipients,
+    ));
+
+    $this->action->execute();
+
+    $this->assertSame('guardians', $this->tokenStorage['post_recipients']['rule']);
+    $this->assertSame($recipients, $this->tokenStorage['post_recipients']['recipients']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/src/DigitalPost/RecipientResolution.php
+++ b/web/modules/custom/aabenforms_digital_post/src/DigitalPost/RecipientResolution.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\DigitalPost;
+
+/**
+ * The outcome of resolving Digital Post recipients for a child.
+ *
+ * Danish law (in force since 21 March 2022) requires post concerning a joint
+ * child to reach BOTH custody holders, while young people aged 15+ are
+ * enrolled in Digital Post themselves and receive authority mail directly.
+ * This DTO carries which rule applied so flows can branch and audit honestly.
+ */
+final class RecipientResolution {
+
+  /**
+   * Post about the child goes to each custody holder (child under 15).
+   */
+  public const RULE_GUARDIANS = 'guardians';
+
+  /**
+   * Post goes to the young person directly (15 or older).
+   */
+  public const RULE_PUPIL = 'pupil';
+
+  /**
+   * No recipient could be determined.
+   *
+   * The flow must fall back to manual handling instead of guessing.
+   */
+  public const RULE_NONE = 'none';
+
+  /**
+   * Constructs a resolution.
+   *
+   * @param string $rule
+   *   One of the RULE_* constants.
+   * @param string $reason
+   *   Human-readable explanation of why this rule applied.
+   * @param array $recipients
+   *   List of recipient records, each with keys:
+   *   - cpr (string): the recipient CPR.
+   *   - full_name (string): display name, '' when unknown.
+   *   - role (string): 'guardian' or 'pupil'.
+   */
+  public function __construct(
+    public readonly string $rule,
+    public readonly string $reason,
+    public readonly array $recipients,
+  ) {
+  }
+
+  /**
+   * The recipient CPR numbers, in stable order.
+   *
+   * @return string[]
+   *   The CPR numbers.
+   */
+  public function cprs(): array {
+    return array_values(array_map(static fn (array $r): string => $r['cpr'], $this->recipients));
+  }
+
+  /**
+   * Whether any recipient was resolved.
+   */
+  public function hasRecipients(): bool {
+    return $this->recipients !== [];
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/src/Service/GuardianRecipientResolver.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Service/GuardianRecipientResolver.php
@@ -143,8 +143,15 @@ class GuardianRecipientResolver {
    *   The age in whole years, in Danish local time.
    */
   protected function ageAt(\DateTimeImmutable $birthDate): int {
+    $copenhagen = new \DateTimeZone('Europe/Copenhagen');
     $today = (new \DateTimeImmutable('@' . $this->time->getRequestTime()))
-      ->setTimezone(new \DateTimeZone('Europe/Copenhagen'));
+      ->setTimezone($copenhagen);
+    // Rebuild the birth date as midnight DANISH time: registry birth dates
+    // are calendar dates, but DateTimeImmutable pins a date-only string to
+    // the ambient PHP timezone (often UTC on CLI/queue workers), and diff()
+    // honours both offsets - which made a pupil count as 14 during the first
+    // hours of their 15th birthday.
+    $birthDate = new \DateTimeImmutable($birthDate->format('Y-m-d'), $copenhagen);
     return $birthDate->diff($today)->y;
   }
 

--- a/web/modules/custom/aabenforms_digital_post/src/Service/GuardianRecipientResolver.php
+++ b/web/modules/custom/aabenforms_digital_post/src/Service/GuardianRecipientResolver.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_digital_post\Service;
+
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
+use Drupal\aabenforms_digital_post\DigitalPost\RecipientResolution;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves who receives Digital Post concerning a child.
+ *
+ * Implements the sender-side recipient rule the post infrastructure does NOT
+ * implement for you:
+ * - Child under 15: one message per registered custody holder (the 21 March
+ *   2022 rule; separated parents at different addresses each get their own
+ *   letter).
+ * - Young person 15+: the pupil receives the post directly (15 is the age of
+ *   mandatory Digital Post enrolment; parents only see it if the teen grants
+ *   access in Digital Post itself).
+ * - Unknown birth date or no registered custody holders: fail closed with
+ *   RULE_NONE so the flow escalates to manual handling instead of guessing.
+ *
+ * Age is computed from the registry birth date (never parsed out of the CPR
+ * number, whose century encoding is ambiguous) against Danish local time.
+ */
+class GuardianRecipientResolver {
+
+  /**
+   * The age from which Digital Post goes to the young person directly.
+   */
+  public const DIGITAL_POST_AGE = 15;
+
+  /**
+   * The logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  public function __construct(
+    protected FamilyRelationsLookupInterface $familyLookup,
+    protected TimeInterface $time,
+    LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->logger = $loggerFactory->get('aabenforms_digital_post');
+  }
+
+  /**
+   * Resolves the Digital Post recipients for post concerning a child.
+   *
+   * @param string $childCpr
+   *   The child's CPR number (10 digits, hyphens tolerated).
+   *
+   * @return \Drupal\aabenforms_digital_post\DigitalPost\RecipientResolution
+   *   The resolution. Never throws: registry failures resolve to RULE_NONE
+   *   (fail closed) with the reason recorded.
+   */
+  public function resolveForChild(string $childCpr): RecipientResolution {
+    $childCpr = preg_replace('/[^0-9]/', '', $childCpr) ?? '';
+    if (strlen($childCpr) !== 10) {
+      return new RecipientResolution(
+        RecipientResolution::RULE_NONE,
+        'Child CPR is missing or malformed.',
+        [],
+      );
+    }
+
+    try {
+      $birthDate = $this->familyLookup->birthDateOf($childCpr);
+
+      if ($birthDate === NULL) {
+        return new RecipientResolution(
+          RecipientResolution::RULE_NONE,
+          'Birth date unknown in the CPR registry; recipient rule cannot be applied.',
+          [],
+        );
+      }
+
+      if ($this->ageAt($birthDate) >= self::DIGITAL_POST_AGE) {
+        return new RecipientResolution(
+          RecipientResolution::RULE_PUPIL,
+          'The young person is 15 or older and receives Digital Post directly.',
+          [
+            ['cpr' => $childCpr, 'full_name' => '', 'role' => 'pupil'],
+          ],
+        );
+      }
+
+      $recipients = [];
+      $seen = [];
+      foreach ($this->familyLookup->guardiansOf($childCpr) as $guardian) {
+        $cpr = (string) ($guardian['cpr'] ?? '');
+        if ($cpr === '' || isset($seen[$cpr])) {
+          continue;
+        }
+        $seen[$cpr] = TRUE;
+        $recipients[] = [
+          'cpr' => $cpr,
+          'full_name' => (string) ($guardian['full_name'] ?? ''),
+          'role' => 'guardian',
+        ];
+      }
+
+      if ($recipients === []) {
+        return new RecipientResolution(
+          RecipientResolution::RULE_NONE,
+          'No registered custody holders found for the child.',
+          [],
+        );
+      }
+
+      return new RecipientResolution(
+        RecipientResolution::RULE_GUARDIANS,
+        sprintf('Child is under 15; post goes to each of the %d registered custody holder(s).', count($recipients)),
+        $recipients,
+      );
+    }
+    catch (\Exception $e) {
+      // Fail closed: an unavailable registry must never cause post about a
+      // child to be sent to a guessed recipient.
+      $this->logger->error('Guardian recipient resolution failed closed: {message}', [
+        'message' => $e->getMessage(),
+      ]);
+      return new RecipientResolution(
+        RecipientResolution::RULE_NONE,
+        'The CPR registry could not be reached; recipient resolution failed closed.',
+        [],
+      );
+    }
+  }
+
+  /**
+   * Computes the age in whole years at the current request time.
+   *
+   * @param \DateTimeImmutable $birthDate
+   *   The birth date.
+   *
+   * @return int
+   *   The age in whole years, in Danish local time.
+   */
+  protected function ageAt(\DateTimeImmutable $birthDate): int {
+    $today = (new \DateTimeImmutable('@' . $this->time->getRequestTime()))
+      ->setTimezone(new \DateTimeZone('Europe/Copenhagen'));
+    return $birthDate->diff($today)->y;
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/GuardianRecipientResolverTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/GuardianRecipientResolverTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_digital_post\Unit\Service;
+
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
+use Drupal\aabenforms_digital_post\DigitalPost\RecipientResolution;
+use Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the guardian recipient resolver (the under-15/15+ rule).
+ *
+ * @coversDefaultClass \Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver
+ * @group aabenforms_digital_post
+ */
+class GuardianRecipientResolverTest extends UnitTestCase {
+
+  /**
+   * Mock family lookup.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $familyLookup;
+
+  /**
+   * The resolver under test.
+   *
+   * @var \Drupal\aabenforms_digital_post\Service\GuardianRecipientResolver
+   */
+  protected GuardianRecipientResolver $resolver;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+
+    // Fixed "today": 2026-07-26.
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn((int) (new \DateTimeImmutable('2026-07-26T12:00:00+02:00'))->format('U'));
+
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+
+    $this->resolver = new GuardianRecipientResolver($this->familyLookup, $time, $loggerFactory);
+  }
+
+  /**
+   * A child under 15 resolves to each registered custody holder.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testUnder15ResolvesToBothGuardians(): void {
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2018-09-01'));
+    $this->familyLookup->method('guardiansOf')->willReturn([
+      ['cpr' => '0101904521', 'type' => 3, 'full_name' => 'Freja Nielsen', 'same_address' => TRUE],
+      ['cpr' => '0803755210', 'type' => 4, 'full_name' => 'Lars Andersen', 'same_address' => FALSE],
+    ]);
+
+    $resolution = $this->resolver->resolveForChild('0109182345');
+
+    $this->assertSame(RecipientResolution::RULE_GUARDIANS, $resolution->rule);
+    $this->assertSame(['0101904521', '0803755210'], $resolution->cprs());
+    $this->assertSame('guardian', $resolution->recipients[0]['role']);
+  }
+
+  /**
+   * A 15+ pupil receives the post directly; guardians are never queried.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testPupilAged15PlusReceivesDirectly(): void {
+    // Born 2010-05-20: 16 years old on 2026-07-26.
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2010-05-20'));
+    $this->familyLookup->expects($this->never())->method('guardiansOf');
+
+    $resolution = $this->resolver->resolveForChild('2005102345');
+
+    $this->assertSame(RecipientResolution::RULE_PUPIL, $resolution->rule);
+    $this->assertSame(['2005102345'], $resolution->cprs());
+    $this->assertSame('pupil', $resolution->recipients[0]['role']);
+  }
+
+  /**
+   * The 15th birthday itself flips the rule to direct delivery.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testExactly15YearsOldReceivesDirectly(): void {
+    // Born 2011-07-26: turns exactly 15 on the fixed "today".
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2011-07-26'));
+
+    $resolution = $this->resolver->resolveForChild('2607112345');
+
+    $this->assertSame(RecipientResolution::RULE_PUPIL, $resolution->rule);
+  }
+
+  /**
+   * One day before the 15th birthday, guardians still receive the post.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testDayBefore15thBirthdayGoesToGuardians(): void {
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2011-07-27'));
+    $this->familyLookup->method('guardiansOf')->willReturn([
+      ['cpr' => '0101904521', 'type' => 3, 'full_name' => 'Freja Nielsen', 'same_address' => TRUE],
+    ]);
+
+    $resolution = $this->resolver->resolveForChild('2707112345');
+
+    $this->assertSame(RecipientResolution::RULE_GUARDIANS, $resolution->rule);
+  }
+
+  /**
+   * Sole custody yields exactly one recipient.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testSoleCustodySingleRecipient(): void {
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2019-03-12'));
+    $this->familyLookup->method('guardiansOf')->willReturn([
+      ['cpr' => '2506924015', 'type' => 3, 'full_name' => 'Sofie Hansen', 'same_address' => TRUE],
+    ]);
+
+    $resolution = $this->resolver->resolveForChild('1203192345');
+
+    $this->assertSame(RecipientResolution::RULE_GUARDIANS, $resolution->rule);
+    $this->assertSame(['2506924015'], $resolution->cprs());
+  }
+
+  /**
+   * Unknown birth date fails closed to RULE_NONE.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testUnknownBirthDateFailsClosed(): void {
+    $this->familyLookup->method('birthDateOf')->willReturn(NULL);
+
+    $resolution = $this->resolver->resolveForChild('9999999999');
+
+    $this->assertSame(RecipientResolution::RULE_NONE, $resolution->rule);
+    $this->assertFalse($resolution->hasRecipients());
+  }
+
+  /**
+   * A child without registered custody holders fails closed.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testNoGuardiansFailsClosed(): void {
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2018-09-01'));
+    $this->familyLookup->method('guardiansOf')->willReturn([]);
+
+    $resolution = $this->resolver->resolveForChild('0109182345');
+
+    $this->assertSame(RecipientResolution::RULE_NONE, $resolution->rule);
+  }
+
+  /**
+   * Registry failure resolves to RULE_NONE instead of throwing.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testRegistryErrorFailsClosed(): void {
+    $this->familyLookup->method('birthDateOf')->willThrowException(new \RuntimeException('down'));
+
+    $resolution = $this->resolver->resolveForChild('0109182345');
+
+    $this->assertSame(RecipientResolution::RULE_NONE, $resolution->rule);
+    $this->assertFalse($resolution->hasRecipients());
+  }
+
+  /**
+   * Malformed CPR input fails closed without touching the registry.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testMalformedCprFailsClosed(): void {
+    $this->familyLookup->expects($this->never())->method('birthDateOf');
+
+    $resolution = $this->resolver->resolveForChild('12345');
+
+    $this->assertSame(RecipientResolution::RULE_NONE, $resolution->rule);
+  }
+
+  /**
+   * Duplicate guardian CPRs are deduplicated.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testDuplicateGuardiansDeduplicated(): void {
+    $this->familyLookup->method('birthDateOf')->willReturn(new \DateTimeImmutable('2018-09-01'));
+    $this->familyLookup->method('guardiansOf')->willReturn([
+      ['cpr' => '0101904521', 'type' => 3, 'full_name' => 'Freja Nielsen', 'same_address' => TRUE],
+      ['cpr' => '0101904521', 'type' => 5, 'full_name' => 'Freja Nielsen', 'same_address' => TRUE],
+    ]);
+
+    $resolution = $this->resolver->resolveForChild('0109182345');
+
+    $this->assertSame(['0101904521'], $resolution->cprs());
+  }
+
+}

--- a/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/GuardianRecipientResolverTest.php
+++ b/web/modules/custom/aabenforms_digital_post/tests/src/Unit/Service/GuardianRecipientResolverTest.php
@@ -101,6 +101,35 @@ class GuardianRecipientResolverTest extends UnitTestCase {
   }
 
   /**
+   * The birthday boundary holds in the first hours of the day.
+   *
+   * Regression: registry birth dates are calendar dates; when constructed in
+   * the ambient timezone (UTC on CLI/queue workers) while "today" is Danish
+   * local time, diff() undercounted the age by one during the first hours of
+   * the 15th birthday and letters went to the guardians instead of the pupil.
+   *
+   * @covers ::resolveForChild
+   */
+  public function testBirthdayBoundaryAtMidnightDanishTime(): void {
+    // 00:30 Danish summer time on the 15th birthday = 22:30 UTC the day
+    // before. The resolver must still count 15 years.
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn((int) (new \DateTimeImmutable('2026-07-26T00:30:00+02:00'))->format('U'));
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+    $resolver = new GuardianRecipientResolver($this->familyLookup, $time, $loggerFactory);
+
+    // Birth date deliberately constructed in UTC, as birthDateOf() does on a
+    // UTC-default worker.
+    $this->familyLookup->method('birthDateOf')
+      ->willReturn(new \DateTimeImmutable('2011-07-26', new \DateTimeZone('UTC')));
+
+    $resolution = $resolver->resolveForChild('2607112345');
+
+    $this->assertSame(RecipientResolution::RULE_PUPIL, $resolution->rule);
+  }
+
+  /**
    * One day before the 15th birthday, guardians still receive the post.
    *
    * @covers ::resolveForChild

--- a/web/modules/custom/aabenforms_institution/aabenforms_institution.info.yml
+++ b/web/modules/custom/aabenforms_institution/aabenforms_institution.info.yml
@@ -1,0 +1,10 @@
+name: 'ÅbenForms Institution'
+type: module
+description: 'Registry of schools and other institutions keyed by institutionsnummer (Institutionsregisteret), with hierarchy-aware routing for workflows. Institutions only - pupils, classes and groups belong to STIL/OS2skoledata.'
+package: 'ÅbenForms'
+core_version_requirement: ^11
+php: ^8.3
+
+dependencies:
+  - aabenforms_core:aabenforms_core
+  - aabenforms_workflows:aabenforms_workflows

--- a/web/modules/custom/aabenforms_institution/aabenforms_institution.info.yml
+++ b/web/modules/custom/aabenforms_institution/aabenforms_institution.info.yml
@@ -6,5 +6,6 @@ core_version_requirement: ^11
 php: ^8.3
 
 dependencies:
+  - drupal:options
   - aabenforms_core:aabenforms_core
   - aabenforms_workflows:aabenforms_workflows

--- a/web/modules/custom/aabenforms_institution/aabenforms_institution.permissions.yml
+++ b/web/modules/custom/aabenforms_institution/aabenforms_institution.permissions.yml
@@ -1,0 +1,4 @@
+administer aabenforms_institution:
+  title: 'Administer institutions'
+  description: 'Create, edit and delete institution registry entries.'
+  restrict access: true

--- a/web/modules/custom/aabenforms_institution/aabenforms_institution.services.yml
+++ b/web/modules/custom/aabenforms_institution/aabenforms_institution.services.yml
@@ -1,0 +1,16 @@
+services:
+  aabenforms_institution.registry:
+    class: Drupal\aabenforms_institution\Service\InstitutionRegistry
+    arguments:
+      - '@entity_type.manager'
+
+  # Decorates the org chart so employee ids of the form
+  # "inst:<institutionsnummer>" resolve their manager via the registry
+  # (school leader, escalating up the parent chain). All other ids
+  # delegate to the decorated directory unchanged.
+  aabenforms_institution.org_chart:
+    class: Drupal\aabenforms_institution\Service\InstitutionOrgChartService
+    decorates: aabenforms_workflows.org_chart
+    arguments:
+      - '@aabenforms_institution.org_chart.inner'
+      - '@aabenforms_institution.registry'

--- a/web/modules/custom/aabenforms_institution/drush.services.yml
+++ b/web/modules/custom/aabenforms_institution/drush.services.yml
@@ -1,0 +1,8 @@
+services:
+  aabenforms_institution.drush_commands:
+    class: Drupal\aabenforms_institution\Drush\InstitutionCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@aabenforms_institution.registry'
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/aabenforms_institution/fixtures/aarhus_demo_institutions.csv
+++ b/web/modules/custom/aabenforms_institution/fixtures/aarhus_demo_institutions.csv
@@ -1,0 +1,10 @@
+institution_number,name,type,district,leader_name,leader_email,parent_number,active
+751000,Børn og Unge (forvaltning),forvaltning,,Marie Kirkegaard,bu-demo@example.dk,,1
+751001,PPR Aarhus,forvaltning,,Jonas Iversen,ppr-demo@example.dk,751000,1
+751101,Frederiksbjerg Skole,skole,Frederiksbjerg,Anne Holm,skoleleder.frederiksbjerg@example.dk,751000,1
+751102,Katrinebjergskolen,skole,Katrinebjerg,Peter Dam,skoleleder.katrinebjerg@example.dk,751000,1
+751103,Møllevangskolen,skole,Møllevang,Lise Krog,skoleleder.moellevang@example.dk,751000,1
+751104,Risskov Skole,skole,Risskov,Søren Bak,skoleleder.risskov@example.dk,751000,1
+751105,Skåde Skole,skole,Skåde,Mette Juhl,,751000,1
+751201,Børnehuset Solstrålen,dagtilbud,Frederiksbjerg,Karin Toft,solstraalen@example.dk,751000,1
+751301,UngiAarhus Syd,fu,,Nikolaj Brandt,ungiaarhus-syd@example.dk,751000,1

--- a/web/modules/custom/aabenforms_institution/src/Drush/InstitutionCommands.php
+++ b/web/modules/custom/aabenforms_institution/src/Drush/InstitutionCommands.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_institution\Drush;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\aabenforms_institution\Entity\AabenformsInstitution;
+use Drupal\aabenforms_institution\Service\InstitutionRegistry;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for the institution registry.
+ *
+ * Af:inst:seed  import institutions from a CSV extract
+ * af:inst:list  show the registry.
+ */
+final class InstitutionCommands extends DrushCommands {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly InstitutionRegistry $registry,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Seed the institution registry from a CSV file.
+   *
+   * The expected columns mirror the bundled demo fixture:
+   * institution_number,name,type,district,leader_name,leader_email,
+   * parent_number,active. Existing rows (matched on institution_number)
+   * are updated, new ones created; parents are linked in a second pass so
+   * row order does not matter. Data source for a real municipality: the
+   * active-institutions extract from data.stil.dk (Institutionsregisteret).
+   *
+   * @command aabenforms:institution:seed
+   * @aliases af:inst:seed
+   * @option file Path to the CSV file. Defaults to the bundled Aarhus demo fixture.
+   * @usage drush af:inst:seed
+   *   Seed the bundled Aarhus demo institutions.
+   * @usage drush af:inst:seed --file=/tmp/institutions.csv
+   *   Seed from a data.stil.dk extract.
+   */
+  public function seed(array $options = ['file' => NULL]): void {
+    $file = $options['file'] ?? \Drupal::service('extension.list.module')->getPath('aabenforms_institution') . '/fixtures/aarhus_demo_institutions.csv';
+    if (!is_readable($file)) {
+      throw new \RuntimeException(sprintf('CSV file not readable: %s', $file));
+    }
+
+    $handle = fopen($file, 'r');
+    if ($handle === FALSE) {
+      throw new \RuntimeException(sprintf('Could not open: %s', $file));
+    }
+
+    $header = fgetcsv($handle, escape: '\\');
+    if ($header === FALSE) {
+      fclose($handle);
+      throw new \RuntimeException('CSV file is empty.');
+    }
+
+    $storage = $this->entityTypeManager->getStorage('aabenforms_institution');
+    $parentLinks = [];
+    $created = 0;
+    $updated = 0;
+
+    while (($row = fgetcsv($handle, escape: '\\')) !== FALSE) {
+      $data = array_combine($header, $row);
+      $number = trim((string) $data['institution_number']);
+      if ($number === '') {
+        continue;
+      }
+
+      $institution = $this->registry->findByNumber($number);
+      if ($institution === NULL) {
+        $institution = $storage->create(['institution_number' => $number]);
+        $created++;
+      }
+      else {
+        $updated++;
+      }
+
+      $institution->set('name', trim((string) $data['name']));
+      $institution->set('type', trim((string) $data['type']) ?: AabenformsInstitution::TYPE_SKOLE);
+      $institution->set('district', trim((string) ($data['district'] ?? '')));
+      $institution->set('leader_name', trim((string) ($data['leader_name'] ?? '')));
+      $institution->set('leader_email', trim((string) ($data['leader_email'] ?? '')));
+      $institution->set('active', trim((string) ($data['active'] ?? '1')) !== '0');
+      $institution->save();
+
+      $parentNumber = trim((string) ($data['parent_number'] ?? ''));
+      if ($parentNumber !== '') {
+        $parentLinks[$number] = $parentNumber;
+      }
+    }
+    fclose($handle);
+
+    // Second pass: link parents now that every row exists. Numeric string
+    // array keys degrade to ints in PHP, so cast both back to strings.
+    foreach ($parentLinks as $childNumber => $parentNumber) {
+      $child = $this->registry->findByNumber((string) $childNumber);
+      $parent = $this->registry->findByNumber((string) $parentNumber);
+      if ($child !== NULL && $parent !== NULL) {
+        $child->set('parent_institution', $parent->id());
+        $child->save();
+      }
+      else {
+        $this->logger()->warning(sprintf('Parent %s for institution %s not found; link skipped.', $parentNumber, $childNumber));
+      }
+    }
+
+    $this->logger()->success(sprintf('Institutions seeded: %d created, %d updated.', $created, $updated));
+  }
+
+  /**
+   * List the institution registry.
+   *
+   * @command aabenforms:institution:list
+   * @aliases af:inst:list
+   * @field-labels
+   *   number: Number
+   *   name: Name
+   *   type: Type
+   *   district: District
+   *   leader: Leader email
+   *   active: Active
+   *
+   * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+   *   The registry rows.
+   */
+  public function listInstitutions() {
+    $rows = [];
+    foreach ($this->registry->listActive() as $institution) {
+      $rows[] = [
+        'number' => $institution->getInstitutionNumber(),
+        'name' => $institution->label(),
+        'type' => $institution->getType(),
+        'district' => $institution->getDistrict(),
+        'leader' => $institution->getLeaderEmail(),
+        'active' => $institution->isActive() ? 'yes' : 'no',
+      ];
+    }
+    return new RowsOfFields($rows);
+  }
+
+}

--- a/web/modules/custom/aabenforms_institution/src/Drush/InstitutionCommands.php
+++ b/web/modules/custom/aabenforms_institution/src/Drush/InstitutionCommands.php
@@ -66,6 +66,14 @@ final class InstitutionCommands extends DrushCommands {
     $updated = 0;
 
     while (($row = fgetcsv($handle, escape: '\\')) !== FALSE) {
+      // Skip blank lines (fgetcsv yields [NULL]) and ragged rows instead of
+      // crashing mid-import and losing the whole parent-linking pass.
+      if ($row === [NULL] || count($row) !== count($header)) {
+        if ($row !== [NULL]) {
+          $this->logger()->warning(sprintf('Skipped ragged CSV row (%d columns, expected %d).', count($row), count($header)));
+        }
+        continue;
+      }
       $data = array_combine($header, $row);
       $number = trim((string) $data['institution_number']);
       if ($number === '') {
@@ -92,6 +100,12 @@ final class InstitutionCommands extends DrushCommands {
       $parentNumber = trim((string) ($data['parent_number'] ?? ''));
       if ($parentNumber !== '') {
         $parentLinks[$number] = $parentNumber;
+      }
+      else {
+        // A re-import whose row no longer names a parent must clear a stale
+        // link, not silently keep the old hierarchy.
+        $institution->set('parent_institution', NULL);
+        $institution->save();
       }
     }
     fclose($handle);

--- a/web/modules/custom/aabenforms_institution/src/Entity/AabenformsInstitution.php
+++ b/web/modules/custom/aabenforms_institution/src/Entity/AabenformsInstitution.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_institution\Entity;
+
+use Drupal\Core\Entity\Attribute\ContentEntityType;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines the ÅbenForms Institution registry entity.
+ *
+ * One row per education institution, keyed by the sector-wide 6-digit
+ * institutionsnummer from Institutionsregisteret (the join key used by
+ * Unilogin, STIL webservices, Aula and the student administration systems).
+ * The registry powers school pickers, submission routing to the right
+ * school leader, and district logic in flows.
+ *
+ * Deliberate boundary: this entity models INSTITUTIONS only. Pupils,
+ * classes, groups and year rollover live in STIL SkoleGrunddata (or
+ * OS2skoledata where a municipality runs it) and are not mirrored here.
+ */
+#[ContentEntityType(
+  id: 'aabenforms_institution',
+  label: new TranslatableMarkup('Institution'),
+  label_collection: new TranslatableMarkup('Institutions'),
+  label_singular: new TranslatableMarkup('institution'),
+  label_plural: new TranslatableMarkup('institutions'),
+  label_count: [
+    'singular' => '@count institution',
+    'plural' => '@count institutions',
+  ],
+  handlers: [
+    'form' => [
+      'default' => ContentEntityForm::class,
+      'edit' => ContentEntityForm::class,
+      'delete' => ContentEntityDeleteForm::class,
+    ],
+    'route_provider' => [
+      'html' => AdminHtmlRouteProvider::class,
+    ],
+  ],
+  base_table: 'aabenforms_institution',
+  admin_permission: 'administer aabenforms_institution',
+  entity_keys: [
+    'id' => 'id',
+    'uuid' => 'uuid',
+    'label' => 'name',
+  ],
+  links: [
+    'canonical' => '/admin/aabenforms/institutions/{aabenforms_institution}',
+    'add-form' => '/admin/aabenforms/institutions/add',
+    'edit-form' => '/admin/aabenforms/institutions/{aabenforms_institution}/edit',
+    'delete-form' => '/admin/aabenforms/institutions/{aabenforms_institution}/delete',
+  ],
+)]
+class AabenformsInstitution extends ContentEntityBase {
+
+  use EntityChangedTrait;
+
+  /**
+   * Institution type: folkeskole and other schools.
+   */
+  public const TYPE_SKOLE = 'skole';
+
+  /**
+   * Institution type: daycare (dagtilbud).
+   */
+  public const TYPE_DAGTILBUD = 'dagtilbud';
+
+  /**
+   * Institution type: leisure/youth (fritids- og ungdomstilbud).
+   */
+  public const TYPE_FU = 'fu';
+
+  /**
+   * Institution type: municipal administrative unit (e.g. PPR, forvaltning).
+   */
+  public const TYPE_FORVALTNING = 'forvaltning';
+
+  /**
+   * Returns the 6-digit institutionsnummer.
+   */
+  public function getInstitutionNumber(): string {
+    return (string) $this->get('institution_number')->value;
+  }
+
+  /**
+   * Returns the institution type (one of the TYPE_* constants).
+   */
+  public function getType(): string {
+    return (string) $this->get('type')->value;
+  }
+
+  /**
+   * Returns the school district name, or ''.
+   */
+  public function getDistrict(): string {
+    return (string) $this->get('district')->value;
+  }
+
+  /**
+   * Returns the leader's (skoleleder) email, or ''.
+   */
+  public function getLeaderEmail(): string {
+    return (string) $this->get('leader_email')->value;
+  }
+
+  /**
+   * Returns the leader's display name, or ''.
+   */
+  public function getLeaderName(): string {
+    return (string) $this->get('leader_name')->value;
+  }
+
+  /**
+   * Whether the institution is active (not closed).
+   */
+  public function isActive(): bool {
+    return (bool) $this->get('active')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['name'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Name'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('form', ['type' => 'string_textfield', 'weight' => 0])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['institution_number'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Institution number'))
+      ->setDescription(new TranslatableMarkup('The 6-digit institutionsnummer from Institutionsregisteret.'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 6)
+      ->addConstraint('UniqueField')
+      ->setDisplayOptions('form', ['type' => 'string_textfield', 'weight' => 1])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['type'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Type'))
+      ->setRequired(TRUE)
+      ->setDefaultValue(self::TYPE_SKOLE)
+      ->setSetting('allowed_values', [
+        self::TYPE_SKOLE => new TranslatableMarkup('School'),
+        self::TYPE_DAGTILBUD => new TranslatableMarkup('Daycare'),
+        self::TYPE_FU => new TranslatableMarkup('Leisure and youth'),
+        self::TYPE_FORVALTNING => new TranslatableMarkup('Administrative unit'),
+      ])
+      ->setDisplayOptions('form', ['type' => 'options_select', 'weight' => 2]);
+
+    $fields['district'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('District'))
+      ->setDescription(new TranslatableMarkup('School district (skoledistrikt) the institution belongs to.'))
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('form', ['type' => 'string_textfield', 'weight' => 3]);
+
+    $fields['leader_name'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Leader name'))
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('form', ['type' => 'string_textfield', 'weight' => 4]);
+
+    $fields['leader_email'] = BaseFieldDefinition::create('email')
+      ->setLabel(new TranslatableMarkup('Leader email'))
+      ->setDescription(new TranslatableMarkup('Review tasks for this institution are routed here.'))
+      ->setDisplayOptions('form', ['type' => 'email_default', 'weight' => 5]);
+
+    $fields['parent_institution'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(new TranslatableMarkup('Parent unit'))
+      ->setDescription(new TranslatableMarkup('The administrative unit this institution reports to (e.g. the school department), forming the routing hierarchy.'))
+      ->setSetting('target_type', 'aabenforms_institution')
+      ->setDisplayOptions('form', ['type' => 'entity_reference_autocomplete', 'weight' => 6]);
+
+    $fields['active'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(new TranslatableMarkup('Active'))
+      ->setDefaultValue(TRUE)
+      ->setDisplayOptions('form', ['type' => 'boolean_checkbox', 'weight' => 7]);
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(new TranslatableMarkup('Changed'));
+
+    return $fields;
+  }
+
+}

--- a/web/modules/custom/aabenforms_institution/src/Plugin/Action/InstitutionLookupAction.php
+++ b/web/modules/custom/aabenforms_institution/src/Plugin/Action/InstitutionLookupAction.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_institution\Plugin\Action;
+
+use Drupal\aabenforms_institution\Service\InstitutionRegistry;
+use Drupal\aabenforms_workflows\Plugin\Action\AabenFormsActionBase;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Institution lookup and review routing.
+ *
+ * Resolves an institutionsnummer to registry data and the review-task
+ * recipient (leader email, escalating up the parent chain when the
+ * institution has none), so flows route submissions to the right school
+ * without self-asserted email fields.
+ */
+#[Action(
+  id: 'aabenforms_institution_lookup',
+  label: new TranslatableMarkup('Institution Lookup'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Resolves an institutionsnummer to institution data and the review-task recipient email.'),
+  version_introduced: '2.1.0',
+)]
+class InstitutionLookupAction extends AabenFormsActionBase {
+
+  /**
+   * The institution registry.
+   *
+   * @var \Drupal\aabenforms_institution\Service\InstitutionRegistry
+   */
+  protected InstitutionRegistry $registry;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->setRegistry($container->get('aabenforms_institution.registry'));
+    return $instance;
+  }
+
+  /**
+   * Setter injection for the registry.
+   *
+   * Public so unit tests can swap in a stub without reflection.
+   */
+  public function setRegistry(InstitutionRegistry $registry): void {
+    $this->registry = $registry;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'institution_number_token' => 'institution_number',
+      'result_token' => 'institution',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['institution_number_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Institution number token name'),
+      '#description' => $this->t('Token containing the 6-digit institutionsnummer.'),
+      '#default_value' => $this->configuration['institution_number_token'],
+      '#required' => TRUE,
+    ];
+
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Writes &lt;name&gt; (institution data), &lt;name&gt;_status (found/not_found/skipped) and &lt;name&gt;_leader_email (review-task recipient, parent-chain escalated).'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['institution_number_token'] = $form_state->getValue('institution_number_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $number = trim($this->getTokenValue($this->configuration['institution_number_token'], ''));
+    $resultToken = (string) $this->configuration['result_token'];
+
+    if ($number === '') {
+      $this->setTokenValue($resultToken, NULL);
+      $this->setTokenValue($resultToken . '_status', 'skipped');
+      $this->setTokenValue($resultToken . '_leader_email', '');
+      $this->recordStep('Institution Lookup', 'Skipped - no institution number provided', 'skipped');
+      return;
+    }
+
+    $institution = $this->registry->findByNumber($number);
+
+    if ($institution === NULL || !$institution->isActive()) {
+      $this->log('Institution lookup: {number} unknown or inactive', ['number' => $number], 'warning');
+      $this->setTokenValue($resultToken, NULL);
+      $this->setTokenValue($resultToken . '_status', 'not_found');
+      $this->setTokenValue($resultToken . '_leader_email', '');
+      $this->recordStep('Institution Lookup', 'Institution not found in the registry or inactive', 'failed');
+      return;
+    }
+
+    $leaderEmail = $this->registry->leaderEmailFor($number);
+
+    $this->setTokenValue($resultToken, [
+      'institution_number' => $institution->getInstitutionNumber(),
+      'name' => (string) $institution->label(),
+      'type' => $institution->getType(),
+      'district' => $institution->getDistrict(),
+      'leader_name' => $institution->getLeaderName(),
+      'leader_email' => $leaderEmail,
+    ]);
+    $this->setTokenValue($resultToken . '_status', 'found');
+    $this->setTokenValue($resultToken . '_leader_email', $leaderEmail);
+    $this->recordStep(
+      'Institution Lookup',
+      sprintf('Institution resolved from the registry%s', $leaderEmail !== '' ? ' with review routing' : ' (no leader email - manual routing needed)'),
+    );
+  }
+
+}

--- a/web/modules/custom/aabenforms_institution/src/Service/InstitutionOrgChartService.php
+++ b/web/modules/custom/aabenforms_institution/src/Service/InstitutionOrgChartService.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_institution\Service;
+
+use Drupal\aabenforms_workflows\Service\OrgChartServiceInterface;
+
+/**
+ * Institution-aware decoration of the org chart.
+ *
+ * The org-chart interface docblock anticipates decoration for real
+ * directories; this decorator adds exactly one capability: employee ids of
+ * the form "inst:<institutionsnummer>" resolve their manager through the
+ * institution registry (school leader, escalating up the parent chain).
+ * Every other id delegates unchanged to the decorated directory, so the
+ * existing HR flows are unaffected.
+ */
+final class InstitutionOrgChartService implements OrgChartServiceInterface {
+
+  /**
+   * Prefix marking an institution-scoped employee identifier.
+   */
+  public const INSTITUTION_PREFIX = 'inst:';
+
+  public function __construct(
+    protected OrgChartServiceInterface $inner,
+    protected InstitutionRegistry $registry,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function findManagerEmail(string $employee_id, string $fallback = ''): string {
+    if (str_starts_with($employee_id, self::INSTITUTION_PREFIX)) {
+      return $this->registry->leaderEmailFor(substr($employee_id, strlen(self::INSTITUTION_PREFIX)));
+    }
+    return $this->inner->findManagerEmail($employee_id, $fallback);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tierLimitCents(string $employee_id): int {
+    return $this->inner->tierLimitCents($employee_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function employeeIdForAccountName(string $account_name): string {
+    return $this->inner->employeeIdForAccountName($account_name);
+  }
+
+}

--- a/web/modules/custom/aabenforms_institution/src/Service/InstitutionRegistry.php
+++ b/web/modules/custom/aabenforms_institution/src/Service/InstitutionRegistry.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_institution\Service;
+
+use Drupal\aabenforms_institution\Entity\AabenformsInstitution;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Query facade over the institution registry.
+ *
+ * Wraps the entity storage so workflow code depends on a small, mockable
+ * surface instead of entity queries scattered through actions.
+ */
+class InstitutionRegistry {
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+  }
+
+  /**
+   * Loads an institution by its 6-digit institutionsnummer.
+   *
+   * @param string $institutionNumber
+   *   The institutionsnummer.
+   *
+   * @return \Drupal\aabenforms_institution\Entity\AabenformsInstitution|null
+   *   The institution, or NULL when unknown.
+   */
+  public function findByNumber(string $institutionNumber): ?AabenformsInstitution {
+    $institutionNumber = trim($institutionNumber);
+    if ($institutionNumber === '') {
+      return NULL;
+    }
+    $storage = $this->entityTypeManager->getStorage('aabenforms_institution');
+    $ids = $storage->getQuery()
+      ->condition('institution_number', $institutionNumber)
+      ->accessCheck(FALSE)
+      ->range(0, 1)
+      ->execute();
+    if ($ids === []) {
+      return NULL;
+    }
+    $institution = $storage->load(reset($ids));
+    return $institution instanceof AabenformsInstitution ? $institution : NULL;
+  }
+
+  /**
+   * Returns active institutions of a type, sorted by name.
+   *
+   * @param string|null $type
+   *   One of the AabenformsInstitution::TYPE_* constants, or NULL for all.
+   *
+   * @return \Drupal\aabenforms_institution\Entity\AabenformsInstitution[]
+   *   The active institutions.
+   */
+  public function listActive(?string $type = NULL): array {
+    $storage = $this->entityTypeManager->getStorage('aabenforms_institution');
+    $query = $storage->getQuery()
+      ->condition('active', TRUE)
+      ->accessCheck(FALSE)
+      ->sort('name');
+    if ($type !== NULL) {
+      $query->condition('type', $type);
+    }
+    $ids = $query->execute();
+    return $ids === [] ? [] : array_values(array_filter(
+      $storage->loadMultiple($ids),
+      static fn ($e) => $e instanceof AabenformsInstitution,
+    ));
+  }
+
+  /**
+   * Resolves the review-task recipient for an institution.
+   *
+   * Walks up the parent chain when the institution itself has no leader
+   * email, so a school without a registered leader escalates to its
+   * administrative parent instead of dropping the task.
+   *
+   * @param string $institutionNumber
+   *   The institutionsnummer.
+   *
+   * @return string
+   *   The leader email, or '' when neither the institution nor any parent
+   *   carries one.
+   */
+  public function leaderEmailFor(string $institutionNumber): string {
+    $institution = $this->findByNumber($institutionNumber);
+    $depth = 0;
+    while ($institution !== NULL && $depth < 5) {
+      $email = $institution->getLeaderEmail();
+      if ($email !== '') {
+        return $email;
+      }
+      $parent = $institution->get('parent_institution')->entity;
+      $institution = $parent instanceof AabenformsInstitution ? $parent : NULL;
+      $depth++;
+    }
+    return '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_institution/tests/src/Kernel/InstitutionRegistryTest.php
+++ b/web/modules/custom/aabenforms_institution/tests/src/Kernel/InstitutionRegistryTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_institution\Kernel;
+
+use Drupal\aabenforms_institution\Entity\AabenformsInstitution;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the institution entity, registry queries and org-chart decoration.
+ *
+ * @group aabenforms_institution
+ */
+class InstitutionRegistryTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'file',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'modeler_api',
+    'eca',
+    'webform',
+    'aabenforms_core',
+    // Hard dep of aabenforms_workflows: parent_cpr_verifier injects
+    // aabenforms_mitid.session_manager.
+    'aabenforms_mitid',
+    'aabenforms_workflows',
+    'aabenforms_institution',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('aabenforms_institution');
+  }
+
+  /**
+   * Creates an institution.
+   *
+   * @param array $values
+   *   Entity values.
+   *
+   * @return \Drupal\aabenforms_institution\Entity\AabenformsInstitution
+   *   The saved institution.
+   */
+  protected function createInstitution(array $values): AabenformsInstitution {
+    /** @var \Drupal\aabenforms_institution\Entity\AabenformsInstitution $institution */
+    $institution = $this->container->get('entity_type.manager')
+      ->getStorage('aabenforms_institution')
+      ->create($values + ['type' => AabenformsInstitution::TYPE_SKOLE, 'active' => TRUE]);
+    $institution->save();
+    return $institution;
+  }
+
+  /**
+   * FindByNumber resolves institutions by institutionsnummer.
+   */
+  public function testFindByNumber(): void {
+    $this->createInstitution([
+      'name' => 'Frederiksbjerg Skole',
+      'institution_number' => '751101',
+      'district' => 'Frederiksbjerg',
+      'leader_email' => 'leder@example.dk',
+    ]);
+
+    $registry = $this->container->get('aabenforms_institution.registry');
+    $found = $registry->findByNumber('751101');
+    $this->assertNotNull($found);
+    $this->assertSame('Frederiksbjerg Skole', $found->label());
+    $this->assertNull($registry->findByNumber('999999'));
+    $this->assertNull($registry->findByNumber(''));
+  }
+
+  /**
+   * Duplicate institution numbers are rejected by the unique constraint.
+   */
+  public function testInstitutionNumberUnique(): void {
+    $this->createInstitution(['name' => 'A', 'institution_number' => '751101']);
+    $duplicate = $this->container->get('entity_type.manager')
+      ->getStorage('aabenforms_institution')
+      ->create([
+        'name' => 'B',
+        'institution_number' => '751101',
+        'type' => AabenformsInstitution::TYPE_SKOLE,
+      ]);
+    $violations = $duplicate->validate();
+    $this->assertGreaterThan(0, $violations->count());
+  }
+
+  /**
+   * Leader email escalates up the parent chain when the school has none.
+   */
+  public function testLeaderEmailEscalatesToParent(): void {
+    $forvaltning = $this->createInstitution([
+      'name' => 'Børn og Unge',
+      'institution_number' => '751000',
+      'type' => AabenformsInstitution::TYPE_FORVALTNING,
+      'leader_email' => 'bu@example.dk',
+    ]);
+    $this->createInstitution([
+      'name' => 'Skåde Skole',
+      'institution_number' => '751105',
+      'leader_email' => '',
+      'parent_institution' => $forvaltning->id(),
+    ]);
+
+    $registry = $this->container->get('aabenforms_institution.registry');
+    $this->assertSame('bu@example.dk', $registry->leaderEmailFor('751105'));
+    // A school with its own leader email uses it directly.
+    $this->createInstitution([
+      'name' => 'Risskov Skole',
+      'institution_number' => '751104',
+      'leader_email' => 'risskov@example.dk',
+      'parent_institution' => $forvaltning->id(),
+    ]);
+    $this->assertSame('risskov@example.dk', $registry->leaderEmailFor('751104'));
+    // Unknown institution: ''.
+    $this->assertSame('', $registry->leaderEmailFor('999999'));
+  }
+
+  /**
+   * ListActive filters by type and excludes inactive institutions.
+   */
+  public function testListActive(): void {
+    $this->createInstitution(['name' => 'B skole', 'institution_number' => '751102']);
+    $this->createInstitution(['name' => 'A skole', 'institution_number' => '751101']);
+    $this->createInstitution([
+      'name' => 'Lukket skole',
+      'institution_number' => '751199',
+      'active' => FALSE,
+    ]);
+    $this->createInstitution([
+      'name' => 'Solstrålen',
+      'institution_number' => '751201',
+      'type' => AabenformsInstitution::TYPE_DAGTILBUD,
+    ]);
+
+    $registry = $this->container->get('aabenforms_institution.registry');
+    $schools = $registry->listActive(AabenformsInstitution::TYPE_SKOLE);
+    $this->assertCount(2, $schools);
+    $this->assertSame('A skole', $schools[0]->label());
+    $this->assertCount(3, $registry->listActive());
+  }
+
+  /**
+   * The org-chart decorator resolves inst:-prefixed ids via the registry.
+   */
+  public function testOrgChartDecoration(): void {
+    $this->createInstitution([
+      'name' => 'Frederiksbjerg Skole',
+      'institution_number' => '751101',
+      'leader_email' => 'leder@example.dk',
+    ]);
+
+    $orgChart = $this->container->get('aabenforms_workflows.org_chart');
+    $this->assertSame('leder@example.dk', $orgChart->findManagerEmail('inst:751101'));
+    $this->assertSame('', $orgChart->findManagerEmail('inst:999999'));
+    // Non-institution ids delegate to the decorated config directory.
+    $this->assertSame('', $orgChart->findManagerEmail('unknown-employee'));
+  }
+
+}

--- a/web/modules/custom/aabenforms_mitid/src/DemoPersonas.php
+++ b/web/modules/custom/aabenforms_mitid/src/DemoPersonas.php
@@ -13,9 +13,10 @@ namespace Drupal\aabenforms_mitid;
  * "Test as demo citizen" action.
  *
  * This is test/demo scaffolding only. Seeding a session here is gated by the
- * `administer aabenforms workflows` permission (and the CLI), never exposed to
- * anonymous citizens, and the resulting session carries the same shape a real
- * MitID callback would produce so downstream actions behave identically.
+ * `administer eca` permission on the "Test as demo citizen" route (and by the
+ * CLI for the Drush command), never exposed to anonymous citizens, and the
+ * resulting session carries the same shape a real MitID callback would produce
+ * so downstream actions behave identically.
  */
 final class DemoPersonas {
 

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.module
@@ -110,7 +110,7 @@ function aabenforms_workflows_mail(string $key, array &$message, array $params):
 
       $message['body'][] = '';
 
-      $message['body'][] = t('This link will expire in 7 days.');
+      $message['body'][] = t('This link will expire in 14 days.');
 
       $message['body'][] = '';
 

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.permissions.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.permissions.yml
@@ -1,0 +1,6 @@
+# Permissions for ÅbenForms Workflows module.
+
+administer workflows:
+  title: 'Administer ÅbenForms workflows'
+  description: 'Create, edit and delete ECA flows through the template browser, the workflow wizard and the flow graph. Grants full control over which municipal decisions are automated, so treat it as an administrative permission.'
+  restrict access: true

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -39,6 +39,8 @@ services:
       - '@aabenforms_core.audit_logger'
       - '@logger.factory'
       - '@aabenforms_core.cpr_access'
+      - '@aabenforms_core.family_lookup'
+      - '@config.factory'
 
   aabenforms_workflows.appeal_ownership_verifier:
     class: Drupal\aabenforms_workflows\Service\AppealOwnershipVerifier

--- a/web/modules/custom/aabenforms_workflows/config/install/aabenforms_workflows.settings.yml
+++ b/web/modules/custom/aabenforms_workflows/config/install/aabenforms_workflows.settings.yml
@@ -1,1 +1,5 @@
 require_parent_cpr_match: true
+# Webform ids whose parent approvals additionally require REGISTERED custody
+# of the child (CPR registry check via the family lookup). Empty by default:
+# existing flows verify identity only.
+custody_gated_forms: []

--- a/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
+++ b/web/modules/custom/aabenforms_workflows/config/schema/aabenforms_workflows.schema.yml
@@ -115,6 +115,12 @@ aabenforms_workflows.settings:
     require_parent_cpr_match:
       type: boolean
       label: 'Fail closed when a parent-approval submission has no expected CPR to verify against'
+    custody_gated_forms:
+      type: sequence
+      label: 'Webform ids whose parent approvals require registered custody of the child'
+      sequence:
+        type: string
+        label: 'Webform id'
     allow_mitid_demo_mode:
       type: boolean
       label: 'Allow MitID validation to pass without a real session (demo only; default off)'

--- a/web/modules/custom/aabenforms_workflows/src/Drush/ModelerCommands.php
+++ b/web/modules/custom/aabenforms_workflows/src/Drush/ModelerCommands.php
@@ -4,26 +4,25 @@ declare(strict_types=1);
 
 namespace Drupal\aabenforms_workflows\Drush;
 
+use Drupal\aabenforms_workflows\EcaModeler;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Commands\DrushCommands;
 
 /**
  * Drush commands for keeping ECA flows owned by the workflow modeler.
  *
- * An ECA flow renders in the React workflow modeler only while its config
- * carries the `modeler_api.modeler_id` third-party setting. ModelOwnerBase
- * defaults a missing setting to "fallback", which drops the flow to the
- * BPMN.iO editor. Some ECA save paths (and editing a flow in BPMN.iO) strip
- * that setting, so flows silently regress to fallback even though config/sync
- * declares the modeler. `af:modeler-adopt` re-asserts it across every flow;
- * it is idempotent and safe to run as a post-deploy step.
+ * The ownership rule itself lives in EcaModeler. This command is the repair
+ * path: some ECA save paths, and editing a flow in BPMN.iO, strip the
+ * `modeler_api.modeler_id` setting, so a flow can regress to the fallback
+ * editor even though config/sync declares the modeler. `af:modeler-adopt`
+ * re-asserts it across every flow; it is idempotent and safe to run as a
+ * post-deploy step.
+ *
+ * It is no longer needed after creating a workflow through the wizard.
+ * WorkflowTemplateInstantiator stamps ownership at creation, so a fresh
+ * wizard build already reports as adopted.
  */
 final class ModelerCommands extends DrushCommands {
-
-  /**
-   * The modeler id every ÅbenForms flow should be owned by.
-   */
-  private const MODELER_ID = 'workflow_modeler';
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -51,15 +50,10 @@ final class ModelerCommands extends DrushCommands {
 
     $fixed = [];
     foreach ($flows as $id => $flow) {
-      if ($flow->getThirdPartySetting('modeler_api', 'modeler_id', 'fallback') === self::MODELER_ID) {
+      if (EcaModeler::isOwned($flow)) {
         continue;
       }
-      $flow->setThirdPartySetting('modeler_api', 'modeler_id', self::MODELER_ID);
-      // ModelerApi shows this label in the list; default it to the flow id when
-      // none is present so the row stays readable.
-      if ($flow->getThirdPartySetting('modeler_api', 'label', '') === '') {
-        $flow->setThirdPartySetting('modeler_api', 'label', $id);
-      }
+      EcaModeler::stamp($flow);
       $flow->save();
       $fixed[] = $id;
     }

--- a/web/modules/custom/aabenforms_workflows/src/EcaModeler.php
+++ b/web/modules/custom/aabenforms_workflows/src/EcaModeler.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows;
+
+use Drupal\Core\Config\Entity\ThirdPartySettingsInterface;
+
+/**
+ * Ownership of ECA flows by the React Workflow Modeler.
+ *
+ * An ECA flow renders in the Workflow Modeler only while its config carries
+ * the `modeler_api.modeler_id` third-party setting. ModelOwnerBase defaults a
+ * missing setting to "fallback", which silently drops the flow to the BPMN.iO
+ * editor. Two places need the same rule, so it lives here rather than being
+ * written twice: the wizard stamps it at creation, and the af:modeler-adopt
+ * Drush command re-asserts it on flows that regressed (editing a flow in
+ * BPMN.iO strips the setting).
+ */
+final class EcaModeler {
+
+  /**
+   * The modeler id every ÅbenForms flow should be owned by.
+   */
+  public const ID = 'workflow_modeler';
+
+  /**
+   * Marks a flow as owned by the Workflow Modeler.
+   *
+   * The label is a modeler-only concern: `label` is not part of the Eca config
+   * entity's exportable properties, so the human-readable name for the modeler
+   * list belongs in the same third-party namespace as the owner id.
+   *
+   * @param \Drupal\Core\Config\Entity\ThirdPartySettingsInterface $flow
+   *   The ECA flow config entity.
+   * @param string $label
+   *   The label to show in the modeler list. Falls back to the flow id when
+   *   empty, so a row is never blank.
+   */
+  public static function stamp(ThirdPartySettingsInterface $flow, string $label = ''): void {
+    $flow->setThirdPartySetting('modeler_api', 'modeler_id', self::ID);
+
+    if ($label === '') {
+      $label = $flow->getThirdPartySetting('modeler_api', 'label', '');
+    }
+    if ($label === '' && method_exists($flow, 'id')) {
+      $label = (string) $flow->id();
+    }
+    if ($label !== '') {
+      $flow->setThirdPartySetting('modeler_api', 'label', $label);
+    }
+  }
+
+  /**
+   * Whether the flow is already owned by the Workflow Modeler.
+   *
+   * @param \Drupal\Core\Config\Entity\ThirdPartySettingsInterface $flow
+   *   The ECA flow config entity.
+   *
+   * @return bool
+   *   TRUE when no stamping is needed.
+   */
+  public static function isOwned(ThirdPartySettingsInterface $flow): bool {
+    return $flow->getThirdPartySetting('modeler_api', 'modeler_id', 'fallback') === self::ID;
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CustodyVerifyAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CustodyVerifyAction.php
@@ -133,7 +133,10 @@ class CustodyVerifyAction extends AabenFormsActionBase {
     $this->setTokenValue($this->configuration['result_token'], $hasCustody ? 'true' : 'false');
 
     if ($hasCustody) {
-      $this->recordStep('Custody Verification', 'Custody confirmed against the CPR registry (SF6006)');
+      // Honest labelling: never claim a registry confirmation for demo data.
+      $this->recordStep('Custody Verification', $this->familyLookup->isDemoMode()
+        ? 'Demo: custody confirmed against test data. Real SF6006 checks require a Serviceplatformen client certificate.'
+        : 'Custody confirmed against the CPR registry (SF6006)');
     }
     else {
       $this->log('Custody verification: adult is not a registered custody holder', [], 'warning');

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CustodyVerifyAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/CustodyVerifyAction.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Verify custody (foraeldremyndighed) via the CPR registry.
+ *
+ * Answers "is this adult a REGISTERED custody holder of this child?" against
+ * the registry. This closes the gap left by the parent-approval CPR gate
+ * (ParentCprVerifier), which only proves the approver is the person named on
+ * the form, not that the person actually holds custody. Fail-closed: any
+ * missing input, unknown CPR or registry failure verifies as 'false'.
+ */
+#[Action(
+  id: 'aabenforms_custody_verify',
+  label: new TranslatableMarkup('Custody Verification'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Verifies that an adult is a registered custody holder of a child via the CPR registry (SF6006 Familie+). Fail-closed.'),
+  version_introduced: '2.1.0',
+)]
+class CustodyVerifyAction extends AabenFormsActionBase {
+
+  /**
+   * The family relations lookup service.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface
+   */
+  protected FamilyRelationsLookupInterface $familyLookup;
+
+  /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->familyLookup = $container->get('aabenforms_core.family_lookup');
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'adult_cpr_token' => 'cpr',
+      'child_cpr_token' => 'child_cpr',
+      'result_token' => 'custody_verified',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['adult_cpr_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Adult CPR token name'),
+      '#description' => $this->t('Token containing the adult CPR (typically the MitID-asserted CPR).'),
+      '#default_value' => $this->configuration['adult_cpr_token'],
+      '#required' => TRUE,
+    ];
+
+    $form['child_cpr_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Child CPR token name'),
+      '#description' => $this->t('Token containing the child CPR to verify custody of.'),
+      '#default_value' => $this->configuration['child_cpr_token'],
+      '#required' => TRUE,
+    ];
+
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t("Token set to 'true' or 'false'. Fail-closed: any error yields 'false'."),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['adult_cpr_token'] = $form_state->getValue('adult_cpr_token');
+    $this->configuration['child_cpr_token'] = $form_state->getValue('child_cpr_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $adultCpr = $this->cleanCpr($this->getTokenValue($this->configuration['adult_cpr_token'], ''));
+    $childCpr = $this->cleanCpr($this->getTokenValue($this->configuration['child_cpr_token'], ''));
+
+    if ($adultCpr === '' || $childCpr === '') {
+      $this->log('Custody verification failed closed: missing CPR input', [], 'warning');
+      $this->setTokenValue($this->configuration['result_token'], 'false');
+      $this->recordStep('Custody Verification', 'Failed closed - adult or child CPR missing', 'failed');
+      return;
+    }
+
+    try {
+      $hasCustody = $this->familyLookup->hasCustody($adultCpr, $childCpr);
+    }
+    catch (\Exception $e) {
+      $this->log('Custody verification failed closed: {message}', ['message' => $e->getMessage()], 'error');
+      $this->setTokenValue($this->configuration['result_token'], 'false');
+      $this->recordStep('Custody Verification', 'Failed closed - the CPR registry could not be reached', 'failed');
+      return;
+    }
+
+    $this->setTokenValue($this->configuration['result_token'], $hasCustody ? 'true' : 'false');
+
+    if ($hasCustody) {
+      $this->recordStep('Custody Verification', 'Custody confirmed against the CPR registry (SF6006)');
+    }
+    else {
+      $this->log('Custody verification: adult is not a registered custody holder', [], 'warning');
+      $this->recordStep('Custody Verification', 'Adult is not a registered custody holder of the child', 'failed');
+    }
+  }
+
+  /**
+   * Decrypts and normalizes a CPR token value to bare digits.
+   *
+   * @param string $raw
+   *   The raw token value (possibly encrypted at rest).
+   *
+   * @return string
+   *   Digit-only CPR, or '' when empty.
+   */
+  protected function cleanCpr(string $raw): string {
+    $revealed = $this->cprAccess->reveal($raw);
+    return $revealed ? (preg_replace('/[^0-9]/', '', $revealed) ?? '') : '';
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FamilyLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FamilyLookupAction.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\aabenforms_workflows\Plugin\Action;
+
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Attribute\EcaAction;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ECA Action: Family/custody lookup for the authenticated citizen.
+ *
+ * Resolves the children the given adult holds custody of, including each
+ * child's full custody-holder set, so downstream steps (co-signature,
+ * Digital Post recipient resolution) never rely on citizen-typed CPRs.
+ */
+#[Action(
+  id: 'aabenforms_family_lookup',
+  label: new TranslatableMarkup('Family Relations Lookup'),
+  type: 'aabenforms',
+)]
+#[EcaAction(
+  description: new TranslatableMarkup('Looks up children and custody holders from the CPR registry (SF6006 Familie+).'),
+  version_introduced: '2.1.0',
+)]
+class FamilyLookupAction extends AabenFormsActionBase {
+
+  /**
+   * The family relations lookup service.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface
+   */
+  protected FamilyRelationsLookupInterface $familyLookup;
+
+  /**
+   * The CPR access helper (decrypts CPR stored at rest).
+   *
+   * @var \Drupal\aabenforms_core\Service\CprAccess
+   */
+  protected CprAccess $cprAccess;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->familyLookup = $container->get('aabenforms_core.family_lookup');
+    $instance->cprAccess = $container->get('aabenforms_core.cpr_access');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'cpr_token' => 'cpr',
+      'result_token' => 'family_data',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['cpr_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('CPR token name'),
+      '#description' => $this->t('Token containing the adult CPR number to look up children for.'),
+      '#default_value' => $this->configuration['cpr_token'],
+      '#required' => TRUE,
+    ];
+
+    $form['result_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Result token name'),
+      '#description' => $this->t('Token to store the children list. A companion token &lt;name&gt;_status carries found, not_found, skipped or error.'),
+      '#default_value' => $this->configuration['result_token'],
+      '#required' => TRUE,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['cpr_token'] = $form_state->getValue('cpr_token');
+    $this->configuration['result_token'] = $form_state->getValue('result_token');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(): void {
+    $cpr = $this->getTokenValue($this->configuration['cpr_token'], '');
+    $cpr = $this->cprAccess->reveal((string) $cpr);
+    $cpr = $cpr ? preg_replace('/[^0-9]/', '', $cpr) : '';
+
+    if (empty($cpr)) {
+      $this->log('Family lookup skipped: no CPR available', [], 'warning');
+      $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('skipped');
+      $this->recordStep('Family Relations Lookup', 'Skipped - no CPR available to look up', 'skipped');
+      return;
+    }
+
+    try {
+      $children = $this->familyLookup->childrenOf($cpr);
+
+      if (empty($children)) {
+        $this->setTokenValue($this->configuration['result_token'], []);
+        $this->setResultStatus('not_found');
+        $this->recordStep('Family Relations Lookup', 'No children with registered custody found in the CPR registry');
+        return;
+      }
+
+      $this->setTokenValue($this->configuration['result_token'], $children);
+      $this->setResultStatus('found');
+      $this->log('Family lookup found {count} children with registered custody', [
+        'count' => count($children),
+      ]);
+      $this->recordStep('Family Relations Lookup', 'Custody-verified family relations retrieved from the CPR registry (SF6006)');
+    }
+    catch (\Exception $e) {
+      $this->log('Family lookup failed: {message}', ['message' => $e->getMessage()], 'error');
+      $this->setTokenValue($this->configuration['result_token'], NULL);
+      $this->setResultStatus('error');
+      $this->recordStep('Family Relations Lookup', 'Familieopslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
+    }
+  }
+
+  /**
+   * Writes the scalar status companion token for downstream gating.
+   *
+   * @param string $status
+   *   One of 'found', 'not_found', 'skipped' or 'error'.
+   */
+  protected function setResultStatus(string $status): void {
+    $resultToken = (string) ($this->configuration['result_token'] ?? '');
+    if ($resultToken !== '') {
+      $this->setTokenValue($resultToken . '_status', $status);
+    }
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FamilyLookupAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/FamilyLookupAction.php
@@ -125,13 +125,16 @@ class FamilyLookupAction extends AabenFormsActionBase {
       $this->log('Family lookup found {count} children with registered custody', [
         'count' => count($children),
       ]);
-      $this->recordStep('Family Relations Lookup', 'Custody-verified family relations retrieved from the CPR registry (SF6006)');
+      // Honest labelling: never claim a registry confirmation for demo data.
+      $this->recordStep('Family Relations Lookup', $this->familyLookup->isDemoMode()
+        ? 'Demo: family relations simulated with test data. Real SF6006 lookups require a Serviceplatformen client certificate.'
+        : 'Custody-verified family relations retrieved from the CPR registry (SF6006)');
     }
     catch (\Exception $e) {
       $this->log('Family lookup failed: {message}', ['message' => $e->getMessage()], 'error');
       $this->setTokenValue($this->configuration['result_token'], NULL);
       $this->setResultStatus('error');
-      $this->recordStep('Family Relations Lookup', 'Familieopslaget er midlertidigt utilgaengeligt. Prov igen senere.', 'failed');
+      $this->recordStep('Family Relations Lookup', 'The family registry lookup is temporarily unavailable', 'failed');
     }
   }
 

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/Action/SendApprovalEmailAction.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/Action/SendApprovalEmailAction.php
@@ -175,7 +175,7 @@ class SendApprovalEmailAction extends AabenFormsActionBase {
         'request_details' => $submission->getElementData('request_details'),
         'approval_url' => $approval_url,
         'deadline' => $this->dateFormatter->format(
-          strtotime('+7 days'),
+          strtotime('+14 days'),
           'long'
         ),
         'submission_id' => $submission->id(),

--- a/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ApprovalTokenService.php
@@ -14,9 +14,13 @@ use Psr\Log\LoggerInterface;
 class ApprovalTokenService {
 
   /**
-   * Token expiration time in seconds (7 days).
+   * Token expiration time in seconds (14 days).
+   *
+   * Matches the national co-signature precedent: the borger.dk Omsorgs- og
+   * ansvarserklaering gives the co-signer a 14-day window to sign via the
+   * Digital Post link.
    */
-  const TOKEN_EXPIRATION = 604800;
+  const TOKEN_EXPIRATION = 1209600;
 
   /**
    * Allowed clock skew when validating a token timestamp (1 hour).

--- a/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\aabenforms_workflows\Service;
 
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\webform\WebformSubmissionInterface;
 use Psr\Log\LoggerInterface;
@@ -56,6 +58,18 @@ class ParentCprVerifier {
   public const RESULT_MISSING_EXPECTED_CPR = 'missing_expected_cpr';
 
   /**
+   * The CPRs match, but the approver holds no registered custody.
+   *
+   * Only returned for forms listed in the custody_gated_forms setting whose
+   * submission carries a child_cpr field: the approver proved they are the
+   * person named on the form, but the CPR registry does not list them as a
+   * custody holder of the child the request concerns. Fail-closed security
+   * outcome (FOB 2025-9 territory: school decisions require the actual
+   * custody holders).
+   */
+  public const RESULT_NO_CUSTODY = 'no_custody';
+
+  /**
    * The MitID session manager.
    *
    * @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager
@@ -94,12 +108,18 @@ class ParentCprVerifier {
    *   The logger factory.
    * @param \Drupal\aabenforms_core\Service\CprAccess $cpr_access
    *   The CPR access helper, used to decrypt the stored parent CPR.
+   * @param \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface $familyLookup
+   *   The family/custody registry lookup (custody gate).
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory (custody_gated_forms setting).
    */
   public function __construct(
     MitIdSessionManager $session_manager,
     AuditLogger $audit_logger,
     LoggerChannelFactoryInterface $logger_factory,
     CprAccess $cpr_access,
+    protected FamilyRelationsLookupInterface $familyLookup,
+    protected ConfigFactoryInterface $configFactory,
   ) {
     $this->sessionManager = $session_manager;
     $this->auditLogger = $audit_logger;
@@ -202,6 +222,16 @@ class ParentCprVerifier {
       return self::RESULT_MISMATCH;
     }
 
+    // Custody gate (opt-in per form): the CPR match proves "the approver is
+    // the person named on the form"; for custody-gated forms we additionally
+    // require "the approver holds registered custody of the child". Only
+    // enforced when the form is listed in custody_gated_forms AND the
+    // submission carries a child_cpr - so existing flows are untouched.
+    $custodyResult = $this->verifyCustody($submission, $asserted, $parent_number, $workflow_id);
+    if ($custodyResult !== NULL) {
+      return $custodyResult;
+    }
+
     $this->logger->info(
       'Parent approval CPR verified for submission @sid, parent @parent',
       [
@@ -220,6 +250,75 @@ class ParentCprVerifier {
       ]
     );
     return self::RESULT_MATCH;
+  }
+
+  /**
+   * Runs the registry custody check for custody-gated forms.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission being approved.
+   * @param string $assertedCpr
+   *   The normalised MitID-asserted CPR.
+   * @param int $parent_number
+   *   The parent number (audit context).
+   * @param string $workflow_id
+   *   The MitID workflow id (audit context).
+   *
+   * @return string|null
+   *   RESULT_NO_CUSTODY when the gate applies and fails, NULL when the gate
+   *   does not apply or passes (verification continues to RESULT_MATCH).
+   */
+  protected function verifyCustody(WebformSubmissionInterface $submission, string $assertedCpr, int $parent_number, string $workflow_id): ?string {
+    $gatedForms = $this->configFactory->get('aabenforms_workflows.settings')->get('custody_gated_forms') ?? [];
+    if ($gatedForms === []) {
+      return NULL;
+    }
+    $webformId = (string) $submission->getWebform()->id();
+    if (!in_array($webformId, $gatedForms, TRUE)) {
+      return NULL;
+    }
+
+    $childCpr = $this->normaliseCpr($this->cprAccess->reveal((string) ($submission->getElementData('child_cpr') ?? '')));
+    if ($childCpr === '') {
+      // Gated form without a child CPR: nothing to check against. The form
+      // schema decides whether child_cpr is required; the gate only enforces
+      // custody when a child is actually identified.
+      return NULL;
+    }
+
+    if ($this->familyLookup->hasCustody($assertedCpr, $childCpr)) {
+      $this->auditLogger->logCprLookup(
+        $assertedCpr,
+        'parent_approval_custody_confirmed',
+        'success',
+        [
+          'submission_uuid' => (string) ($submission->uuid() ?? ''),
+          'parent_number' => $parent_number,
+          'workflow_id' => $workflow_id,
+        ]
+      );
+      return NULL;
+    }
+
+    $this->logger->warning(
+      'Parent approval blocked: no registered custody for submission @sid, parent @parent',
+      [
+        '@sid' => (int) $submission->id(),
+        '@parent' => $parent_number,
+      ]
+    );
+    $this->auditLogger->logCprLookup(
+      $assertedCpr,
+      'parent_approval_no_custody',
+      'failure',
+      [
+        'submission_uuid' => (string) ($submission->uuid() ?? ''),
+        'parent_number' => $parent_number,
+        'workflow_id' => $workflow_id,
+        'child_cpr_hash' => hash('sha256', $childCpr),
+      ]
+    );
+    return self::RESULT_NO_CUSTODY;
   }
 
   /**

--- a/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/ParentCprVerifier.php
@@ -280,10 +280,29 @@ class ParentCprVerifier {
 
     $childCpr = $this->normaliseCpr($this->cprAccess->reveal((string) ($submission->getElementData('child_cpr') ?? '')));
     if ($childCpr === '') {
-      // Gated form without a child CPR: nothing to check against. The form
-      // schema decides whether child_cpr is required; the gate only enforces
-      // custody when a child is actually identified.
-      return NULL;
+      // Fail closed: a form was explicitly opted into the custody gate, so a
+      // missing or digit-less child_cpr must block the approval, not skip the
+      // check. Otherwise a headless submission that blanks the field (or a
+      // gated form whose child element is misnamed) silently bypasses the
+      // registry check the gate exists to enforce.
+      $this->logger->warning(
+        'Parent approval blocked: custody-gated form @form has no usable child_cpr on submission @sid',
+        [
+          '@form' => $webformId,
+          '@sid' => (int) $submission->id(),
+        ]
+      );
+      $this->auditLogger->logCprLookup(
+        $assertedCpr,
+        'parent_approval_custody_missing_child_cpr',
+        'failure',
+        [
+          'submission_uuid' => (string) ($submission->uuid() ?? ''),
+          'parent_number' => $parent_number,
+          'workflow_id' => $workflow_id,
+        ]
+      );
+      return self::RESULT_NO_CUSTODY;
     }
 
     if ($this->familyLookup->hasCustody($assertedCpr, $childCpr)) {
@@ -295,6 +314,9 @@ class ParentCprVerifier {
           'submission_uuid' => (string) ($submission->uuid() ?? ''),
           'parent_number' => $parent_number,
           'workflow_id' => $workflow_id,
+          // Honest evidence: an audit row must never assert a registry
+          // confirmation when the answer came from demo fixtures.
+          'demo_mode' => $this->familyLookup->isDemoMode(),
         ]
       );
       return NULL;

--- a/web/modules/custom/aabenforms_workflows/src/Service/WorkflowTemplateInstantiator.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/WorkflowTemplateInstantiator.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\aabenforms_workflows\Service;
 
+use Drupal\aabenforms_workflows\EcaModeler;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -284,27 +285,27 @@ class WorkflowTemplateInstantiator {
     $actions = $this->buildEcaActions($xml, $configuration, $conditions);
     $this->gateIdentityActions($actions, $conditions);
 
-    // Build ECA config structure.
-    $eca_config = [
-      'langcode' => 'en',
-      'status' => $configuration['status'] ?? TRUE,
-      'dependencies' => [
-        'module' => ['eca', 'webform', 'aabenforms_workflows'],
-      ],
-      'id' => $workflow_id,
-      'label' => $configuration['label'] ?? $workflow_id,
-      'modeller' => 'fallback',
-      'version' => '1.0.0',
-      'events' => $this->buildEcaEvents($xml, $configuration),
-      'gateways' => [],
-      'conditions' => $conditions,
-      'actions' => $actions,
-    ];
-
-    // Save ECA config.
-    $config = $this->configFactory->getEditable('eca.eca.' . $workflow_id);
-    $config->setData($eca_config);
-    $config->save();
+    // Save through the entity API, not configFactory->setData(). Writing the
+    // config array directly skipped ConfigEntityBase entirely: the flow got no
+    // uuid, no third-party settings (so it fell out of the Workflow Modeler
+    // until someone ran af:modeler-adopt by hand), and it carried `label`,
+    // `modeller` and `version`, none of which are in Eca::$config_export or in
+    // eca.schema.yml - so any later entity save dropped them again. The
+    // exportable properties are id, uuid, status, weight, template, events,
+    // conditions, gateways and actions; the human-readable label lives in the
+    // template_instance config and in modeler_api.label.
+    $storage = $this->entityTypeManager->getStorage('eca');
+    /** @var \Drupal\eca\Entity\Eca $eca */
+    $eca = $storage->load($workflow_id) ?: $storage->create(['id' => $workflow_id]);
+    $eca->set('status', $configuration['status'] ?? TRUE);
+    $eca->set('weight', 0);
+    $eca->set('template', FALSE);
+    $eca->set('events', $this->buildEcaEvents($xml, $configuration));
+    $eca->set('conditions', $conditions);
+    $eca->set('gateways', []);
+    $eca->set('actions', $actions);
+    EcaModeler::stamp($eca, (string) ($configuration['label'] ?? $workflow_id));
+    $eca->save();
   }
 
   /**
@@ -917,10 +918,12 @@ class WorkflowTemplateInstantiator {
         $config->delete();
       }
 
-      // Delete ECA workflow.
-      $eca_config = $this->configFactory->getEditable('eca.eca.' . $workflow_id);
-      if (!$eca_config->isNew()) {
-        $eca_config->delete();
+      // Delete the ECA flow through the entity API so entity hooks fire and
+      // ECA can tear down what it registered for the flow. Deleting the raw
+      // config removed the data without ever telling the entity system.
+      $eca = $this->entityTypeManager->getStorage('eca')->load($workflow_id);
+      if ($eca !== NULL) {
+        $eca->delete();
       }
 
       // Rebuild routes.

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/WizardFlowModelerOwnershipTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/WizardFlowModelerOwnershipTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Kernel;
+
+use Drupal\aabenforms_workflows\EcaModeler;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\webform\Entity\Webform;
+
+/**
+ * Tests the config shape of a flow built through the wizard.
+ *
+ * The instantiator used to write eca.eca.* straight through the config factory
+ * with setData(), bypassing the entity API. Three things went wrong at once:
+ * the flow got no uuid, it carried no modeler_api third-party settings (so it
+ * dropped out of the Workflow Modeler until someone ran af:modeler-adopt by
+ * hand), and it carried `label`, `modeller` and `version`, none of which are
+ * in Eca::$config_export or eca.schema.yml.
+ *
+ * @group aabenforms_workflows
+ */
+class WizardFlowModelerOwnershipTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'file',
+    'key',
+    'encrypt',
+    'real_aes',
+    'domain',
+    'webform',
+    'modeler_api',
+    'eca',
+    'eca_base',
+    'eca_content',
+    'eca_user',
+    'aabenforms_core',
+    'aabenforms_mitid',
+    'aabenforms_workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * None of the 21 custom ECA action plugins ship an `eca.action.plugin.*`
+   * config schema, so every generated flow trips ConfigSchemaChecker on
+   * `actions.<id>.configuration missing schema`. That is a real pre-existing
+   * gap, not something this test introduced, and it is invisible outside tests
+   * because ConfigSchemaChecker is registered only by KernelTestBase and
+   * FunctionalTestSetupTrait, never in production.
+   *
+   * Writing schema for 21 plugins is its own piece of work, tracked in #186
+   * rather than blocking modeler ownership. Turn this back on once that lands:
+   * it is the check that would have caught the `label` / `modeller` /
+   * `version` keys this test now asserts are gone.
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * The workflow id created by the test, for teardown.
+   */
+  private string $workflowId = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('webform_submission');
+    $this->installSchema('system', ['sequences']);
+    // WebformEntityStorage writes a next_serial row per webform on save, so
+    // the module's own table has to exist before any webform config is
+    // installed or created.
+    $this->installSchema('webform', ['webform']);
+    $this->installConfig(['webform']);
+
+    Webform::create([
+      'id' => 'wizard_contact_test',
+      'title' => 'Wizard contact test',
+      'elements' => "email:\n  '#type': email\n  '#title': Email\n",
+    ])->save();
+  }
+
+  /**
+   * Builds a flow the way the wizard does.
+   *
+   * @return \Drupal\eca\Entity\Eca
+   *   The generated flow.
+   */
+  private function instantiateContactFlow() {
+    /** @var \Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator $instantiator */
+    $instantiator = \Drupal::service('aabenforms_workflows.template_instantiator');
+
+    $result = $instantiator->instantiate('contact_form', [
+      'label' => 'Wizard Contact Flow',
+      'webform_id' => 'wizard_contact_test',
+      'parameters' => [
+        'workflow_label' => 'Wizard Contact Flow',
+        'submitter_email_field' => 'email',
+        'recipient_email' => 'kontakt@aabenby.dk',
+      ],
+    ]);
+
+    $this->assertTrue(
+      $result['success'] ?? FALSE,
+      'Instantiation failed: ' . json_encode($result['errors'] ?? $result['message'] ?? [])
+    );
+    $this->workflowId = (string) $result['workflow_id'];
+
+    $flow = \Drupal::entityTypeManager()->getStorage('eca')->load($this->workflowId);
+    $this->assertNotNull($flow, 'The wizard should have created an ECA flow entity.');
+
+    return $flow;
+  }
+
+  /**
+   * A wizard-built flow is owned by the Workflow Modeler at creation.
+   */
+  public function testWizardFlowIsAdoptedAtCreation(): void {
+    $flow = $this->instantiateContactFlow();
+
+    $this->assertSame(
+      EcaModeler::ID,
+      $flow->getThirdPartySetting('modeler_api', 'modeler_id', 'fallback'),
+      'A wizard-built flow must be owned by the workflow modeler without needing af:modeler-adopt.'
+    );
+    $this->assertTrue(EcaModeler::isOwned($flow));
+    $this->assertNotSame(
+      '',
+      $flow->getThirdPartySetting('modeler_api', 'label', ''),
+      'The modeler list shows this label; an empty one renders a blank row.'
+    );
+  }
+
+  /**
+   * The saved config matches what the Eca entity actually exports.
+   */
+  public function testWizardFlowConfigMatchesTheEntitySchema(): void {
+    $this->instantiateContactFlow();
+
+    $raw = $this->config('eca.eca.' . $this->workflowId)->getRawData();
+
+    $this->assertNotEmpty($raw['uuid'] ?? '', 'A config entity written through the entity API gets a uuid; the raw-config write did not, which breaks config sync between environments.');
+    $this->assertArrayHasKey('weight', $raw);
+    $this->assertArrayHasKey('template', $raw);
+    $this->assertArrayHasKey('events', $raw);
+    $this->assertArrayHasKey('actions', $raw);
+
+    foreach (['label', 'modeller', 'version'] as $stale) {
+      $this->assertArrayNotHasKey($stale, $raw, sprintf(
+        'The flow carries "%s", which is not in Eca::$config_export nor eca.schema.yml. Any later entity save drops it, so writing it produces config that disagrees with itself.',
+        $stale
+      ));
+    }
+  }
+
+  /**
+   * Adopting immediately after the wizard is a no-op.
+   *
+   * This is the behavioural proof that ownership is set at creation rather
+   * than repaired afterwards.
+   */
+  public function testAdoptFindsNothingToFixAfterTheWizard(): void {
+    $this->instantiateContactFlow();
+
+    $flows = \Drupal::entityTypeManager()->getStorage('eca')->loadMultiple();
+    $unowned = array_filter($flows, static fn ($flow) => !EcaModeler::isOwned($flow));
+
+    $this->assertSame([], array_keys($unowned), 'Every flow should already be adopted, so af:modeler-adopt has nothing to repair.');
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CustodyVerifyActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/CustodyVerifyActionTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\CustodyVerifyAction;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the CustodyVerifyAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\CustodyVerifyAction
+ * @group aabenforms_workflows
+ */
+class CustodyVerifyActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\CustodyVerifyAction
+   */
+  protected CustodyVerifyAction $action;
+
+  /**
+   * Mock family lookup service.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $familyLookup;
+
+  /**
+   * Mock execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $collector;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')
+      ->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')
+      ->willReturnCallback(function ($name, $value) use ($tokenServices) {
+        $this->tokenStorage[$name] = $value;
+        return $tokenServices;
+      });
+
+    $this->action = new CustodyVerifyAction(
+      [
+        'adult_cpr_token' => 'cpr',
+        'child_cpr_token' => 'child_cpr',
+        'result_token' => 'custody_verified',
+      ],
+      'aabenforms_custody_verify',
+      [],
+      $this->createMock(EntityTypeManagerInterface::class),
+      $tokenServices,
+      $this->createMock(AccountProxyInterface::class),
+      $this->createMock(TimeInterface::class),
+      $this->createMock(EcaState::class),
+      $this->createMock(LoggerChannelInterface::class),
+    );
+    $this->collector = $this->createMock(WorkflowExecutionCollector::class);
+    $this->action->setExecutionCollector($this->collector);
+
+    $this->familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+    $cprAccess = $this->createMock(CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+
+    $reflection = new \ReflectionClass($this->action);
+    foreach (['familyLookup' => $this->familyLookup, 'cprAccess' => $cprAccess] as $property => $value) {
+      $prop = $reflection->getProperty($property);
+      $prop->setAccessible(TRUE);
+      $prop->setValue($this->action, $value);
+    }
+  }
+
+  /**
+   * Registered custody holder verifies as 'true'.
+   *
+   * @covers ::execute
+   */
+  public function testCustodyConfirmed(): void {
+    $this->tokenStorage['cpr'] = '0101904521';
+    $this->tokenStorage['child_cpr'] = '0109182345';
+    $this->familyLookup->expects($this->once())
+      ->method('hasCustody')
+      ->with('0101904521', '0109182345')
+      ->willReturn(TRUE);
+
+    $this->action->execute();
+
+    $this->assertSame('true', $this->tokenStorage['custody_verified']);
+  }
+
+  /**
+   * A non-custody holder verifies as 'false' with a failed step.
+   *
+   * @covers ::execute
+   */
+  public function testCustodyDenied(): void {
+    $this->tokenStorage['cpr'] = '2506924015';
+    $this->tokenStorage['child_cpr'] = '0109182345';
+    $this->familyLookup->method('hasCustody')->willReturn(FALSE);
+
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+
+    $this->assertSame('false', $this->tokenStorage['custody_verified']);
+  }
+
+  /**
+   * Missing input fails closed without calling the registry.
+   *
+   * @covers ::execute
+   */
+  public function testMissingInputFailsClosed(): void {
+    $this->tokenStorage['cpr'] = '0101904521';
+    // No child_cpr token set.
+    $this->familyLookup->expects($this->never())->method('hasCustody');
+
+    $this->action->execute();
+
+    $this->assertSame('false', $this->tokenStorage['custody_verified']);
+  }
+
+  /**
+   * A registry exception fails closed with a failed step.
+   *
+   * @covers ::execute
+   */
+  public function testRegistryErrorFailsClosed(): void {
+    $this->tokenStorage['cpr'] = '0101904521';
+    $this->tokenStorage['child_cpr'] = '0109182345';
+    $this->familyLookup->method('hasCustody')->willThrowException(new \RuntimeException('down'));
+
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+
+    $this->assertSame('false', $this->tokenStorage['custody_verified']);
+  }
+
+  /**
+   * CPRs are normalized (hyphens stripped) before the registry call.
+   *
+   * @covers ::execute
+   */
+  public function testCprNormalization(): void {
+    $this->tokenStorage['cpr'] = '010190-4521';
+    $this->tokenStorage['child_cpr'] = '010918-2345';
+    $this->familyLookup->expects($this->once())
+      ->method('hasCustody')
+      ->with('0101904521', '0109182345')
+      ->willReturn(TRUE);
+
+    $this->action->execute();
+
+    $this->assertSame('true', $this->tokenStorage['custody_verified']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/FamilyLookupActionTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Plugin/Action/FamilyLookupActionTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Drupal\Tests\aabenforms_workflows\Unit\Plugin\Action;
+
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
+use Drupal\aabenforms_core\Service\CprAccess;
+use Drupal\aabenforms_core\Service\WorkflowExecutionCollector;
+use Drupal\aabenforms_workflows\Plugin\Action\FamilyLookupAction;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eca\EcaState;
+use Drupal\eca\Token\TokenInterface as EcaTokenInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the FamilyLookupAction ECA plugin.
+ *
+ * @coversDefaultClass \Drupal\aabenforms_workflows\Plugin\Action\FamilyLookupAction
+ * @group aabenforms_workflows
+ */
+class FamilyLookupActionTest extends UnitTestCase {
+
+  /**
+   * The action under test.
+   *
+   * @var \Drupal\aabenforms_workflows\Plugin\Action\FamilyLookupAction
+   */
+  protected FamilyLookupAction $action;
+
+  /**
+   * Mock family lookup service.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $familyLookup;
+
+  /**
+   * Mock execution collector.
+   *
+   * @var \Drupal\aabenforms_core\Service\WorkflowExecutionCollector|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $collector;
+
+  /**
+   * Token storage for testing.
+   *
+   * @var array
+   */
+  protected array $tokenStorage = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $tokenServices = $this->createMock(EcaTokenInterface::class);
+    $tokenServices->method('getTokenData')
+      ->willReturnCallback(fn ($name) => $this->tokenStorage[$name] ?? NULL);
+    $tokenServices->method('addTokenData')
+      ->willReturnCallback(function ($name, $value) use ($tokenServices) {
+        $this->tokenStorage[$name] = $value;
+        return $tokenServices;
+      });
+
+    $this->action = new FamilyLookupAction(
+      ['cpr_token' => 'cpr', 'result_token' => 'family_data'],
+      'aabenforms_family_lookup',
+      [],
+      $this->createMock(EntityTypeManagerInterface::class),
+      $tokenServices,
+      $this->createMock(AccountProxyInterface::class),
+      $this->createMock(TimeInterface::class),
+      $this->createMock(EcaState::class),
+      $this->createMock(LoggerChannelInterface::class),
+    );
+    $this->collector = $this->createMock(WorkflowExecutionCollector::class);
+    $this->action->setExecutionCollector($this->collector);
+
+    $this->familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+    $cprAccess = $this->createMock(CprAccess::class);
+    $cprAccess->method('reveal')->willReturnArgument(0);
+
+    $reflection = new \ReflectionClass($this->action);
+    foreach (['familyLookup' => $this->familyLookup, 'cprAccess' => $cprAccess] as $property => $value) {
+      $prop = $reflection->getProperty($property);
+      $prop->setAccessible(TRUE);
+      $prop->setValue($this->action, $value);
+    }
+  }
+
+  /**
+   * Children found: result token holds the list, status token 'found'.
+   *
+   * @covers ::execute
+   */
+  public function testChildrenFound(): void {
+    $this->tokenStorage['cpr'] = '0101904521';
+    $children = [
+      ['cpr' => '0109182345', 'full_name' => 'Emil Nielsen Andersen', 'guardians' => []],
+    ];
+    $this->familyLookup->expects($this->once())
+      ->method('childrenOf')
+      ->with('0101904521')
+      ->willReturn($children);
+
+    $this->action->execute();
+
+    $this->assertSame($children, $this->tokenStorage['family_data']);
+    $this->assertSame('found', $this->tokenStorage['family_data_status']);
+  }
+
+  /**
+   * No children: empty list, status 'not_found', step still recorded.
+   *
+   * @covers ::execute
+   */
+  public function testNoChildren(): void {
+    $this->tokenStorage['cpr'] = '1502856234';
+    $this->familyLookup->method('childrenOf')->willReturn([]);
+
+    $this->collector->expects($this->once())->method('addStep');
+
+    $this->action->execute();
+
+    $this->assertSame([], $this->tokenStorage['family_data']);
+    $this->assertSame('not_found', $this->tokenStorage['family_data_status']);
+  }
+
+  /**
+   * Missing CPR: skipped status, lookup never called, skipped step recorded.
+   *
+   * @covers ::execute
+   */
+  public function testMissingCprSkips(): void {
+    $this->familyLookup->expects($this->never())->method('childrenOf');
+
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'skipped');
+
+    $this->action->execute();
+
+    $this->assertNull($this->tokenStorage['family_data']);
+    $this->assertSame('skipped', $this->tokenStorage['family_data_status']);
+  }
+
+  /**
+   * Registry error: status 'error', result NULL, failed step recorded.
+   *
+   * @covers ::execute
+   */
+  public function testRegistryErrorRecordsFailedStep(): void {
+    $this->tokenStorage['cpr'] = '0101904521';
+    $this->familyLookup->method('childrenOf')->willThrowException(new \RuntimeException('down'));
+
+    $this->collector->expects($this->once())
+      ->method('addStep')
+      ->with($this->anything(), $this->anything(), $this->anything(), 'failed');
+
+    $this->action->execute();
+
+    $this->assertNull($this->tokenStorage['family_data']);
+    $this->assertSame('error', $this->tokenStorage['family_data_status']);
+  }
+
+  /**
+   * Hyphenated CPRs are normalized before lookup.
+   *
+   * @covers ::execute
+   */
+  public function testCprNormalization(): void {
+    $this->tokenStorage['cpr'] = '010190-4521';
+    $this->familyLookup->expects($this->once())
+      ->method('childrenOf')
+      ->with('0101904521')
+      ->willReturn([]);
+
+    $this->action->execute();
+  }
+
+  /**
+   * Default configuration exposes the documented token names.
+   *
+   * @covers ::defaultConfiguration
+   */
+  public function testDefaultConfiguration(): void {
+    $defaults = $this->action->defaultConfiguration();
+    $this->assertSame('cpr', $defaults['cpr_token']);
+    $this->assertSame('family_data', $defaults['result_token']);
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ApprovalTokenServiceTest.php
@@ -76,8 +76,8 @@ class ApprovalTokenServiceTest extends UnitTestCase {
    * A token older than TOKEN_EXPIRATION fails the expiry check.
    */
   public function testExpiredTokenRejected(): void {
-    // 7 days + 1 second ago - past TOKEN_EXPIRATION (604800).
-    $token = $this->service->generateToken(42, 1, time() - 604801);
+    // TOKEN_EXPIRATION + 1 second ago - just past the window.
+    $token = $this->service->generateToken(42, 1, time() - ApprovalTokenService::TOKEN_EXPIRATION - 1);
     $this->assertFalse($this->service->validateToken(42, 1, $token));
   }
 
@@ -178,7 +178,7 @@ class ApprovalTokenServiceTest extends UnitTestCase {
    */
   public function testIsTokenExpiredSemantics(): void {
     // Genuinely-past well-formed token → TRUE.
-    $past = $this->service->generateToken(42, 1, time() - 604801);
+    $past = $this->service->generateToken(42, 1, time() - ApprovalTokenService::TOKEN_EXPIRATION - 1);
     $this->assertTrue($this->service->isTokenExpired($past));
 
     // Fresh well-formed token → FALSE.

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
@@ -389,18 +389,23 @@ class ParentCprVerifierTest extends UnitTestCase {
   }
 
   /**
-   * A gated form without a child CPR on the submission skips the gate.
+   * A gated form without a child CPR fails closed (no silent skip).
    *
    * @covers ::verify
    */
-  public function testGatedFormWithoutChildCprSkipsGate(): void {
+  public function testGatedFormWithoutChildCprFailsClosed(): void {
     $this->custodyGatedForms = ['school_transfer'];
     $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
     $this->familyLookup->expects($this->never())->method('hasCustody');
 
     $this->assertSame(
-      ParentCprVerifier::RESULT_MATCH,
+      ParentCprVerifier::RESULT_NO_CUSTODY,
       $this->verifier->verify($this->custodySubmission('school_transfer', NULL), 1, 'wf-custody'),
+    );
+    // A digit-less child CPR is equally unusable and must also fail closed.
+    $this->assertSame(
+      ParentCprVerifier::RESULT_NO_CUSTODY,
+      $this->verifier->verify($this->custodySubmission('school_transfer', 'N/A'), 1, 'wf-custody'),
     );
   }
 

--- a/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Unit/Service/ParentCprVerifierTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\aabenforms_workflows\Unit\Service;
 
+use Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface;
 use Drupal\aabenforms_core\Service\AuditLogger;
 use Drupal\aabenforms_core\Service\CprAccess;
 use Drupal\aabenforms_mitid\Service\MitIdSessionManager;
 use Drupal\aabenforms_workflows\Service\ParentCprVerifier;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\webform\WebformInterface;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
@@ -56,6 +60,20 @@ class ParentCprVerifierTest extends UnitTestCase {
   protected $logger;
 
   /**
+   * Mock family/custody lookup.
+   *
+   * @var \Drupal\aabenforms_core\Family\FamilyRelationsLookupInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $familyLookup;
+
+  /**
+   * Webform ids the custody gate applies to in the current test.
+   *
+   * @var array
+   */
+  protected array $custodyGatedForms = [];
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -75,11 +93,24 @@ class ParentCprVerifierTest extends UnitTestCase {
       static fn (string $v): string => str_starts_with($v, 'AFENC1:') ? substr($v, 7) : $v
     );
 
+    $this->familyLookup = $this->createMock(FamilyRelationsLookupInterface::class);
+
+    // Config factory: custody_gated_forms reads $this->custodyGatedForms so
+    // individual tests can switch the gate on for a form id.
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')->willReturnCallback(
+      fn ($key) => $key === 'custody_gated_forms' ? $this->custodyGatedForms : NULL
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($settings);
+
     $this->verifier = new ParentCprVerifier(
       $this->sessionManager,
       $this->auditLogger,
       $logger_factory,
       $cprAccess,
+      $this->familyLookup,
+      $configFactory,
     );
   }
 
@@ -284,6 +315,93 @@ class ParentCprVerifierTest extends UnitTestCase {
     $this->assertSame('mismatch', ParentCprVerifier::RESULT_MISMATCH);
     $this->assertSame('missing_mitid_cpr', ParentCprVerifier::RESULT_MISSING_MITID_CPR);
     $this->assertSame('missing_expected_cpr', ParentCprVerifier::RESULT_MISSING_EXPECTED_CPR);
+  }
+
+  /**
+   * Builds a submission mock for a custody-gated form with a child CPR.
+   */
+  protected function custodySubmission(string $webformId, ?string $childCpr, string $parentCpr = '0101001234'): WebformSubmissionInterface {
+    $webform = $this->createMock(WebformInterface::class);
+    $webform->method('id')->willReturn($webformId);
+    $submission = $this->createMock(WebformSubmissionInterface::class);
+    $submission->method('getElementData')
+      ->willReturnCallback(static function (string $field) use ($childCpr, $parentCpr) {
+        return match ($field) {
+          'parent1_cpr' => $parentCpr,
+          'child_cpr' => $childCpr,
+          default => NULL,
+        };
+      });
+    $submission->method('getWebform')->willReturn($webform);
+    $submission->method('id')->willReturn(77);
+    $submission->method('uuid')->willReturn('sub-uuid-custody');
+    return $submission;
+  }
+
+  /**
+   * A gated form blocks a matching approver without registered custody.
+   *
+   * @covers ::verify
+   */
+  public function testCustodyGateBlocksNonCustodyHolder(): void {
+    $this->custodyGatedForms = ['school_transfer'];
+    $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
+    $this->familyLookup->method('hasCustody')
+      ->with('0101001234', '0109182345')
+      ->willReturn(FALSE);
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_NO_CUSTODY,
+      $this->verifier->verify($this->custodySubmission('school_transfer', '0109182345'), 1, 'wf-custody'),
+    );
+  }
+
+  /**
+   * A gated form passes a registered custody holder through to MATCH.
+   *
+   * @covers ::verify
+   */
+  public function testCustodyGatePassesCustodyHolder(): void {
+    $this->custodyGatedForms = ['school_transfer'];
+    $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
+    $this->familyLookup->method('hasCustody')->willReturn(TRUE);
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MATCH,
+      $this->verifier->verify($this->custodySubmission('school_transfer', '0109182345'), 1, 'wf-custody'),
+    );
+  }
+
+  /**
+   * Non-gated forms never consult the custody registry.
+   *
+   * @covers ::verify
+   */
+  public function testNonGatedFormSkipsCustodyCheck(): void {
+    $this->custodyGatedForms = ['some_other_form'];
+    $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
+    $this->familyLookup->expects($this->never())->method('hasCustody');
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MATCH,
+      $this->verifier->verify($this->custodySubmission('school_transfer', '0109182345'), 1, 'wf-custody'),
+    );
+  }
+
+  /**
+   * A gated form without a child CPR on the submission skips the gate.
+   *
+   * @covers ::verify
+   */
+  public function testGatedFormWithoutChildCprSkipsGate(): void {
+    $this->custodyGatedForms = ['school_transfer'];
+    $this->sessionManager->method('getCprFromSession')->willReturn('0101001234');
+    $this->familyLookup->expects($this->never())->method('hasCustody');
+
+    $this->assertSame(
+      ParentCprVerifier::RESULT_MATCH,
+      $this->verifier->verify($this->custodySubmission('school_transfer', NULL), 1, 'wf-custody'),
+    );
   }
 
 }

--- a/web/modules/custom/aabenforms_workflows/workflows/skoleskift.bpmn
+++ b/web/modules/custom/aabenforms_workflows/workflows/skoleskift.bpmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:eca="https://drupal.org/project/eca"
+                  id="Definitions_skoleskift"
+                  targetNamespace="http://aabenforms.dk/bpmn">
+  <bpmn:process id="skoleskift" name="Skoleskift (school transfer)" isExecutable="true">
+    <bpmn:documentation>[category: municipal]
+School transfer application with registry-verified custody (FOB 2025-9):
+MitID identity gate, CPR custody check, co-signature from the other custody
+holder via Digital Post, school leader review, decision letters to BOTH
+custody holders, klagefrist and ESDH archiving. The executable models are
+eca.eca.skoleskift_flow, skoleskift_cosign_flow and skoleskift_decision_flow;
+this template documents the citizen-facing insert flow.
+    </bpmn:documentation>
+
+    <bpmn:startEvent id="StartEvent_Submission" name="Application submitted">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:serviceTask id="Task_MitId" name="Validate MitID session" eca:action="aabenforms_mitid_validate">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_Custody" name="Verify custody (CPR registry)" eca:action="aabenforms_custody_verify">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_OpenCase" name="Open case (skoleskift)" eca:action="aabenforms_case_open">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_Journal" name="Journalize case (SF1470)" eca:action="aabenforms_case_journal">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+      <bpmn:outgoing>Flow_5</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_Institution" name="Look up target school" eca:action="aabenforms_institution_lookup">
+      <bpmn:incoming>Flow_5</bpmn:incoming>
+      <bpmn:outgoing>Flow_6</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:exclusiveGateway id="Gateway_Custody" name="Custody situation">
+      <bpmn:incoming>Flow_6</bpmn:incoming>
+      <bpmn:outgoing>Flow_Sole</bpmn:outgoing>
+      <bpmn:outgoing>Flow_JointAgreed</bpmn:outgoing>
+      <bpmn:outgoing>Flow_JointDisagreed</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    <bpmn:serviceTask id="Task_Cosign" name="Send co-sign invitation (Digital Post)" eca:action="aabenforms_send_cosign_invitation">
+      <bpmn:incoming>Flow_JointAgreed</bpmn:incoming>
+      <bpmn:outgoing>Flow_AwaitCosign</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_Partshoering" name="Open partshoering (known disagreement, FOB 2025-9)" eca:action="aabenforms_case_partshoering">
+      <bpmn:incoming>Flow_JointDisagreed</bpmn:incoming>
+      <bpmn:outgoing>Flow_Manual</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:userTask id="Task_Review" name="School leader review">
+      <bpmn:incoming>Flow_Sole</bpmn:incoming>
+      <bpmn:incoming>Flow_AwaitCosign</bpmn:incoming>
+      <bpmn:outgoing>Flow_Decision</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:serviceTask id="Task_Resolve" name="Resolve recipients (both custody holders)" eca:action="aabenforms_resolve_guardians">
+      <bpmn:incoming>Flow_Decision</bpmn:incoming>
+      <bpmn:outgoing>Flow_Letters</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_Letters" name="Decision letters via Digital Post" eca:action="aabenforms_digital_post_send">
+      <bpmn:incoming>Flow_Letters</bpmn:incoming>
+      <bpmn:outgoing>Flow_Archive</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Task_Esdh" name="Archive in ESDH" eca:action="aabenforms_case_esdh_journal">
+      <bpmn:incoming>Flow_Archive</bpmn:incoming>
+      <bpmn:outgoing>Flow_End</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:endEvent id="EndEvent_Done" name="Decision delivered">
+      <bpmn:incoming>Flow_End</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:endEvent id="EndEvent_Manual" name="Manual handling">
+      <bpmn:incoming>Flow_Manual</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_Submission" targetRef="Task_MitId"/>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_MitId" targetRef="Task_Custody"/>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Task_Custody" targetRef="Task_OpenCase"/>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="Task_OpenCase" targetRef="Task_Journal"/>
+    <bpmn:sequenceFlow id="Flow_5" sourceRef="Task_Journal" targetRef="Task_Institution"/>
+    <bpmn:sequenceFlow id="Flow_6" sourceRef="Task_Institution" targetRef="Gateway_Custody"/>
+    <bpmn:sequenceFlow id="Flow_Sole" name="Sole custody" sourceRef="Gateway_Custody" targetRef="Task_Review"/>
+    <bpmn:sequenceFlow id="Flow_JointAgreed" name="Joint custody, agreed" sourceRef="Gateway_Custody" targetRef="Task_Cosign"/>
+    <bpmn:sequenceFlow id="Flow_JointDisagreed" name="Known disagreement" sourceRef="Gateway_Custody" targetRef="Task_Partshoering"/>
+    <bpmn:sequenceFlow id="Flow_AwaitCosign" name="Co-signed" sourceRef="Task_Cosign" targetRef="Task_Review"/>
+    <bpmn:sequenceFlow id="Flow_Manual" sourceRef="Task_Partshoering" targetRef="EndEvent_Manual"/>
+    <bpmn:sequenceFlow id="Flow_Decision" sourceRef="Task_Review" targetRef="Task_Resolve"/>
+    <bpmn:sequenceFlow id="Flow_Letters" sourceRef="Task_Resolve" targetRef="Task_Letters"/>
+    <bpmn:sequenceFlow id="Flow_Archive" sourceRef="Task_Letters" targetRef="Task_Esdh"/>
+    <bpmn:sequenceFlow id="Flow_End" sourceRef="Task_Esdh" targetRef="EndEvent_Done"/>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
Lands the school and family chain that the client case study describes, plus the two tracker findings that surfaced while reviewing it.

Closes #185
Closes #173
Closes #75

## What this adds

The chain no OS2 product has assembled end to end:

- **Custody is looked up, not typed.** `Sf6006FamilyLookup` behind `FamilyRelationsLookupInterface` (SF6006 Familie+), with `DemoFamilyRepository` for the POC case and WireMock mappings that mirror it. Custody filtering happens in the service, not in callers, and `hasCustody()` is fail-closed.
- **Co-signature (medunderskrift)** from the second custody holder via Digital Post, with a registry check that the recipient actually holds custody before the invitation goes out.
- **Dual-guardian decision letters.** `GuardianRecipientResolver` implements the 21 March 2022 rule: each custody holder under 15, the young person directly from 15.
- **Partshoering on disagreement**, so a school transfer is not pushed through against the other holder's will (FOB 2025-9).
- **`aabenforms_institution`**, a new module, plus nine ECA flows in `config/sync`.

The interface seam is deliberate: the 2027 Datafordeler migration replaces one implementation and nothing else. Every consumer type-hints the interface; only `aabenforms_core.services.yml` names the concrete class.

## Verification

Run against the exact CI invocations, not approximations of them.

- **PHPCS**: exit 0, `--standard=Drupal --warning-severity=0 web/modules/custom`
- **PHPUnit**: `--testsuite=unit,kernel` (the scope CI uses), **608 tests, 2669 assertions, OK**
- PHPStan reports pre-existing tree-wide debt and is `continue-on-error: true` by design

Boundary coverage worth naming, because it was a real bug: `GuardianRecipientResolverTest::testBirthdayBoundaryAtMidnightDanishTime` pins 00:30 CEST on the 15th birthday, which is 22:30 UTC the day before. Age was previously computed in UTC, so letters went to the guardians instead of the young person for the first hours of their birthday. Tests cover both sides of the boundary and both fail-closed paths.

## Two fixes folded in from the review

**#75, undeclared permissions.** A full audit of `_permission:` in routing, `hasPermission()` in code and every custom `permissions.yml` found exactly two undeclared permissions. `administer workflows` guards 11 routes and is granted by `user.role.case_worker`, declared nowhere, so it cannot be granted through the UI at all. The decision-state guard checked `administer aabenforms workflows`, which never existed, so only its role branch did any work. Both now declared; `PermissionDeclarationTest` walks the YAML on disk so this cannot recur silently.

**#173, wizard modeler ownership.** Broader than the issue described. `generateEcaWorkflow()` wrote config through `configFactory->setData()`, bypassing the entity API: no uuid, no third-party settings, and three keys (`label`, `modeller`, `version`) that are not in `Eca::$config_export` and get dropped on any later entity save. Now created through eca storage. `af:modeler-adopt` stays as the repair path, since editing in BPMN.iO still strips the setting.

## Known and recorded, not fixed here

- **#186 (new)**: no custom ECA action plugin ships `eca.action.plugin.*` config schema. Pre-existing and invisible in production, since `ConfigSchemaChecker` runs only in tests. It surfaced because this PR adds the first kernel test that drives flow creation, which therefore opts out of strict schema checking.
- **#172**: CPR encryption still rests on the key convention. `child_cpr` and `applicant_cpr` are safe because they end in `_cpr`, not because of the type branch, which matches no real plugin id. This PR adds forms that depend on that convention without worsening it.
- The decision-state guard covers CREATE only. Safe today because JSON:API is read-only and the new forms ship `draft: none`; `ProtectDecisionFieldsTest` pins both so a change fails loudly.

## Deploy note

This adds 18 files under `config/sync` on top of the 42 commits already undeployed to `api.aabenforms.dk`, 21 of which touch `.install` or `config/sync`. That deploy needs a DB snapshot and a watched run; it is not part of this merge.
