### PR TITLE
Flow overview: group ECA flows by citizen journey

### DIFF
--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.links.menu.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.links.menu.yml
@@ -11,3 +11,10 @@ aabenforms_workflows.template_select:
   route_name: aabenforms_workflows.template_select
   parent: system.admin_config_workflow
   weight: 11
+
+aabenforms_workflows.flow_overview:
+  title: 'Flow overview'
+  description: 'All ECA flows grouped by citizen journey'
+  route_name: aabenforms_workflows.flow_overview
+  parent: system.admin_config_workflow
+  weight: 9

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.routing.yml
@@ -142,3 +142,11 @@ aabenforms_workflows.wizard_generate_svg:
     _permission: 'administer workflows'
   options:
     _ajax_route: TRUE
+
+aabenforms_workflows.flow_overview:
+  path: '/admin/aabenforms/flows'
+  defaults:
+    _controller: '\Drupal\aabenforms_workflows\Controller\FlowOverviewController::overview'
+    _title: 'Flow overview'
+  requirements:
+    _permission: 'administer workflows'

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.services.yml
@@ -126,3 +126,9 @@ services:
     class: Drupal\aabenforms_workflows\Service\FlowGraphRenderer
     arguments:
       - '@aabenforms_workflows.eca_graph_builder'
+
+  aabenforms_workflows.flow_journey_grouper:
+    class: Drupal\aabenforms_workflows\Service\FlowJourneyGrouper
+    arguments:
+      - '@entity_type.manager'
+      - '@config.factory'

--- a/web/modules/custom/aabenforms_workflows/src/Controller/FlowOverviewController.php
+++ b/web/modules/custom/aabenforms_workflows/src/Controller/FlowOverviewController.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Drupal\aabenforms_workflows\Service\FlowJourneyGrouper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Journey-grouped overview of all ECA flows (#200).
+ *
+ * The raw model list at /admin/config/workflow/eca stays as the low-level
+ * admin view; this page shows the same flows grouped by the citizen journey
+ * they belong to, with trigger, source and status visible per row, so an
+ * operator can see which flows belong together and spot a flow bound to a
+ * webform outside its journey at a glance.
+ */
+class FlowOverviewController extends ControllerBase {
+
+  public function __construct(protected readonly FlowJourneyGrouper $grouper) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static($container->get('aabenforms_workflows.flow_journey_grouper'));
+  }
+
+  /**
+   * Renders the grouped overview.
+   *
+   * @return array<string, mixed>
+   *   A render array.
+   */
+  public function overview(): array {
+    $groups = $this->grouper->group();
+
+    $build = [
+      '#attached' => ['library' => ['aabenforms_workflows/workflow_wizard']],
+      'intro' => [
+        '#markup' => '<p>' . $this->t('Flows grouped by the journey they belong to. Stages run top to bottom: intake, event-driven steps, decision. The raw model list remains at <a href=":url">ECA models</a>.', [
+          ':url' => Url::fromRoute('entity.eca.collection')->toString(),
+        ]) . '</p>',
+      ],
+    ];
+
+    $total = 0;
+    $enabled = 0;
+    foreach ($groups['journeys'] as $journey) {
+      foreach ($journey['flows'] as $flow) {
+        $total++;
+        $enabled += $flow['enabled'] ? 1 : 0;
+      }
+    }
+    foreach (['events', 'scheduled', 'other'] as $bucket) {
+      foreach ($groups[$bucket] as $flow) {
+        $total++;
+        $enabled += $flow['enabled'] ? 1 : 0;
+      }
+    }
+    $build['summary'] = [
+      '#markup' => '<p><strong>' . $this->t('@enabled enabled of @total flows in @journeys journeys.', [
+        '@enabled' => $enabled,
+        '@total' => $total,
+        '@journeys' => count($groups['journeys']),
+      ]) . '</strong></p>',
+    ];
+
+    foreach ($groups['journeys'] as $webform_id => $journey) {
+      $build['journey_' . $webform_id] = $this->journeyDetails(
+        $this->t('@label (@count flows)', ['@label' => $journey['label'], '@count' => count($journey['flows'])]),
+        $journey['flows'],
+      );
+    }
+
+    $buckets = [
+      'events' => $this->t('Event-driven steps without a journey'),
+      'scheduled' => $this->t('Scheduled (cron)'),
+      'other' => $this->t('Other'),
+    ];
+    foreach ($buckets as $key => $label) {
+      if ($groups[$key]) {
+        $build['bucket_' . $key] = $this->journeyDetails(
+          $this->t('@label (@count)', ['@label' => $label, '@count' => count($groups[$key])]),
+          $groups[$key],
+        );
+      }
+    }
+
+    return $build;
+  }
+
+  /**
+   * Builds one journey group as an open details with a flow table.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|string $title
+   *   The group title.
+   * @param array<int, array<string, mixed>> $flows
+   *   Flow rows from the grouper.
+   *
+   * @return array<string, mixed>
+   *   A render array.
+   */
+  protected function journeyDetails($title, array $flows): array {
+    $rows = [];
+    foreach ($flows as $flow) {
+      $links = [
+        '#type' => 'dropbutton',
+        '#links' => [
+          'edit' => [
+            'title' => $this->t('Edit'),
+            'url' => Url::fromRoute('entity.eca.edit_form', ['eca' => $flow['id']]),
+          ],
+          'graph' => [
+            'title' => $this->t('Graph'),
+            'url' => Url::fromRoute('aabenforms_workflows.flow_graph', ['eca' => $flow['id']]),
+          ],
+        ],
+      ];
+      $rows[] = [
+        $flow['label'],
+        ['data' => ['#markup' => '<code>' . $flow['id'] . '</code>']],
+        implode(', ', $flow['triggers']),
+        $flow['wizard'] ? $this->t('Wizard') : $this->t('Hand-authored'),
+        $flow['enabled'] ? $this->t('Enabled') : $this->t('Disabled'),
+        ['data' => $links],
+      ];
+    }
+
+    return [
+      '#type' => 'details',
+      '#title' => $title,
+      '#open' => TRUE,
+      'table' => [
+        '#type' => 'table',
+        '#header' => [
+          $this->t('Flow'),
+          $this->t('Machine name'),
+          $this->t('Trigger'),
+          $this->t('Source'),
+          $this->t('Status'),
+          $this->t('Operations'),
+        ],
+        '#rows' => $rows,
+        '#empty' => $this->t('No flows.'),
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/src/Plugin/AabenformsDashboard/WorkflowsSection.php
+++ b/web/modules/custom/aabenforms_workflows/src/Plugin/AabenformsDashboard/WorkflowsSection.php
@@ -105,6 +105,16 @@ class WorkflowsSection extends AabenformsDashboardSectionBase {
   /**
    * {@inheritdoc}
    */
+  public function getSecondaryLink(): array {
+    return [
+      'label' => $this->t('Flow overview'),
+      'url' => Url::fromRoute('aabenforms_workflows.flow_overview'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheTags(): array {
     return ['config:eca_list', 'aabenforms_workflows:templates'];
   }

--- a/web/modules/custom/aabenforms_workflows/src/Service/FlowJourneyGrouper.php
+++ b/web/modules/custom/aabenforms_workflows/src/Service/FlowJourneyGrouper.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\aabenforms_workflows\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Groups ECA flows into citizen journeys for the flow overview (#200).
+ *
+ * The flat ECA model list hides that many flows are stages of one journey
+ * (intake -> co-sign -> decision). The grouping here is mechanical and
+ * derivable from config alone, in priority order:
+ *
+ * 1. A flow that listens to a webform (insert or update) belongs to that
+ *    webform's journey. Intake and decision stages of the same case meet
+ *    here, because they bind the same webform.
+ * 2. A flow that only listens to a custom event joins the journey whose
+ *    member flows share its first machine-name token (skoleskift_cosign_flow
+ *    joins the skoleskift journey). No match puts it in the event bucket.
+ * 3. Cron-only flows land in the scheduled bucket; anything else in other.
+ */
+class FlowJourneyGrouper {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+    protected readonly ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * Builds the grouped overview.
+   *
+   * @return array{journeys: array<string, array{label: string, flows: array<int, array<string, mixed>>}>, events: array<int, array<string, mixed>>, scheduled: array<int, array<string, mixed>>, other: array<int, array<string, mixed>>}
+   *   Journeys keyed by webform id plus the three fallback buckets. Each
+   *   flow row carries id, label, enabled, wizard, triggers (strings) and
+   *   a stage weight used for ordering inside a journey.
+   */
+  public function group(): array {
+    $wizard_ids = [];
+    foreach ($this->configFactory->listAll('aabenforms_workflows.template_instance.') as $name) {
+      $wizard_ids[substr($name, strlen('aabenforms_workflows.template_instance.'))] = TRUE;
+    }
+
+    $journeys = [];
+    $unbound = [];
+
+    $webform_storage = $this->entityTypeManager->getStorage('webform');
+    /** @var \Drupal\eca\Entity\Eca $eca */
+    foreach ($this->entityTypeManager->getStorage('eca')->loadMultiple() as $id => $eca) {
+      $row = [
+        'id' => $id,
+        'label' => (string) $eca->label(),
+        'enabled' => (bool) $eca->status(),
+        'wizard' => isset($wizard_ids[$id]),
+        'triggers' => [],
+        'stage' => 3,
+      ];
+      $webforms = [];
+      $has_custom = FALSE;
+      $has_cron = FALSE;
+
+      foreach ($eca->get('events') ?? [] as $event) {
+        $plugin = $event['plugin'] ?? '';
+        $config = $event['configuration'] ?? [];
+        $type = (string) ($config['type'] ?? '');
+        if (str_starts_with($type, 'webform_submission ')) {
+          $webform_id = substr($type, strlen('webform_submission '));
+          $webforms[$webform_id] = TRUE;
+          $op = str_ends_with($plugin, ':update') ? 'update' : 'submission';
+          $webform = $webform_storage->load($webform_id);
+          $row['triggers'][] = (string) ($op === 'update'
+            ? $this->t('On update (@webform)', ['@webform' => $webform ? $webform->label() : $webform_id])
+            : $this->t('On submission (@webform)', ['@webform' => $webform ? $webform->label() : $webform_id]));
+          $row['stage'] = min($row['stage'], $op === 'update' ? 2 : 0);
+        }
+        elseif (str_ends_with($plugin, ':custom')) {
+          $has_custom = TRUE;
+          $row['triggers'][] = (string) $this->t('Event: @event', ['@event' => $config['event_id'] ?? '?']);
+          $row['stage'] = min($row['stage'], 1);
+        }
+        elseif (str_contains($plugin, 'cron')) {
+          $has_cron = TRUE;
+          $row['triggers'][] = (string) $this->t('Cron: @frequency', ['@frequency' => $config['frequency'] ?? '?']);
+        }
+        else {
+          $row['triggers'][] = $plugin;
+        }
+      }
+
+      if ($webforms) {
+        foreach (array_keys($webforms) as $webform_id) {
+          if (!isset($journeys[$webform_id])) {
+            $webform = $webform_storage->load($webform_id);
+            $journeys[$webform_id] = [
+              'label' => (string) ($webform ? $webform->label() : $webform_id),
+              'flows' => [],
+            ];
+          }
+          $journeys[$webform_id]['flows'][] = $row;
+        }
+      }
+      else {
+        $row['kind'] = $has_custom ? 'events' : ($has_cron ? 'scheduled' : 'other');
+        $unbound[] = $row;
+      }
+    }
+
+    // Pass 2: an unbound custom-event flow joins the journey whose member
+    // flows share its first machine-name token.
+    $events = [];
+    $scheduled = [];
+    $other = [];
+    foreach ($unbound as $row) {
+      if ($row['kind'] === 'events') {
+        $token = explode('_', $row['id'])[0];
+        $joined = FALSE;
+        foreach ($journeys as $webform_id => $journey) {
+          foreach ($journey['flows'] as $member) {
+            if (explode('_', $member['id'])[0] === $token) {
+              $journeys[$webform_id]['flows'][] = $row;
+              $joined = TRUE;
+              break 2;
+            }
+          }
+        }
+        if (!$joined) {
+          $events[] = $row;
+        }
+      }
+      elseif ($row['kind'] === 'scheduled') {
+        $scheduled[] = $row;
+      }
+      else {
+        $other[] = $row;
+      }
+    }
+
+    // Stage order inside a journey: intake (insert) -> event-driven steps
+    // -> decision (update); stable by id within a stage.
+    foreach ($journeys as &$journey) {
+      usort($journey['flows'], static fn (array $a, array $b) => [$a['stage'], $a['id']] <=> [$b['stage'], $b['id']]);
+    }
+    unset($journey);
+    uasort($journeys, static fn (array $a, array $b) => strcasecmp($a['label'], $b['label']));
+
+    return [
+      'journeys' => $journeys,
+      'events' => $events,
+      'scheduled' => $scheduled,
+      'other' => $other,
+    ];
+  }
+
+}

--- a/web/modules/custom/aabenforms_workflows/tests/src/Kernel/FlowJourneyGrouperTest.php
+++ b/web/modules/custom/aabenforms_workflows/tests/src/Kernel/FlowJourneyGrouperTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\aabenforms_workflows\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\eca\Entity\Eca;
+use Drupal\webform\Entity\Webform;
+
+/**
+ * Tests the journey grouping behind the flow overview (#200).
+ *
+ * @group aabenforms_workflows
+ */
+class FlowJourneyGrouperTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'key',
+    'encrypt',
+    'domain',
+    'webform',
+    'modeler_api',
+    'eca',
+    'eca_base',
+    'eca_content',
+    'aabenforms_core',
+    'aabenforms_mitid',
+    'aabenforms_workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('webform', ['webform']);
+    Webform::create(['id' => 'school_transfer', 'title' => 'Ansøgning om skoleskift'])->save();
+    Webform::create(['id' => 'contact', 'title' => 'Contact Form'])->save();
+  }
+
+  /**
+   * Creates a bare ECA flow with the given events.
+   *
+   * @param string $id
+   *   The flow id.
+   * @param array<string, array<string, mixed>> $events
+   *   Events keyed by machine name: ['plugin' => ..., 'configuration' => [...]].
+   * @param bool $status
+   *   Enabled state.
+   */
+  private function createFlow(string $id, array $events, bool $status = TRUE): void {
+    foreach ($events as &$event) {
+      $event += ['successors' => []];
+    }
+    unset($event);
+    Eca::create([
+      'id' => $id,
+      'label' => $id,
+      'status' => $status,
+      'modeler' => 'fallback',
+      'version' => '1.0.0',
+      'events' => $events,
+      'conditions' => [],
+      'gateways' => [],
+      'actions' => [],
+    ])->save();
+  }
+
+  /**
+   * Journeys form around webforms; stages order intake, event, decision.
+   */
+  public function testGrouping(): void {
+    // The skoleskift shape: intake (insert), decision (update), and a
+    // co-sign stage that only listens to a custom event but shares the
+    // machine-name token.
+    $this->createFlow('skoleskift_flow', [
+      'e1' => ['plugin' => 'content_entity:insert', 'configuration' => ['type' => 'webform_submission school_transfer']],
+    ]);
+    $this->createFlow('skoleskift_decision_flow', [
+      'e1' => ['plugin' => 'content_entity:update', 'configuration' => ['type' => 'webform_submission school_transfer']],
+    ]);
+    $this->createFlow('skoleskift_cosign_flow', [
+      'e1' => ['plugin' => 'content_entity:custom', 'configuration' => ['event_id' => 'parent2_approved']],
+    ]);
+    // A custom-event flow sharing no token with any journey.
+    $this->createFlow('parent1_approval_flow', [
+      'e1' => ['plugin' => 'content_entity:custom', 'configuration' => ['event_id' => 'parent1_approved']],
+    ]);
+    // A cron-only flow and a disabled webform-bound flow.
+    $this->createFlow('nightly_tabulation', [
+      'e1' => ['plugin' => 'eca_base:eca_cron', 'configuration' => ['frequency' => '+1 day']],
+    ]);
+    $this->createFlow('contact_flow', [
+      'e1' => ['plugin' => 'content_entity:insert', 'configuration' => ['type' => 'webform_submission contact']],
+    ], FALSE);
+
+    $groups = $this->container->get('aabenforms_workflows.flow_journey_grouper')->group();
+
+    // Two journeys, one per bound webform.
+    $this->assertSame(['Ansøgning om skoleskift', 'Contact Form'],
+      array_map(static fn (array $j) => $j['label'], array_values($groups['journeys'])));
+
+    // The skoleskift journey holds all three stages in intake -> event ->
+    // decision order, including the custom-event co-sign joined by token.
+    $skoleskift = array_map(static fn (array $f) => $f['id'], $groups['journeys']['school_transfer']['flows']);
+    $this->assertSame(['skoleskift_flow', 'skoleskift_cosign_flow', 'skoleskift_decision_flow'], $skoleskift);
+
+    // The unmatched custom-event flow lands in the events bucket.
+    $this->assertSame(['parent1_approval_flow'], array_map(static fn (array $f) => $f['id'], $groups['events']));
+    // Cron-only flows land in scheduled.
+    $this->assertSame(['nightly_tabulation'], array_map(static fn (array $f) => $f['id'], $groups['scheduled']));
+
+    // Status and triggers survive into the rows.
+    $contact = $groups['journeys']['contact']['flows'][0];
+    $this->assertFalse($contact['enabled']);
+    $this->assertSame('On submission (Contact Form)', $contact['triggers'][0]);
+    $this->assertFalse($contact['wizard']);
+  }
+
+  /**
+   * Wizard-built flows are flagged from their template_instance config.
+   */
+  public function testWizardSourceFlag(): void {
+    $this->createFlow('contact_form_123', [
+      'e1' => ['plugin' => 'content_entity:insert', 'configuration' => ['type' => 'webform_submission contact']],
+    ]);
+    $this->container->get('config.factory')->getEditable('aabenforms_workflows.template_instance.contact_form_123')
+      ->set('label', 'Wizard built')->save();
+
+    $groups = $this->container->get('aabenforms_workflows.flow_journey_grouper')->group();
+    $this->assertTrue($groups['journeys']['contact']['flows'][0]['wizard']);
+  }
+
+}


### PR DESCRIPTION
Fixes #200.

New `/admin/aabenforms/flows` page. On the local dataset: **30 enabled of 32 flows in 23 journeys** - skoleskift's three stages (intake insert -> co-sign custom event -> decision update) sit under one heading, likewise the guardian-consent trio and the parent-approval family.

- `FlowJourneyGrouper` service: journeys keyed by bound webform; custom-event flows join by first machine-name token; event/cron/other buckets for the rest. Pure config derivation, no new storage.
- Rows carry trigger summary, source (Wizard vs Hand-authored via template_instance configs), status, and edit/graph operations. Misbindings like #197's become visually obvious - the flow sits in the wrong journey group.
- Linked from the dashboard Workflows card (secondary link) and the admin menu under Configuration > Workflow. The raw eca_ui list is untouched and cross-linked.
- Kernel test: grouping, stage ordering, token join, buckets, wizard flag (2 tests, 14 assertions). Workflows suites green (258 tests). phpcs errors-only + phpstan level 6 clean on new files.

Screenshot of the page rendering the real local flows is in the session artifacts; v1 deliberately skips 'last fired' columns (#90) and health checks (#144) per the issue.