### PR TITLE
Enable the Digital Post queue and receipt modules on deploy

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -4,7 +4,9 @@ module:
   aabenforms_case: 0
   aabenforms_core: 0
   aabenforms_digital_post: 0
+  aabenforms_digital_post_beskedfordeler: 0
   aabenforms_digital_post_eca: 0
+  aabenforms_digital_post_queue: 0
   aabenforms_digital_post_session_inbox: 0
   aabenforms_esdh: 0
   aabenforms_institution: 0
@@ -14,6 +16,7 @@ module:
   aabenforms_tenant: 0
   aabenforms_webform: 0
   aabenforms_workflows: 0
+  advancedqueue: 0
   block: 0
   bpmn_io: 0
   breakpoint: 0


### PR DESCRIPTION
Three modules are enabled in local dev but absent from `config/sync/core.extension.yml`, so `drush cim` has never installed them on any deployed environment:

```
advancedqueue
aabenforms_digital_post_queue
aabenforms_digital_post_beskedfordeler
```

`advancedqueue` is in `composer.json`, so the code has shipped to production on every deploy and sat there unused. This is not the deploy being behind; it is `config/sync` being behind the dev database.

## Why this is more than a missing dashboard card

**`LiveSf1601Client` returns `Result::pending()` on a 2xx**, deliberately, because acceptance by Serviceplatformen is not delivery. The thing that resolves `pending` into delivered or failed is the beskedfordeler receipt handler. It is not enabled on production, so **a live Digital Post send stays `pending` forever** with nothing to close the loop.

Without `aabenforms_digital_post_queue` there is also no outbox and no retry, so a Serviceplatformen outage loses the letter rather than retrying it. That was the resilience work from #182.

This also corrects the record on #78: the receipt submodule and its two kernel tests are genuinely on `main`, but the module was enabled nowhere, so the async loop was not actually closed in production. Commented there.

## Verification

The mechanism is proven on this exact pipeline, today rather than in principle. Run 30286451159 logged:

```
[notice] Synchronized extensions: installed aabenforms_esdh, aabenforms_institution, aabenforms_nemlogin.
```

Those three were installed purely because they had been added to `core.extension.yml`. This change is the same edit for three more.

Locally I snapshotted the database, ran `drush cim -y`, and confirmed:

- all three modules end up `Enabled`
- active config count is unchanged at 254, so the import deleted nothing
- demo data intact: 267 webform submissions, 32 ECA flows, 56 cases
- residual drift drops to 2 `Different` entries, both unrelated

Snapshot then restored, so the standing demo environment is untouched.

## Deploy note

`advancedqueue` ships its own schema, so the next deploy's `drush updb` does real work. The pipeline still takes **no database snapshot** before `updb` and `cim`, and backups are weekly VPS-level snapshots with no per-tenant dump. This is a good deploy to take a manual dump before, and a good argument for fixing that gap in `contabo-infrastructure`.
