### PR TITLE
Wizard hardening: AJAX race lockout, no silent webform preselect, honest step numbers

### DIFF
--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.libraries.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.libraries.yml
@@ -14,9 +14,12 @@ workflow_wizard:
   css:
     theme:
       css/workflow-wizard.css: {}
+  js:
+    js/workflow-wizard.js: {}
   dependencies:
     - core/drupal
     - core/jquery
+    - core/once
     - aabenforms_core/admin
 
 bpmn_editor:

--- a/web/modules/custom/aabenforms_workflows/js/workflow-wizard.js
+++ b/web/modules/custom/aabenforms_workflows/js/workflow-wizard.js
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Wizard interaction hardening.
+ *
+ * Clicking Back/Next/Create while a wizard AJAX request (e.g. the webform
+ * select rebuilding the field mappings) is still in flight posts a stale
+ * form_build_id. The cached form state that id resolves to no longer matches,
+ * so the wizard falls back to step 1 and every choice the admin made is lost
+ * (#196). Lock the navigation buttons for the duration of any AJAX request on
+ * the wizard page so that race cannot be entered.
+ */
+(function (Drupal, once, $) {
+  'use strict';
+
+  Drupal.behaviors.aabenformsWizardAjaxLock = {
+    attach(context) {
+      once('af-wizard-ajax-lock', 'form.workflow-wizard-form', context).forEach((form) => {
+        const setLocked = (locked) => {
+          form.querySelectorAll('[data-drupal-selector="edit-actions"] input[type="submit"]').forEach((button) => {
+            button.disabled = locked;
+            button.classList.toggle('is-disabled', locked);
+          });
+        };
+        $(document).on('ajaxSend.afWizardLock', () => setLocked(true));
+        $(document).on('ajaxComplete.afWizardLock ajaxStop.afWizardLock', () => setLocked(false));
+      });
+    },
+  };
+})(Drupal, once, jQuery);

--- a/web/modules/custom/aabenforms_workflows/src/Form/WorkflowTemplateWizardForm.php
+++ b/web/modules/custom/aabenforms_workflows/src/Form/WorkflowTemplateWizardForm.php
@@ -331,7 +331,7 @@ class WorkflowTemplateWizardForm extends FormBase {
     $template_id = $form_state->getValue('template_id');
 
     $form['step_title'] = [
-      '#markup' => '<h2>' . $this->t('Step 2: Configure Webform Integration') . '</h2>',
+      '#markup' => '<h2>' . $this->t('Step 3: Configure Webform Integration') . '</h2>',
     ];
 
     $form['help'] = [
@@ -351,6 +351,12 @@ class WorkflowTemplateWizardForm extends FormBase {
       '#description' => $this->t('Which webform should trigger this workflow?'),
       '#options' => $webform_options,
       '#required' => TRUE,
+      // An explicit empty default: without it the first webform
+      // (alphabetically) is silently preselected, and a flow can go live
+      // bound to the wrong form without the admin ever touching the field
+      // (#197 - three such flows were found on production).
+      '#empty_option' => $this->t('- Select webform -'),
+      '#empty_value' => '',
       '#default_value' => $form_state->getValue('webform_id'),
       '#ajax' => [
         'callback' => '::updateFieldMappings',
@@ -405,7 +411,7 @@ class WorkflowTemplateWizardForm extends FormBase {
     $template_id = $form_state->getValue('template_id');
 
     $form['step_title'] = [
-      '#markup' => '<h2>' . $this->t('Step 3: Configure Actions') . '</h2>',
+      '#markup' => '<h2>' . $this->t('Step 4: Configure Actions') . '</h2>',
     ];
 
     $form['help'] = [
@@ -443,10 +449,20 @@ class WorkflowTemplateWizardForm extends FormBase {
       ];
 
       foreach ($actions as $action_id => $action) {
+        // A collapsed details hiding a required field means the admin sees a
+        // near-empty step, clicks Next, and gets errors for fields that were
+        // never visible (#197). Open every action that requires input.
+        $has_required = FALSE;
+        foreach ($action['configurable_fields'] as $field) {
+          if (!empty($field['required'])) {
+            $has_required = TRUE;
+            break;
+          }
+        }
         $form['action_config'][$action_id] = [
           '#type' => 'details',
           '#title' => $action['name'],
-          '#open' => FALSE,
+          '#open' => $has_required,
         ];
 
         foreach ($action['configurable_fields'] as $field_id => $field) {
@@ -472,7 +488,7 @@ class WorkflowTemplateWizardForm extends FormBase {
     $template_id = $form_state->getValue('template_id');
 
     $form['step_title'] = [
-      '#markup' => '<h2>' . $this->t('Step 4: Data Visibility (Optional)') . '</h2>',
+      '#markup' => '<h2>' . $this->t('Step 5: Data Visibility (Optional)') . '</h2>',
     ];
 
     // Only show for templates with multi-party workflows.
@@ -514,7 +530,7 @@ class WorkflowTemplateWizardForm extends FormBase {
     $template = $templates[$template_id];
 
     $form['step_title'] = [
-      '#markup' => '<h2>' . $this->t('Step 5: Preview and Activate') . '</h2>',
+      '#markup' => '<h2>' . $this->t('Step 6: Preview and Activate') . '</h2>',
     ];
 
     $form['help'] = [


### PR DESCRIPTION
Fixes #196. Fixes #197.

## #196 - the progress-wiping race
Nav buttons are now disabled while any AJAX request on the wizard form is in flight (`js/workflow-wizard.js`, attached via the existing `workflow_wizard` library). The stale-`form_build_id` POST that dumped admins back to step 1 with all progress lost can no longer be produced.

## #197 - three UX defects
1. **Empty option on the webform select** (`- Select webform -`), required client- and server-side. This closes the path that silently bound three production wizard flows to the wrong webform (hr_onboarding and med_election_nomination to Contact Form, phone_declaration to Company Verification).
2. **Step headings renumbered** - positions 3-6 said Step 2-5 against a 6-stop progress bar; they now read Step 3-6.
3. **Action-config sections with required fields open by default** - Next can no longer fail on fields that were never visible.

## Verification (Playwright vs DDEV)
- Race scenario (change select, click Next immediately): lands on Step 4, no bounce, no error.
- Empty webform: blocked on step 3; with `novalidate` forced, server returns 'Select Webform field is required'.
- Full walk: headings 1-2-3-4-5-6, required fields all visible (4 visible, 0 hidden), flow created enabled. Test flow cleaned up afterwards.
- phpcs errors-only clean; workflows unit+kernel suites green (256 tests, 1139 assertions). No new phpstan findings.

Note: prod still carries the three misbound flows; cleanup is an ops task awaiting owner approval (tracked in #197 comments).