### PR TITLE
Dashboard: count real MitID logins and enabled ECA flows

### DIFF
--- a/web/modules/custom/aabenforms_core/src/Service/AuditLogger.php
+++ b/web/modules/custom/aabenforms_core/src/Service/AuditLogger.php
@@ -134,17 +134,22 @@ class AuditLogger {
   /**
    * Logs workflow data access.
    *
+   * Rows land with action='workflow_access' and the sub-action in the
+   * purpose column. The parameter is named $purpose to match, so queries
+   * written from a call site's vocabulary do not filter the wrong column
+   * (the dashboard's MitID login counter did exactly that, #191).
+   *
    * @param string $workflow_id
    *   The workflow instance ID.
-   * @param string $action
-   *   The action performed (e.g., 'view', 'update', 'delete').
+   * @param string $purpose
+   *   The sub-action performed (e.g., 'view', 'mitid_session_created').
    * @param string $status
    *   The result status.
    * @param array<string, mixed> $context
    *   Additional context.
    */
-  public function logWorkflowAccess(string $workflow_id, string $action, string $status, array $context = []): void {
-    $this->log('workflow_access', $workflow_id, $action, $status, $context);
+  public function logWorkflowAccess(string $workflow_id, string $purpose, string $status, array $context = []): void {
+    $this->log('workflow_access', $workflow_id, $purpose, $status, $context);
   }
 
   /**

--- a/web/modules/custom/aabenforms_mitid/src/Plugin/AabenformsDashboard/MitidSection.php
+++ b/web/modules/custom/aabenforms_mitid/src/Plugin/AabenformsDashboard/MitidSection.php
@@ -96,8 +96,16 @@ class MitidSection extends AabenformsDashboardSectionBase {
 
     $since = $this->time->getRequestTime() - 86400;
     try {
+      // A successful MitID login is audited by MitIdSessionManager::
+      // storeSession() as action='workflow_access' with the sub-action in
+      // the purpose column (AuditLogger::logWorkflowAccess() wraps log(),
+      // whose first parameter is the action 'workflow_access' itself). The
+      // previous query counted action='mitid_login', which nothing writes,
+      // so this tile was structurally stuck at zero (#191).
       $logins24h = (int) $this->database->select('aabenforms_audit_log', 'l')
-        ->condition('action', 'mitid_login')
+        ->condition('action', 'workflow_access')
+        ->condition('purpose', 'mitid_session_created')
+        ->condition('status', 'success')
         ->condition('timestamp', $since, '>=')
         ->countQuery()
         ->execute()

--- a/web/modules/custom/aabenforms_mitid/tests/src/Kernel/MitidSectionLoginMetricTest.php
+++ b/web/modules/custom/aabenforms_mitid/tests/src/Kernel/MitidSectionLoginMetricTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_mitid\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\aabenforms_mitid\Plugin\AabenformsDashboard\MitidSection;
+
+/**
+ * Proves the dashboard's "Logins (24h)" counter moves on a real login (#191).
+ *
+ * The regression this guards: the tile queried action='mitid_login', which
+ * nothing ever writes - a successful login is audited as
+ * action='workflow_access' / purpose='mitid_session_created' - so the
+ * counter was structurally stuck at zero while logins happened underneath.
+ *
+ * @group aabenforms_mitid
+ */
+class MitidSectionLoginMetricTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'node',
+    'domain',
+    'key',
+    'encrypt',
+    'aabenforms_core',
+    'aabenforms_mitid',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('aabenforms_core', ['aabenforms_audit_log']);
+    $this->installConfig(['system', 'aabenforms_mitid']);
+  }
+
+  /**
+   * Reads the Logins (24h) value from the section's secondary metrics.
+   */
+  private function loginsMetric(): int {
+    $section = MitidSection::create($this->container, [], 'mitid', []);
+    foreach ($section->getSecondaryMetrics() as $metric) {
+      if ((string) $metric['label'] === 'Logins (24h)') {
+        return (int) $metric['value'];
+      }
+    }
+    $this->fail('The MitID card no longer exposes a Logins (24h) metric.');
+  }
+
+  /**
+   * A session created through MitIdSessionManager moves the counter.
+   */
+  public function testLoginCounterCountsStoredSessions(): void {
+    $this->assertSame(0, $this->loginsMetric(), 'Counter starts at zero');
+
+    /** @var \Drupal\aabenforms_mitid\Service\MitIdSessionManager $sm */
+    $sm = $this->container->get('aabenforms_mitid.session_manager');
+    // The audit row is only written for a session that carries a CPR, which
+    // is exactly what a completed MitID login stores.
+    $this->assertTrue($sm->storeSession('wf_' . bin2hex(random_bytes(16)), [
+      'cpr' => '0101904521',
+      'name' => 'Test Testesen',
+      'assurance_level' => 'substantial',
+    ]));
+
+    $this->assertSame(1, $this->loginsMetric(), 'One stored MitID session counts as one login');
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/AabenformsDashboard/WorkflowsSection.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/AabenformsDashboard/WorkflowsSection.php
@@ -8,6 +8,7 @@ use Drupal\aabenforms_core\Dashboard\AabenformsDashboardSectionBase;
 use Drupal\aabenforms_core\Dashboard\Attribute\AabenformsDashboardSection;
 use Drupal\aabenforms_workflows\Service\BpmnTemplateManager;
 use Drupal\aabenforms_workflows\Service\WorkflowTemplateInstantiator;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,6 +25,7 @@ class WorkflowsSection extends AabenformsDashboardSectionBase {
     array $plugin_definition,
     protected readonly BpmnTemplateManager $templateManager,
     protected readonly WorkflowTemplateInstantiator $instantiator,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -38,6 +40,7 @@ class WorkflowsSection extends AabenformsDashboardSectionBase {
       $plugin_definition,
       $container->get('aabenforms_workflows.bpmn_template_manager'),
       $container->get('aabenforms_workflows.template_instantiator'),
+      $container->get('entity_type.manager'),
     );
   }
 
@@ -45,16 +48,30 @@ class WorkflowsSection extends AabenformsDashboardSectionBase {
    * {@inheritdoc}
    */
   public function getLabel(): TranslatableMarkup {
-    return $this->t('Workflow Templates');
+    return $this->t('Workflows');
   }
 
   /**
    * {@inheritdoc}
    */
   public function getHeroMetric(): ?array {
-    $instances = $this->instantiator->getInstances();
+    // "Active workflows" means enabled ECA flows - every flow that fires,
+    // whether hand-authored in config/sync or built with the wizard. The
+    // previous count read only the wizard's template_instance configs, so
+    // deploying hand-authored flows never moved the number and a deploy
+    // looked like it had not landed (#192).
+    try {
+      $count = $this->entityTypeManager->getStorage('eca')->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('status', TRUE)
+        ->count()
+        ->execute();
+    }
+    catch (\Throwable) {
+      $count = 0;
+    }
     return [
-      'value' => count($instances),
+      'value' => (int) $count,
       'label' => $this->t('active workflows'),
     ];
   }
@@ -64,6 +81,10 @@ class WorkflowsSection extends AabenformsDashboardSectionBase {
    */
   public function getSecondaryMetrics(): array {
     return [
+      [
+        'label' => $this->t('Built with the wizard'),
+        'value' => count($this->instantiator->getInstances()),
+      ],
       [
         'label' => $this->t('Templates available'),
         'value' => count($this->templateManager->getAvailableTemplates()),

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/WorkflowsSectionMetricTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/WorkflowsSectionMetricTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\aabenforms_workflows\Plugin\AabenformsDashboard\WorkflowsSection;
+use Drupal\eca\Entity\Eca;
+
+/**
+ * Proves the dashboard's "active workflows" counts ECA flows (#192).
+ *
+ * The regression this guards: the hero metric counted the wizard's
+ * template_instance configs only, so hand-authored flows in config/sync -
+ * all 32 of them on main - never moved the number and a deploy that created
+ * new flows looked like it had not landed.
+ *
+ * @group aabenforms_workflows
+ */
+class WorkflowsSectionMetricTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'key',
+    'encrypt',
+    'domain',
+    'webform',
+    'modeler_api',
+    'eca',
+    'aabenforms_core',
+    'aabenforms_mitid',
+    'aabenforms_workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * Builds the dashboard section plugin.
+   */
+  private function heroValue(): int {
+    $section = WorkflowsSection::create($this->container, [], 'workflows', []);
+    return (int) $section->getHeroMetric()['value'];
+  }
+
+  /**
+   * Creates a bare ECA flow entity.
+   */
+  private function createFlow(string $id, bool $status): void {
+    Eca::create([
+      'id' => $id,
+      'label' => $id,
+      'status' => $status,
+      'modeler' => 'fallback',
+      'version' => '1.0.0',
+      'events' => [],
+      'conditions' => [],
+      'gateways' => [],
+      'actions' => [],
+    ])->save();
+  }
+
+  /**
+   * The hero metric reflects enabled ECA flows, not wizard instances.
+   */
+  public function testActiveWorkflowsCountsEnabledEcaFlows(): void {
+    $this->assertSame(0, $this->heroValue(), 'No flows, no active workflows');
+
+    // Two hand-authored (non-wizard) flows, the shape a config deploy adds.
+    $this->createFlow('hand_authored_a', TRUE);
+    $this->createFlow('hand_authored_b', TRUE);
+    // A disabled flow must not count as active.
+    $this->createFlow('disabled_flow', FALSE);
+
+    $this->assertSame(2, $this->heroValue(), 'Enabled ECA flows move the counter; disabled ones do not');
+  }
+
+}


### PR DESCRIPTION
Fixes #191. Fixes #192.

## MitID Logins (24h) (#191)
The tile queried `action='mitid_login'` - grep shows nothing ever writes that value, and `AuditLogger::logWorkflowAccess()` puts the caller's sub-action in the **purpose** column anyway. A production login wrote `workflow_access / mitid_session_created` and the counter stayed 0 under an activity panel showing the login. Now queries `action='workflow_access' AND purpose='mitid_session_created' AND status='success'`.

Also defuses the trap the issue called out: `logWorkflowAccess($workflow_id, $purpose, ...)` - the parameter is named for the column it lands in.

## Active workflows (#192)
Option A from the issue: the hero metric counts **enabled ECA flows** (`eca` storage, `status=TRUE`), which is what 'active workflows' means to a reader. The wizard-instance count moves to a secondary metric labelled 'Built with the wizard', and the card is retitled 'Workflows'. Live-verified on DDEV: hero went from 6-forever to 30 (the enabled flows on that install); creating a MitID session moved Logins (24h) 0 -> 1.

## Tests
- `MitidSectionLoginMetricTest`: a session stored through `MitIdSessionManager` moves the counter off zero (would have caught the original bug and catches the next column rename).
- `WorkflowsSectionMetricTest`: two enabled flows count 2; a disabled flow does not count.
- Unit+kernel suites for the three touched modules green (353 tests, 1728 assertions), phpcs errors-only clean, no new phpstan findings (`accessCheck(FALSE)` added on the new entity query).