### PR TITLE
Compliance pack: DPA, Art. 30 record, DPIA, NIS2 runbook

### DIFF
--- a/docs/compliance/DATABEHANDLERAFTALE.md
+++ b/docs/compliance/DATABEHANDLERAFTALE.md
@@ -1,0 +1,272 @@
+# Databehandleraftale
+
+**Standardkontraktsbestemmelser (databeskyttelsesforordningens artikel 28, stk. 3)**
+
+Udkast. Strukturen følger Datatilsynets standardkontraktsbestemmelser for
+databehandleraftaler (den danske skabelon godkendt af Det Europæiske
+Databeskyttelsesråd). Felter i [kantede parenteser] udfyldes pr. kommune før
+underskrift. Dokumentet er en draft til brug i udbuds- og pilotdialog og er
+ikke juridisk rådgivning.
+
+---
+
+## Parterne
+
+**Den dataansvarlige:**
+[Kommune], CVR [CVR-nr.], [adresse] ("Kommunen")
+
+**Databehandleren:**
+Fenix Nordic [selskabsform], CVR [CVR-nr.], [adresse] ("Leverandøren"),
+som driftsansvarlig for AabenForms-platformen.
+
+## 1. Præambel
+
+1. Disse bestemmelser fastsætter databehandlerens rettigheder og
+   forpligtelser, når databehandleren behandler personoplysninger på vegne af
+   den dataansvarlige som led i driften af selvbetjenings- og
+   sagsbehandlingsplatformen **AabenForms** (headless Drupal-backend med
+   tilhørende borgervendt frontend).
+2. Bestemmelserne er udformet med henblik på parternes efterlevelse af
+   artikel 28, stk. 3, i databeskyttelsesforordningen (forordning (EU)
+   2016/679) samt databeskyttelsesloven, herunder § 11 om behandling af
+   CPR-numre.
+3. I forbindelse med leveringen af AabenForms behandler databehandleren
+   personoplysninger på vegne af den dataansvarlige i overensstemmelse med
+   disse bestemmelser.
+4. Bestemmelserne har forrang i forhold til eventuelle tilsvarende
+   bestemmelser i andre aftaler mellem parterne, herunder hovedaftalen om
+   levering af AabenForms.
+5. Der hører fire bilag til disse bestemmelser (A-D), og bilagene udgør en
+   integreret del af bestemmelserne.
+
+## 2. Den dataansvarliges forpligtelser og rettigheder
+
+1. Den dataansvarlige har overordnet ansvaret for, at behandlingen af
+   personoplysninger sker inden for rammerne af databeskyttelsesforordningen
+   og databeskyttelsesloven. Kommunen er som offentlig myndighed berettiget
+   til at behandle CPR-numre efter databeskyttelseslovens § 11, stk. 1.
+2. Den dataansvarlige har derfor både retten og pligten til at træffe
+   beslutninger om, til hvilke formål og med hvilke hjælpemidler der må ske
+   behandling. Det materielle hjemmelsgrundlag for de enkelte
+   selvbetjeningsforløb (fx folkeskoleloven, barnets lov, forvaltningsloven)
+   fremgår af bilag A.
+
+## 3. Databehandleren handler efter instruks
+
+1. Databehandleren må kun behandle personoplysninger efter dokumenteret
+   instruks fra den dataansvarlige, medmindre det kræves i henhold til
+   EU-ret eller national ret. Instruksen fremgår af bilag C.
+2. Databehandleren underretter omgående den dataansvarlige, hvis en instruks
+   efter databehandlerens mening er i strid med databeskyttelsesreglerne.
+
+## 4. Fortrolighed
+
+1. Databehandleren giver kun adgang til personoplysninger til personer, der
+   er underlagt fortrolighedsforpligtelse, og kun i det omfang det er
+   nødvendigt (need-to-know). Adgang til produktionsmiljøet er personlig,
+   navngiven og logget.
+2. Databehandleren kan efter anmodning påvise, at de pågældende personer er
+   underlagt fortrolighedsforpligtelse.
+
+## 5. Behandlingssikkerhed
+
+1. Parterne har vurderet sikkerheden ud fra risikoen for de registrerede,
+   herunder at platformen behandler CPR-numre, oplysninger om børn og
+   forældremyndighed samt i visse forløb helbredsoplysninger (artikel 9).
+   De tekniske og organisatoriske foranstaltninger fremgår af bilag C,
+   afsnit C.2.
+2. Kernen i foranstaltningerne er: feltnær AES-256-kryptering af CPR-numre
+   i hvile med fail-closed adfærd (en indsendelse afvises frem for at gemme
+   CPR i klartekst), krypteret transport (TLS), rollebaseret adgang, fuld
+   auditlogning af adgang til personoplysninger og maskeret visning af CPR.
+
+## 6. Anvendelse af underdatabehandlere
+
+1. Databehandleren må ikke gøre brug af en underdatabehandler uden forudgående
+   generel skriftlig godkendelse fra den dataansvarlige.
+2. Databehandleren har den dataansvarliges generelle godkendelse til brug af
+   de underdatabehandlere, der er anført i bilag B. Databehandleren
+   underretter skriftligt om planlagte ændringer med mindst [30] dages
+   varsel, og den dataansvarlige kan gøre indsigelse.
+3. Databehandleren pålægger underdatabehandleren de samme
+   databeskyttelsesforpligtelser som i disse bestemmelser og forbliver fuldt
+   ansvarlig over for den dataansvarlige.
+
+## 7. Overførsel til tredjelande eller internationale organisationer
+
+1. Al behandling sker på infrastruktur i EU/EØS (bilag B). Enhver overførsel
+   af personoplysninger til tredjelande må kun ske efter dokumenteret
+   instruks fra den dataansvarlige og med gyldigt overførselsgrundlag
+   (kapitel V).
+
+## 8. Bistand til den dataansvarlige
+
+1. Databehandleren bistår, under hensyntagen til behandlingens karakter, så
+   vidt muligt den dataansvarlige med opfyldelse af dennes forpligtelser
+   over for de registrerede (artikel 12-22), herunder indsigt, berigtigelse
+   og sletning. Platformens auditlog og eksportfunktioner understøtter
+   besvarelse af indsigtsanmodninger.
+2. Databehandleren bistår ligeledes den dataansvarlige med artikel 32-36,
+   herunder anmeldelse af brud (jf. punkt 9) og konsekvensanalyser (se
+   DPIA_KONSEKVENSANALYSE.md som arbejdsgrundlag).
+
+## 9. Underretning om brud på persondatasikkerheden
+
+1. Databehandleren underretter den dataansvarlige **uden unødig forsinkelse
+   og senest inden for [24] timer** efter at være blevet opmærksom på et brud
+   på persondatasikkerheden hos databehandleren eller en underdatabehandler,
+   så den dataansvarlige kan overholde sin 72-timers anmeldelsesfrist til
+   Datatilsynet (artikel 33).
+2. Underretningen følger eskalationsproceduren i NIS2_INCIDENT_RUNBOOK.md og
+   indeholder som minimum: bruddets karakter, berørte kategorier og antal
+   registrerede, sandsynlige konsekvenser og trufne/foreslåede
+   foranstaltninger.
+
+## 10. Sletning og returnering af oplysninger
+
+1. Ved ophør af tjenesterne returnerer databehandleren efter den
+   dataansvarliges valg alle personoplysninger i et struktureret, almindeligt
+   anvendt format og sletter derefter samtlige kopier, medmindre EU-ret eller
+   national ret kræver opbevaring. Sletningen dokumenteres skriftligt.
+2. Slettefrister for de enkelte oplysningstyper i drift fremgår af bilag C,
+   afsnit C.4. **Ærlig status:** en automatiseret retention-/sletningsmotor
+   pr. sagstype er planlagt, men endnu ikke bygget (GitHub issue #91).
+   Indtil den er i drift, udføres sletning efter instruks som en manuel,
+   dokumenteret driftsprocedure. Auditloggen renses automatisk efter den
+   konfigurerede retention (standard 5 år).
+
+## 11. Revision, herunder inspektion
+
+1. Databehandleren stiller alle oplysninger, der er nødvendige for at påvise
+   overholdelse af artikel 28, til rådighed for den dataansvarlige og giver
+   mulighed for og bidrager til revisioner og inspektioner.
+2. Formen aftales i bilag C, afsnit C.6 (fx årlig skriftlig
+   overensstemmelseserklæring plus inspektionsadgang med [14] dages varsel).
+   Platformens kildekode er åben (GPL-2.0-or-later), hvilket giver den
+   dataansvarlige en revisionsadgang, en lukket leverandør ikke kan tilbyde.
+
+## 12. Parternes aftaler om andre forhold
+
+1. Regulering af økonomi, ansvar og misligholdelse ved brud på disse
+   bestemmelser fremgår af parternes hovedaftale (SLA-vilkår aftales
+   særskilt).
+
+## 13. Ikrafttræden og ophør
+
+1. Bestemmelserne træder i kraft ved begge parters underskrift og gælder, så
+   længe databehandleren behandler personoplysninger på vegne af den
+   dataansvarlige.
+
+---
+
+## Bilag A - Oplysninger om behandlingen
+
+**A.1 Formål:** Drift af kommunens digitale selvbetjenings- og
+arbejdsgangsplatform: modtagelse af ansøgninger og anmeldelser fra borgere,
+identitetssikring (MitID), automatiserede sagsskridt (ECA-flows), afsendelse
+af Digital Post og aflevering til kommunens fagsystemer/ESDH.
+
+**A.2 Behandlingens karakter:** Indsamling via webformularer, opslag i
+autoritative registre (CPR via SF1520, CVR via SF1530 - via
+Serviceplatformen, når kommunens tilslutning foreligger), strukturering,
+opbevaring (krypteret for CPR), forsendelse (Digital Post SF1601),
+journalisering og sletning.
+
+**A.3 Kategorier af registrerede:** Borgere (ansøgere), børn, forældre og
+forældremyndighedsindehavere, medarbejdere hos kommunen (sagsbehandlere),
+fagpersoner der indgiver underretninger.
+
+**A.4 Kategorier af personoplysninger:**
+
+| Kategori | Eksempler | Klassifikation |
+|---|---|---|
+| Identifikation | Navn, CPR-nummer, adresse, kontaktoplysninger | Alm. + CPR (dbl. § 11) |
+| Identitetssikring | MitID-sessionsdata, sikringsniveau (assurance level) | Alm. |
+| Familieforhold | Forældremyndighed, samlevende/bopælsstatus, barn-forælder-relationer | Alm., beskyttelsesværdige, vedrører børn |
+| Helbred | Oplysninger om funktionsnedsættelse/merudgifter (fx forløb efter barnets lov § 86), PPR-henvisningsgrundlag | **Artikel 9 (følsomme)** |
+| Sociale forhold | Underretningsindhold om bekymring for et barn | Følsomt indhold, skærpet beskyttelse |
+| Sagsdata | Ansøgningsindhold, afgørelsesbreve, frister, status | Alm. |
+| Tekniske spor | Auditlog (bruger, handling, formål, IP, hashet identifikator), driftslogs | Alm. |
+
+**A.5 Varighed:** Så længe hovedaftalen løber; slettefrister jf. bilag C.4.
+
+**A.6 Materielt hjemmelsgrundlag pr. forløb (eksempler, udfyldes af
+kommunen):** skoleflytning (folkeskoleloven § 36, stk. 3), underretning
+(barnets lov §§ 133-135), merudgifter til børn (barnets lov § 86),
+partshøring og afgørelse (forvaltningsloven §§ 19-25), valg til MED-udvalg
+(kommunens MED-aftale).
+
+## Bilag B - Underdatabehandlere
+
+Godkendte underdatabehandlere ved aftalens indgåelse:
+
+| Navn | CVR/reg. | Ydelse | Lokation |
+|---|---|---|---|
+| [Hostingleverandør, fx Contabo GmbH] | [reg.nr.] | Server-/infrastrukturdrift (produktionsmiljø) | EU (Tyskland) |
+| [E-mailleverandør, fx Mailgun EU] | [reg.nr.] | Transaktionel e-mail (notifikationer, ikke Digital Post) | EU-region (kontraktkrav) |
+
+Bemærk: Serviceplatformen/KOMBIT og Digital Post er **ikke**
+underdatabehandlere for Leverandøren; kommunens egen tilslutningsaftale
+gælder. Ingen underdatabehandlere uden for EU/EØS.
+
+## Bilag C - Instruks
+
+**C.1 Behandlingens genstand/instruks:** Databehandleren behandler alene
+oplysningerne til drift af de i bilag A nævnte forløb, som kommunen har
+konfigureret og taget i brug. Ingen behandling til egne formål; ingen
+anvendelse til udvikling/test uden forudgående anonymisering.
+
+**C.2 Behandlingssikkerhed (tekniske og organisatoriske foranstaltninger):**
+
+- Feltnær AES-256-kryptering af CPR i hvile; fail-closed (indsendelse
+  afvises, hvis krypteringsnøglen er utilgængelig). Ved multi-tenant-drift
+  anvendes tenant-specifikke nøgler, så en kommunes nøgle ikke kan afkode en
+  andens data.
+- CPR vises maskeret (DDMMÅÅ-XXXX) i borger- og sessionsflader; fuldt CPR
+  eksponeres kun ved dokumenteret tjenstligt behov.
+- Fuld auditlog af adgang til og opslag på personoplysninger (bruger,
+  handling, formål, status, IP, SHA-256-hashet identifikator) med
+  konfigurerbar retention (standard 5 år) og automatisk oprydning.
+- Identitetssikring af borgerforløb via MitID (OIDC); fail-closed som
+  standard, demo-tilstand kræver eksplicit konfigurationsflag og er
+  deaktiveret i produktion.
+- Rollebaseret adgang; afgørelsesbærende felter kan ikke sættes af borgeren
+  (server-side guard); lovlige sagstilstandsovergange håndhæves på
+  entitetsniveau (forvaltningsloven §§ 19-25 understøttet i datamodellen).
+- TLS på al transport; adgang til produktion via personlige nøgler.
+- Kendte, planlagte forbedringer føres åbent i issue-trackeren, p.t. bl.a.
+  udvidet rate limiting (#142) og automatiseret retention (#91). Status
+  meddeles kommunen ved væsentlige ændringer.
+
+**C.3 Bistand:** Jf. punkt 8-9; svarfrister for bistand aftales i SLA.
+
+**C.4 Opbevaring/sletning (udfyldes endeligt af kommunen pr. sagsområde):**
+
+| Datatype | Frist (udkast) | Ansvar |
+|---|---|---|
+| Webform-indsendelser efter aflevering til ESDH/fagsystem | [90 dage] | Databehandler efter instruks |
+| MitID-sessionsdata | 15 minutter (TTL, automatisk) | Automatisk |
+| Auditlog | 5 år (konfigurerbar) | Automatisk |
+| Digital Post-afsendelseslog | [1 år] | Databehandler efter instruks |
+| Backups | [30 dage rullende] | Databehandler |
+
+**C.5 Lokation:** Produktionsmiljø: [api.aabenforms.dk eller
+kommune-specifik instans], EU-datacenter jf. bilag B.
+
+**C.6 Revision:** Årlig skriftlig erklæring om efterlevelse + inspektion med
+[14] dages varsel. Kildekoden er offentligt tilgængelig og kan revideres
+frit.
+
+## Bilag D - Parternes regulering af andre forhold
+
+[SLA-henvisning, supportvindue, exitplan inkl. dataeksportformat
+(struktureret JSON/CSV pr. forløb), pris for bistand ud over det aftalte.]
+
+---
+
+*Underskrifter:*
+
+| For den dataansvarlige | For databehandleren |
+|---|---|
+| Dato: | Dato: |
+| Navn/titel: | Navn/titel: |

--- a/docs/compliance/DPIA_KONSEKVENSANALYSE.md
+++ b/docs/compliance/DPIA_KONSEKVENSANALYSE.md
@@ -1,0 +1,131 @@
+# Konsekvensanalyse vedrørende databeskyttelse (DPIA)
+
+**AabenForms - digital selvbetjening og sagsgange for [Kommune]**
+
+Udkast til brug for kommunens DPIA efter databeskyttelsesforordningens
+artikel 35. Kommunen er dataansvarlig og ejer den endelige analyse; dette
+dokument leverer den systematiske beskrivelse, leverandørens
+risikovurdering og de tekniske foranstaltninger, så kommunens DPO kan
+færdiggøre analysen uden at starte forfra. Risikotabellen afspejler
+platformens **verificerede** tilstand (jf. `../PROMISES-VS-VERIFIED.md`) -
+ikke marketingmateriale.
+
+## 1. Er en DPIA påkrævet?
+
+Ja. Behandlingen rammer flere af kriterierne i Datatilsynets/EDPB's liste
+over behandlinger med sandsynlig høj risiko:
+
+- **Oplysninger om børn** behandles systematisk (skoleskift, PPR,
+  underretninger, merudgifter), og børn er sårbare registrerede.
+- **Følsomme oplysninger (art. 9)**: helbred/funktionsnedsættelse i
+  merudgifts- og PPR-forløb; socialt belastende indhold i underretninger.
+- **CPR-numre** (national identifikator, dbl. § 11) i næsten alle forløb.
+- **Forældremyndigheds- og familierelationer**, herunder konfliktfyldte
+  (dobbelt-forældre-godkendelse), hvor fejl kan have alvorlige konsekvenser.
+- Behandlingen sker i stor skala for en kommunes borgere og kombinerer
+  registre (CPR-opslag, MitID-identitet, Digital Post).
+
+## 2. Systematisk beskrivelse af behandlingen (art. 35, stk. 7, litra a)
+
+### 2.1 Dataflow (resumé; detaljeret sporing i `../DATA-FLOW.md`)
+
+1. Borgeren udfylder en formular i den borgervendte frontend; ved
+   identitetskrævende forløb gennemføres MitID-login først (OIDC).
+   MitID-sessionen lever server-side med 15 minutters TTL; frontend ser kun
+   maskeret CPR (DDMMÅÅ-XXXX).
+2. Indsendelsen modtages af backend-API'et, hvor identitet håndhæves
+   server-side, og CPR-felter krypteres feltnært (AES-256) **før** lagring.
+   Kryptering er fail-closed: kan der ikke krypteres, afvises indsendelsen
+   frem for at gemme klartekst.
+3. ECA-arbejdsgange udfører sagsskridt: registeropslag (SF1520/SF1530 via
+   Serviceplatformen, når kommunens tilslutning er aktiv), samtykkegates
+   (forældre-CPR verificeres mod MitID-session, fail-closed), fristberegning
+   (danske helligdage, Europe/Copenhagen), afgørelsesbreve.
+4. Kommunikation til borgeren sendes som Digital Post (SF1601).
+   Sagen afleveres til kommunens ESDH/fagsystem.
+5. Al adgang til personoplysninger auditlogges (bruger, handling, formål,
+   status, IP, SHA-256-hashet identifikator); retention 5 år, automatisk
+   oprydning via cron.
+
+### 2.2 Systemkarakteristika med databeskyttelsesrelevans
+
+- Headless Drupal 11-backend, Nuxt-frontend; åben kildekode
+  (GPL-2.0-or-later), hvilket muliggør uafhængig revision.
+- Multi-tenant-arkitektur med tenant-specifikke krypteringsnøgler; en
+  kommunes nøgle kan ikke afkode en anden kommunes CPR-data.
+- Afgørelsesbærende felter (fx caseworker_status) kan ikke sættes af
+  borgeren; guard håndhæves server-side.
+- Lovlige sagstilstandsovergange håndhæves på entitetsniveau: en afsluttet
+  sag er uforanderlig, en bebyrdende afgørelse kræver gennemført partshøring
+  (forvaltningsloven § 19) eller registreret undtagelse.
+
+## 3. Nødvendighed og proportionalitet (art. 35, stk. 7, litra b)
+
+- **Dataminimering:** Formularer indsamler kun felter, som det konkrete
+  forløb kræver; CPR anvendes, hvor entydig identifikation er lovpligtig
+  eller nødvendig (dbl. § 11). Frontend modtager aldrig fuldt CPR fra
+  sessionen.
+- **Formålsbegrænsning:** Leverandøren behandler alene efter instruks
+  (databehandleraftalens bilag C); ingen sekundær anvendelse.
+- **Opbevaringsbegrænsning:** MitID-sessioner udløber automatisk efter 15
+  minutter; auditlog renses efter konfigureret retention. Sletning af
+  sagsdata sker i dag efter instruks som dokumenteret manuel procedure;
+  automatiseret retention pr. sagstype er planlagt (issue #91) - se risiko
+  R6.
+- **Alternativvurdering:** Papir-/blanketbaseret behandling ville indebære
+  ringere sikkerhed (ukrypteret transport/opbevaring, ingen auditlog) og
+  dårligere borgerretssikkerhed (ingen håndhævet partshøring/frister).
+
+## 4. Risikovurdering (art. 35, stk. 7, litra c)
+
+Skala: sandsynlighed og konsekvens 1-3 (lav/mellem/høj). Restrisiko efter
+foranstaltninger. Statuskolonnen er ærlig: "åben" betyder, at kommunen skal
+forholde sig til restrisikoen, før forløbet går i produktion.
+
+| # | Risiko for de registrerede | S | K | Foranstaltning | Restrisiko / status |
+|---|---|---|---|---|---|
+| R1 | CPR lækkes fra hvilende data (databasekompromittering) | 1 | 3 | Feltnær AES-256-kryptering, fail-closed, tenant-nøgler; nøgler uden for databasen (env/key-provider) | Lav. Lukket for alle CPR-elementtyper efter #172 (verificeret ved regressionstest) |
+| R2 | Forkert forælder godkender på barnets vegne (myndighedsfejl i konfliktsager) | 1 | 3 | Samtykkegate verificerer forælder-CPR mod MitID-session, fail-closed; begge forældremyndighedsindehavere skal godkende; submit-time re-verifikation | Lav (tidligere defekt, nu verificeret lukket) |
+| R3 | Borger opnår afgørelse uden sagsbehandling (manipulation af statusfelter) | 1 | 3 | Server-side guard på afgørelsesfelter; JSON:API read-only; tilstandsmaskine på entitetsniveau | Lav |
+| R4 | MitID-sessionskapabilitet lækker via URL (browserhistorik, Referer, proxylogs) og misbruges inden 15-min-TTL | 2 | 2 | Maskeret CPR i svar, auditlogget opslag inkl. miss (probing er synlig), session bundet til browser-session ved udstedelse | **Åben (mellem): endpointet stoler p.t. på bearer alene; engangskode/HTTPOnly-cookie er planlagt (issue #156)** |
+| R5 | Volumetrisk misbrug/enumeration mod API og MitID-ruter | 2 | 2 | Flood control på webform-submit; sessionsopslag auditlogges | **Åben (mellem): rate limiting på JSON:API og MitID-ruter udestår (issue #142)** |
+| R6 | Data opbevares længere end nødvendigt | 2 | 2 | Dokumenteret manuel sletteprocedure efter instruks; auditlog auto-renses; MitID-TTL | **Åben (mellem): automatiseret retention/sletning pr. sagstype udestår (issue #91); manuel procedure skal aftales i bilag C.4** |
+| R7 | Digital Post sendes to gange eller til forkert modtager | 2 | 2 | Fail-closed transporttilstand; afsendelseslog med hashet modtager | **Åben (mellem): idempotensnøgle og modtager-fra-verificeret-session er planlagt (issue #73); indtil da manuel kontrol i kritiske forløb** |
+| R8 | Følsomt underretningsindhold ses af uvedkommende internt | 1 | 3 | Rollebaseret adgang, auditlog med formålsangivelse, personlig produktionsadgang | Lav-mellem; kommunens egen rolletildeling er den bærende kontrol |
+| R9 | Registerudfald (Serviceplatformen) blokerer sagsgange | 2 | 1 | Fejl rapporteres ærligt i sagsforløbet (skipped/failed) | Åben (lav): circuit breaker planlagt (issue #72); driftsrisiko, ikke rettighedsrisiko |
+| R10 | Auditlog indeholder selv persondata og bliver et mål | 1 | 2 | Identifikatorer hashes (SHA-256), IP nødvendig for sporbarhed, 5 års retention med auto-oprydning, adgang rollebegrænset | Lav |
+
+## 5. Planlagte foranstaltninger og tidsplan (art. 35, stk. 7, litra d)
+
+| Åben risiko | Foranstaltning | Reference | Målsætning |
+|---|---|---|---|
+| R4 | Engangskode eller HTTPOnly-cookie i stedet for kapabilitet i URL | #156 | Før pilot med rigtige borgerdata |
+| R5 | Rate limiting på JSON:API + MitID-ruter | #142 | Før pilot |
+| R6 | Retention-/sletningsmotor pr. sagstype | #91 | Før eller tidligt i pilot; indtil da manuel procedure |
+| R7 | Idempotensnøgle + modtager fra verificeret session | #73 | Før forløb med bebyrdende afgørelser |
+
+Konklusion (leverandørens indstilling til kommunens DPO): Med de fire
+planlagte foranstaltninger gennemført er restrisikoen for de registrerede
+lav. Uden dem bør pilot afgrænses til forløb uden bebyrdende afgørelser,
+eller kommunen skal aktivt acceptere restrisikoen. Forudgående høring af
+Datatilsynet (art. 36) vurderes ikke påkrævet, når foranstaltningerne er
+gennemført - vurderingen er kommunens.
+
+## 6. Inddragelse
+
+- **DPO:** Kommunens DPO forelægges denne analyse og fører sin udtalelse i
+  afsnit 7.
+- **De registrerede:** Borgerforløbene testes med brugerpaneler;
+  tilgængelighed (WCAG) auditeres i frontend før erklæring.
+- **Leverandør:** Fenix Nordic vedligeholder risikotabellen ved hver
+  væsentlig ændring og underretter kommunen (databehandleraftalens punkt 9).
+
+## 7. DPO'ens udtalelse og den dataansvarliges godkendelse
+
+[Udfyldes af kommunen.]
+
+| Rolle | Navn | Dato | Beslutning |
+|---|---|---|---|
+| DPO | | | |
+| Systemejer | | | |
+| Dataansvarlig ledelse | | | |

--- a/docs/compliance/FORTEGNELSE_ART30.md
+++ b/docs/compliance/FORTEGNELSE_ART30.md
@@ -1,0 +1,139 @@
+# Fortegnelse over behandlingsaktiviteter (artikel 30)
+
+Udkast. To dele: **del 1** er Leverandørens fortegnelse som databehandler
+(artikel 30, stk. 2) og er den, kommunens DPO efterspørger i en
+leverandørvurdering. **Del 2** er input til kommunens egen fortegnelse som
+dataansvarlig (artikel 30, stk. 1) pr. selvbetjeningsforløb, så kommunen ikke
+skal starte fra nul.
+
+---
+
+## Del 1 - Databehandlerens fortegnelse (art. 30, stk. 2)
+
+**Databehandler:** Fenix Nordic [selskabsform], CVR [CVR-nr.], [adresse].
+Kontakt: [navn, e-mail]. Databeskyttelsesrådgiver: [navn/e-mail eller "ikke
+udpegningspligtig, kontaktpunkt: ..."].
+
+**Dataansvarlige, der behandles for:** [Kommune(r) med aktiv aftale -
+vedligeholdes som liste pr. kontrakt.]
+
+### Kategorier af behandling, der foretages på vegne af hver dataansvarlig
+
+| # | Behandlingskategori | Beskrivelse |
+|---|---|---|
+| 1 | Modtagelse og opbevaring af borgerindsendelser | Webformularer (ansøgninger, anmeldelser, underretninger, samtykker) modtages via platformens API og opbevares i platformens database; CPR-felter krypteres feltnært (AES-256) før skrivning |
+| 2 | Identitetssikring | MitID-login (OIDC); sessionsdata (navn, maskeret CPR, fødselsdato, adresse, sikringsniveau) opbevares midlertidigt med 15 minutters TTL |
+| 3 | Registeropslag | Opslag i CPR (SF1520) og CVR (SF1530) via Serviceplatformen på kommunens tilslutning; svar anvendes i sagsforløbet og opbevares som sagsdata |
+| 4 | Automatiserede sagsskridt | ECA-arbejdsgange: validering, forældre-/værgesamtykke, partshøring, fristberegning, afgørelsesbreve |
+| 5 | Forsendelse | Digital Post (SF1601) til borgere; transaktionel e-mail-notifikation via underdatabehandler (EU-region) |
+| 6 | Journalisering/aflevering | Overdragelse af sag og dokumenter til kommunens ESDH/fagsystem via konnektor |
+| 7 | Auditlogning | Logning af al adgang til personoplysninger (bruger, handling, formål, status, IP, hashet identifikator); retention 5 år, automatisk oprydning |
+| 8 | Backup og gendannelse | Krypterede backups af produktionsdata, [30 dage rullende] |
+| 9 | Sletning | Sletning efter den dataansvarliges instruks; automatiseret retention pr. sagstype er planlagt (issue #91), p.t. dokumenteret manuel procedure |
+
+### Overførsler til tredjelande
+
+Ingen. Al behandling sker i EU/EØS (hosting i EU-datacenter; e-mail i
+EU-region ved kontraktkrav).
+
+### Generel beskrivelse af tekniske og organisatoriske
+sikkerhedsforanstaltninger (art. 32, stk. 1)
+
+Se DATABEHANDLERAFTALE.md bilag C.2. Hovedpunkter: feltnær AES-256-kryptering
+af CPR med fail-closed adfærd og tenant-specifikke nøgler, maskeret
+CPR-visning, MitID-identitetssikring (fail-closed), rollebaseret adgang,
+server-side beskyttelse af afgørelsesfelter, håndhævede sagstilstandsregler,
+fuld auditlog, TLS, personlig og logget produktionsadgang, åben kildekode
+(revisionsbar).
+
+---
+
+## Del 2 - Input til kommunens fortegnelse (art. 30, stk. 1) pr. forløb
+
+Kommunen er dataansvarlig for alle borgerforløb på platformen. Tabellerne
+nedenfor er udfyldte udkast; kommunen tilpasser formål/hjemmel til egen
+praksis og tilføjer sine slettefrister.
+
+### 2.1 Skoleflytning (skoleskift)
+
+| Felt | Indhold |
+|---|---|
+| Formål | Behandling af anmodning om skoleskift, indhentelse af samtykke fra begge forældremyndighedsindehavere |
+| Hjemmel | Folkeskoleloven § 36, stk. 3 (frit skolevalg); databeskyttelsesforordningen art. 6, stk. 1, litra e; CPR: databeskyttelseslovens § 11, stk. 1 |
+| Registrerede | Barnet, forældre/forældremyndighedsindehavere |
+| Oplysninger | Navne, CPR-numre (krypteret), adresser, nuværende/ønsket skole, forældremyndighedsforhold, MitID-verifikation, samtykker |
+| Modtagere | Afgivende og modtagende skole, kommunens skoleforvaltning; Digital Post-kvittering til forældrene |
+| Sletning | [Kommunens frist, fx ved afsluttet indskrivning + X måneder] |
+
+### 2.2 Underretning (fagperson og borger)
+
+| Felt | Indhold |
+|---|---|
+| Formål | Modtagelse og videresendelse af underretninger om bekymring for et barn |
+| Hjemmel | Barnets lov §§ 133-135 (underretningspligt); art. 6, stk. 1, litra c/e; art. 9, stk. 2, litra f/g i det omfang følsomme oplysninger indgår |
+| Registrerede | Barnet, forældre, underretter (kan være anonym for borgere) |
+| Oplysninger | Bekymringsbeskrivelse (kan indeholde helbredsmæssige og sociale oplysninger), navne, evt. CPR (krypteret), relationer |
+| Modtagere | Kommunens familieafdeling; frist håndhæves (24 timer for kvittering jf. praksis) |
+| Sletning | Overdrages til sagssystem; platformskopi slettes efter [frist] |
+
+### 2.3 Merudgifter til børn
+
+| Felt | Indhold |
+|---|---|
+| Formål | Ansøgning om dækning af nødvendige merudgifter ved forsørgelse af barn med funktionsnedsættelse |
+| Hjemmel | Barnets lov § 86; art. 6, stk. 1, litra e; **art. 9, stk. 2, litra b/g (helbredsoplysninger)**; CPR: dbl. § 11, stk. 1 |
+| Registrerede | Barnet, forældre |
+| Oplysninger | Helbreds-/funktionsnedsættelsesoplysninger, udgiftsdokumentation, CPR (krypteret), familieforhold, MitID-verifikation |
+| Modtagere | Kommunens socialforvaltning; afgørelse via Digital Post |
+| Sletning | [Kommunens frist jf. regnskabs- og sagskrav] |
+
+### 2.4 Forældresamtykke/værgesamtykke (guardian consent, parent request)
+
+| Felt | Indhold |
+|---|---|
+| Formål | Indhentelse af gyldigt samtykke fra begge forældremyndighedsindehavere i sager, der kræver det (dobbelt-godkendelsesforløb) |
+| Hjemmel | Følger hovedsagens hjemmel; forældremyndighed efter forældreansvarsloven; art. 6, stk. 1, litra e |
+| Registrerede | Barnet, begge forældre |
+| Oplysninger | CPR for forældre (krypteret, verificeret mod MitID-session), forældremyndighedsstatus, samtykkebeslutning, tidsstempler |
+| Modtagere | Sagsbehandler; kvittering via Digital Post til begge forældre |
+| Sletning | Som hovedsagen |
+| Bemærkning | Samtykkegate er fail-closed: forkert eller uverificeret CPR afviser godkendelsen |
+
+### 2.5 PPR-henvisning
+
+| Felt | Indhold |
+|---|---|
+| Formål | Henvisning af barn til Pædagogisk Psykologisk Rådgivning |
+| Hjemmel | Folkeskoleloven § 12, stk. 2 (specialundervisning mv.); art. 9, stk. 2, litra g i det omfang helbredsoplysninger indgår |
+| Registrerede | Barnet, forældre, henvisende fagperson |
+| Oplysninger | Henvisningsgrundlag (kan indeholde helbred/trivsel), CPR (krypteret), samtykker fra forældremyndighedsindehavere |
+| Modtagere | PPR, skole |
+| Sletning | [Kommunens frist] |
+
+### 2.6 Valg til MED-udvalg (opstilling og afstemning)
+
+| Felt | Indhold |
+|---|---|
+| Formål | Digital opstilling og afstemning til MED-udvalg |
+| Hjemmel | Kommunens MED-aftale; art. 6, stk. 1, litra e/f |
+| Registrerede | Medarbejdere |
+| Oplysninger | Navn, CPR til entydig vælgeridentifikation (krypteret), stemmeafgivelse (hemmelig; kun afkrydsning af at der er stemt) |
+| Modtagere | Valgudvalg (optælling, ikke enkeltstemmer pr. person) |
+| Sletning | Efter valgets endelige opgørelse + klagefrist |
+
+### 2.7 Borgerservice-ansøgninger og adresseændring (demo-/standardforløb)
+
+| Felt | Indhold |
+|---|---|
+| Formål | Diverse selvbetjeningsforløb (flytning, ansøgninger) |
+| Hjemmel | CPR-loven §§ 12-13 (anmeldelse af flytning) hhv. det enkelte forløbs sektorlovgivning |
+| Registrerede | Borgere |
+| Oplysninger | Navn, CPR (krypteret), adresser, kontaktoplysninger |
+| Modtagere | Relevant forvaltning |
+| Sletning | [Kommunens frist] |
+
+---
+
+*Vedligehold: Når et nyt forløb konfigureres i platformen, tilføjes en række
+her, før forløbet går i produktion. Fortegnelsen er et levende dokument og
+skal kunne forevises Datatilsynet på anmodning (art. 30, stk. 4).*

--- a/docs/compliance/NIS2_INCIDENT_RUNBOOK.md
+++ b/docs/compliance/NIS2_INCIDENT_RUNBOOK.md
@@ -1,0 +1,159 @@
+# NIS2 incident-response runbook
+
+**AabenForms drift - hændelseshåndtering med NIS2- og GDPR-frister**
+
+Udkast. Operationel drejebog for sikkerhedshændelser i AabenForms-driften,
+skrevet så den kan vedlægges kommunens informationssikkerhedsdokumentation.
+Kommuner er omfattet af NIS2 som offentlig forvaltning (væsentlige enheder)
+efter den danske NIS2-lov (i kraft 1. juli 2025); Leverandøren indgår i
+kommunens leverandørkæde og skal kunne levere input til kommunens
+anmeldelser inden for fristerne. Kontaktfelter i [kantede parenteser]
+udfyldes pr. kommune før drift.
+
+## 1. Definitioner og klassifikation
+
+**Hændelse:** enhver begivenhed, der kompromitterer tilgængelighed,
+integritet, fortrolighed eller autenticitet af platformen eller data i den.
+
+**Væsentlig hændelse (NIS2-anmeldelsespligtig):** en hændelse, der (a) har
+forårsaget eller kan forårsage alvorlig driftsforstyrrelse eller økonomisk
+tab, eller (b) har påvirket eller kan påvirke andre (fysiske eller
+juridiske personer) ved at forvolde betydelig materiel eller immateriel
+skade.
+
+**Brud på persondatasikkerheden (GDPR art. 4, nr. 12):** hændelse, der fører
+til hændelig/ulovlig tilintetgørelse, tab, ændring eller uautoriseret
+videregivelse af eller adgang til personoplysninger.
+
+### Alvorlighedsniveauer
+
+| Niveau | Kriterium | Eksempler |
+|---|---|---|
+| SEV1 | Bekræftet kompromittering af persondata eller nøglemateriale; platform bruges aktivt til angreb | CPR-krypteringsnøgle lækket; database eksfiltreret; aktiv udnyttelse af MitID-flow |
+| SEV2 | Sandsynlig kompromittering eller alvorlig funktionsfejl med databeskyttelseskonsekvens | Kapabilitets-id'er misbrugt inden TTL; Digital Post sendt til forkerte modtagere; auditlog manipuleret |
+| SEV3 | Driftsforstyrrelse uden tegn på datakompromittering | Længerevarende nedetid, registerudfald (Serviceplatformen), DoS uden databrud |
+| SEV4 | Forsøg/scanning uden effekt | Fejlede probes mod sessionendpoint (synlige i auditlog), brute-force stoppet af flood control |
+
+SEV1-SEV2 udløser altid vurdering af **både** NIS2-varsling og GDPR art. 33.
+SEV3 kan være NIS2-anmeldelsespligtig (væsentlig driftsforstyrrelse) uden at
+være et persondatabrud.
+
+## 2. Frister (de tal, alle skal kunne udenad)
+
+### NIS2 (kommunen som væsentlig enhed; CSIRT: CFCS)
+
+| Frist | Handling |
+|---|---|
+| **24 timer** | Tidlig varsling til CSIRT'en (CFCS) ved væsentlig hændelse: mistanke om ondsindet handling og evt. grænseoverskridende påvirkning angives |
+| **72 timer** | Hændelsesanmeldelse: opdateret vurdering, alvorlighed, konsekvenser, kompromitteringsindikatorer |
+| Ved anmodning | Statusrapport til CSIRT'en |
+| **1 måned** | Endelig rapport: detaljeret beskrivelse, årsag, afhjælpning, evt. grænseoverskridende virkning |
+
+### GDPR
+
+| Frist | Handling |
+|---|---|
+| **Uden unødig forsinkelse, senest 24 timer** (kontraktkrav, databehandleraftalens punkt 9) | Leverandøren underretter kommunen om brud hos Leverandøren eller underdatabehandler |
+| **72 timer** | Kommunen (dataansvarlig) anmelder brud til Datatilsynet (art. 33), medmindre bruddet sandsynligvis ikke indebærer risiko |
+| **Uden unødig forsinkelse** | Underretning af de registrerede ved sandsynlig høj risiko (art. 34) - relevant ved CPR-/børnedata |
+
+Fristerne løber parallelt. En SEV1 kl. 14:00 en fredag betyder tidlig
+NIS2-varsling senest lørdag kl. 14:00 og Datatilsynet-anmeldelse senest
+mandag kl. 14:00. Weekend udskyder intet.
+
+## 3. Roller og kontakter
+
+| Rolle | Hvem | Kontakt |
+|---|---|---|
+| Incident manager (Leverandør) | [navn] | [tlf./e-mail, 24/7-aftale jf. SLA] |
+| Teknisk drift (Leverandør) | [navn] | [kontakt] |
+| Kommunens informationssikkerhedskoordinator | [navn] | [kontakt] |
+| Kommunens DPO | [navn] | [kontakt] |
+| CSIRT (CFCS) | Center for Cybersikkerhed | Anmeldelse via virk.dk / CFCS' anmeldelsesportal |
+| Datatilsynet | - | Anmeldelse via virk.dk ("Anmeld brud på persondatasikkerheden") |
+| Politiet (ved strafbart forhold) | NSK/NC3 | 114 / anmeldelse |
+
+Ansvarsfordeling: **Leverandøren** opdager, inddæmmer, dokumenterer og
+leverer teknisk grundlag. **Kommunen** ejer anmeldelserne til CFCS og
+Datatilsynet (dataansvarlig/omfattet enhed) - Leverandøren anmelder aldrig
+selv på kommunens vegne, men skal levere udkast til anmeldelsestekst inden
+for fristerne ovenfor.
+
+## 4. Drejebog pr. fase
+
+### Fase 0 - Detektion (mål: minutter)
+
+Kilder: auditlog-anomalier (fx mange session-miss = probing), driftsalarmer,
+CFCS-varsler, borgerhenvendelse, ansvarlig disclosure (SUPPORT.md).
+Første handling: opret hændelseslog med UTC-tidsstempler; alt efterfølgende
+noteres dér. Udpeg incident manager.
+
+### Fase 1 - Triage og klassifikation (mål: < 1 time)
+
+1. Klassificér SEV1-SEV4 (tabel ovenfor). Ved tvivl: vælg det højere niveau.
+2. Afgør: er persondata berørt (art. 33-spor)? Er driften væsentligt
+   forstyrret (NIS2-spor)? Begge kan være ja.
+3. SEV1/SEV2: ring (ikke mail) til kommunens
+   informationssikkerhedskoordinator og DPO. Start 24-timers-uret for
+   kontraktuel underretning: send den indledende skriftlige underretning
+   **så snart de kendte fakta er nedskrevet** - vent aldrig på fuld
+   afklaring.
+
+### Fase 2 - Inddæmning (parallelt med fase 1)
+
+Standardgreb i prioriteret rækkefølge, afhængigt af scenarie:
+
+- Kompromitteret nøgle/adgang: rotér CPR-krypteringsnøgler
+  (tenant-specifikke nøgler begrænser blastradius til én kommune), rotér
+  API-/OIDC-hemmeligheder, invalider alle MitID-sessioner (15-min-TTL gør
+  dette hurtigt selvudtømmende).
+- Aktivt misbrug af endpoint: blokér på reverse proxy (IP/mønster); sæt om
+  nødvendigt platformen i vedligeholdstilstand frem for at lade
+  eksfiltrering fortsætte.
+- Forkert udsendt Digital Post: stop køen, dokumentér berørte afsendelser
+  via afsendelsesloggen (hashet modtager gør omfangsbestemmelse mulig uden
+  ny eksponering).
+- Bevar bevismateriale: databasesnapshot og logeksport FØR oprydning;
+  auditloggens integritet er central for både CFCS- og
+  Datatilsynet-rapporten.
+
+### Fase 3 - Anmeldelse (kommunens spor, Leverandøren leverer udkast)
+
+Leverandøren leverer inden for fristerne udkast indeholdende:
+
+1. Hændelsens karakter og tidslinje (fra hændelsesloggen).
+2. Berørte kategorier og antal registrerede/datasæt (fra auditlog og
+   afsendelseslog; CPR-omfang opgøres uden at eksponere CPR - hashede
+   identifikatorer tælles).
+3. Sandsynlige konsekvenser for de registrerede.
+4. Trufne og planlagte foranstaltninger.
+5. NIS2-specifikt: formodet ondsindet/ikke-ondsindet, evt.
+   grænseoverskridende virkning, kompromitteringsindikatorer.
+
+### Fase 4 - Genopretning
+
+Gendan fra verificeret backup om nødvendigt; ved nøglerotation
+genkrypteres berørte CPR-felter; verificér med regressionstests
+(CprEncryptionPresaveTest m.fl.) før platformen åbnes igen. Kommunen
+godkender genåbning af borgerforløb.
+
+### Fase 5 - Efterspil (senest 2 uger efter lukning; NIS2-slutrapport senest 1 måned)
+
+- Post-mortem uden skyldsplacering; tidslinje, rodårsag, hvad der
+  detekterede/burde have detekteret.
+- Opdater `PROMISES-VS-VERIFIED.md` og DPIA-risikotabellen, hvis hændelsen
+  ændrer den verificerede tilstand.
+- Opret GitHub-issues for alle afledte forbedringer; sikkerhedsrettelser
+  markeres [SECURITY] i changelog (jf. issue #149).
+- Levér udkast til NIS2-slutrapport til kommunen.
+
+## 5. Øvelser og vedligehold
+
+- **Tabletop-øvelse** af scenarie SEV1 (nøglelæk) og SEV2 (forkert Digital
+  Post) sammen med kommunen: første gang før pilotstart, derefter årligt.
+- Runbook revideres ved hver ændring i kontaktkæde, underdatabehandlere
+  eller lovgivning, og mindst årligt.
+- Kendte åbne svagheder med hændelsesrelevans føres i DPIA'ens risikotabel
+  (p.t. #156 kapabilitet i URL, #142 rate limiting, #143 certifikatudløb) -
+  vagthavende skal kende dem, fordi de er de mest sandsynlige
+  SEV2-scenarier.

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,41 @@
+# Compliance pack (pre-sales / procurement)
+
+Documents a Danish municipality's IT and DPO function needs before a pilot can
+start (issue #92). A kommune cannot procure without a databehandleraftale and
+cannot lawfully process without an Article 30 record; the DPIA is required on
+its own because the platform processes custody data on children.
+
+The documents are in Danish because their audience is the kommune's DPO,
+jurist and informationssikkerhedskoordinator. They are drafts on the
+platform's honest current state (see `../PROMISES-VS-VERIFIED.md`): where a
+control is planned but not built, the document says so and references the
+GitHub issue.
+
+| Document | Purpose | Status |
+|---|---|---|
+| [DATABEHANDLERAFTALE.md](DATABEHANDLERAFTALE.md) | Data processing agreement following the structure of Datatilsynet's standardkontraktsbestemmelser (art. 28(3)), with bilag A-D filled in for AabenForms | Draft - parties, CVR and signatures to be completed per kommune |
+| [FORTEGNELSE_ART30.md](FORTEGNELSE_ART30.md) | Record of processing activities: art. 30(2) as databehandler, plus the kommune's art. 30(1) input per workflow | Draft - reusable across kommuner |
+| [DPIA_KONSEKVENSANALYSE.md](DPIA_KONSEKVENSANALYSE.md) | Data protection impact assessment (art. 35): CPR, children's and custody data, MitID identity, Digital Post | Draft - risk table reflects verified platform state |
+| [NIS2_INCIDENT_RUNBOOK.md](NIS2_INCIDENT_RUNBOOK.md) | Incident response runbook with the NIS2 and GDPR art. 33/34 notification deadlines | Draft - contact table to be completed per kommune |
+
+Out of scope here: tilgaengelighedserklaeringen (accessibility statement)
+depends on the frontend axe/WCAG audit landing first, tracked in
+madsnorgaard/aabenforms-frontend#25.
+
+## How to use in a procurement conversation
+
+1. Send the DPA draft and the Art. 30 record with the first technical
+   material; they answer the DPO's first two questions unprompted.
+2. The DPIA is a working document: the kommune is dataansvarlig and owns the
+   final DPIA, but arriving with a substantially complete draft moves the
+   conversation from "can you?" to "when do we start?".
+3. The NIS2 runbook doubles as the operational annex the kommune's
+   informationssikkerhedsudvalg will ask for.
+
+## Maintenance
+
+Keep these synchronized with reality. When a security issue closes (e.g. #91
+retention, #142 rate limiting), update the affected rows in the DPIA risk
+table and the security annex in the DPA. A compliance document that overstates
+the platform is worse than none - it is exactly what a municipal evaluator
+checks first.


### PR DESCRIPTION
Refs #92 (leaves it open: tilgaengelighedserklaeringen still depends on the frontend WCAG audit, aabenforms-frontend#25).

Delivers the four document drafts #92 lists as the procurement gate, in Danish for the kommune's DPO/jurist audience, under `docs/compliance/`:

| Doc | What it answers |
|---|---|
| `DATABEHANDLERAFTALE.md` | The DPO's first question. Datatilsynet standardkontraktsbestemmelser structure (art. 28(3)), bilag A-D filled in: data categories (incl. art. 9 health data in merudgifter/PPR flows), sub-processors (EU only), security annex matching what the code actually does |
| `FORTEGNELSE_ART30.md` | Art. 30(2) processor record + pre-filled art. 30(1) rows per workflow with hjemmel (folkeskoleloven § 36, barnets lov §§ 86/133-135, forvaltningsloven §§ 19-25, dbl. § 11) |
| `DPIA_KONSEKVENSANALYSE.md` | Art. 35(7) draft the kommune can finish instead of start. Risk table is grounded in `PROMISES-VS-VERIFIED.md` and names the open issues (#156, #142, #91, #73) as explicit residual risks with 'before pilot' targets - no overclaiming |
| `NIS2_INCIDENT_RUNBOOK.md` | NIS2 24h/72h/1-month deadlines and GDPR art. 33 72h side by side, SEV1-4 classification, role split (kommunen files, leverandøren drafts), containment playbook keyed to the platform's actual controls (tenant keys, 15-min session TTL, hashed send log) |

All honest-status: where a control is planned but not built, the document says so and links the issue. `docs/compliance/README.md` indexes the pack and sets the maintenance rule (update the DPIA rows when the referenced issues close).