### PR TITLE
i18n foundation: Danish admin via locale + da language + module po files

### DIFF
--- a/config/sync/aabenforms_core.settings.yml
+++ b/config/sync/aabenforms_core.settings.yml
@@ -1,6 +1,8 @@
 _core:
   default_config_hash: 91eddBLmEzocTHYCBUQFuMc4UrlvzjYYg6a0I4Ke4no
 serviceplatformen:
+  username: ''
+  password: ''
   urls:
     SF1520: 'https://exttest.serviceplatformen.dk/service/CPR/CPRBasicInformation/1'
     SF1530: 'https://exttest.serviceplatformen.dk/service/CVR/CVROnline/1'
@@ -13,8 +15,6 @@ serviceplatformen:
   cache:
     enabled: true
     default_expiration: 900
-  username: ''
-  password: ''
 encryption:
   default_profile: aabenforms_aes256
 audit:

--- a/config/sync/aabenforms_esdh.settings.yml
+++ b/config/sync/aabenforms_esdh.settings.yml
@@ -1,9 +1,6 @@
 active_connector: demo
-# SBSYS (SBSIP REST) live transport - all empty until an operator enrolls.
-# The client secret is held in a drupal:key entry named by sbsys_client_secret_key,
-# never in config/sync. sbsys_templates maps a case type to its SBSIP template id.
 sbsys_base_url: ''
 sbsys_token_url: ''
 sbsys_client_id: ''
 sbsys_client_secret_key: ''
-sbsys_templates: {}
+sbsys_templates: {  }

--- a/config/sync/aabenforms_mitid.settings.yml
+++ b/config/sync/aabenforms_mitid.settings.yml
@@ -14,12 +14,9 @@ token_endpoint: 'http://keycloak:8080/realms/danish-gov-test/protocol/openid-con
 userinfo_endpoint: 'http://keycloak:8080/realms/danish-gov-test/protocol/openid-connect/userinfo'
 redirect_uri: 'https://aabenforms.ddev.site/mitid/callback'
 issuer: 'http://keycloak:8080/realms/danish-gov-test'
-accepted_issuers:
-  # The containerised Keycloak issues tokens with the browser-facing host
-  # (localhost:8080) while the backend reaches it - and fetches JWKS - via the
-  # internal host (keycloak:8080, the `issuer` above). Both are the same realm.
-  - 'http://localhost:8080/realms/danish-gov-test'
 scopes:
   - openid
   - ssn
 pkce_enabled: true
+accepted_issuers:
+  - 'http://localhost:8080/realms/danish-gov-test'

--- a/config/sync/aabenforms_nemlogin.settings.yml
+++ b/config/sync/aabenforms_nemlogin.settings.yml
@@ -1,24 +1,12 @@
-# NemLog-in OIOSAML 3 Service Provider settings.
-#
-# Certificates and keys are NOT stored here: sp_cert_key / sp_private_key_key
-# name entries in the `key` module (drupal:key), so the OCES3 material stays out
-# of config/sync. Live activation is gated on an SP registration + metadata
-# exchange in NemLog-in integrationstest (ops), so all endpoints default empty.
 enabled: false
 strict: true
-# The SP entityId - must equal the value registered in NemLog-in and is the
-# audience the returned assertion is restricted to.
 sp_entity_id: ''
-# Absolute SP endpoint URLs (built from the site by default via the controller).
 acs_url: ''
 slo_url: ''
-# NemLog-in IdP metadata, filled in after the integrationstest exchange.
 idp_entity_id: 'https://saml.nemlog-in.dk'
 idp_sso_url: ''
 idp_slo_url: ''
 idp_cert: ''
-# `key` module entry names holding the SP OCES3 keypair (PEM).
 sp_cert_key: ''
 sp_private_key_key: ''
-# Minimum NSIS assurance the SP requests and re-verifies (low|substantial|high).
-required_assurance_level: 'substantial'
+required_assurance_level: substantial

--- a/config/sync/aabenforms_workflows.settings.yml
+++ b/config/sync/aabenforms_workflows.settings.yml
@@ -1,12 +1,6 @@
 require_parent_cpr_match: true
-# Webform ids whose parent approvals additionally require REGISTERED custody
-# of the child (CPR registry check via the family lookup).
 custody_gated_forms:
   - school_transfer
   - ppr_referral
   - guardian_consent
-# MitID demo mode lets a workflow run without a real session. It must ship OFF:
-# with it on, an identity gate cannot be relied on. Exported here (default FALSE)
-# so a `drush cim` cannot silently change it. Even when ON, MitIdValidateAction
-# records a non-verified status that gates never treat as verified.
 allow_mitid_demo_mode: false

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -39,6 +39,8 @@ module:
   jsonapi_frontend: 0
   jsonapi_frontend_webform: 0
   key: 0
+  language: 0
+  locale: 0
   modeler: 0
   modeler_api: 0
   mysql: 0

--- a/config/sync/language.entity.da.yml
+++ b/config/sync/language.entity.da.yml
@@ -1,0 +1,9 @@
+uuid: 015c8035-e0a6-436b-97ff-e30eb392bf96
+langcode: en
+status: true
+dependencies: {  }
+id: da
+label: Danish
+direction: ltr
+weight: 0
+locked: false

--- a/config/sync/language.entity.en.yml
+++ b/config/sync/language.entity.en.yml
@@ -1,0 +1,11 @@
+uuid: 0273fa79-5d43-4995-9bef-25cf45a10079
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: lBXDpdDPXQtrfTJQhr6MjRJJEEyYSoRJ0acdvHLsWeA
+id: en
+label: English
+direction: ltr
+weight: 0
+locked: false

--- a/config/sync/language.entity.und.yml
+++ b/config/sync/language.entity.und.yml
@@ -1,0 +1,11 @@
+uuid: 94de4f63-81fc-48bf-8f4c-a3af465e8847
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: eNX6lLCKDaY83nCMh20My---y03KbiFlv802DKCCpvg
+id: und
+label: 'Not specified'
+direction: ltr
+weight: 2
+locked: true

--- a/config/sync/language.entity.zxx.yml
+++ b/config/sync/language.entity.zxx.yml
@@ -1,0 +1,11 @@
+uuid: 66f75127-5dfc-48a2-8a63-988f59b56df8
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 35CefWbnzaiytcg3acexxz_GTvuwIjYd_ZTcmmR-tXA
+id: zxx
+label: 'Not applicable'
+direction: ltr
+weight: 3
+locked: true

--- a/config/sync/language.mappings.yml
+++ b/config/sync/language.mappings.yml
@@ -1,0 +1,13 @@
+_core:
+  default_config_hash: EMWe7Yu4Q5eD-NUfNuQAWGBvYUNZPIinztEtONSmsDc
+map:
+  'no': nb
+  pt: pt-pt
+  zh: zh-hans
+  zh-tw: zh-hant
+  zh-hk: zh-hant
+  zh-mo: zh-hant
+  zh-cht: zh-hant
+  zh-cn: zh-hans
+  zh-sg: zh-hans
+  zh-chs: zh-hans

--- a/config/sync/language.negotiation.yml
+++ b/config/sync/language.negotiation.yml
@@ -1,0 +1,13 @@
+_core:
+  default_config_hash: uEePITI9tV6WqzmsTb7MfPCi5yPWXSxAN1xeLcYFQbM
+session:
+  parameter: language
+url:
+  source: path_prefix
+  prefixes:
+    en: ''
+    da: da
+  domains:
+    en: ''
+    da: ''
+selected_langcode: site_default

--- a/config/sync/language.types.yml
+++ b/config/sync/language.types.yml
@@ -1,0 +1,20 @@
+_core:
+  default_config_hash: dqouFqVseNJNvEjsoYKxbinFOITuCxYhi4y2OTNQP_8
+all:
+  - language_interface
+  - language_content
+  - language_url
+configurable:
+  - language_interface
+negotiation:
+  language_content:
+    enabled:
+      language-interface: 0
+  language_url:
+    enabled:
+      language-url: 0
+      language-url-fallback: 1
+  language_interface:
+    enabled:
+      language-user-admin: -20
+      language-url: 0

--- a/config/sync/language/da/block.block.claro_breadcrumbs.yml
+++ b/config/sync/language/da/block.block.claro_breadcrumbs.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Brødkrummer

--- a/config/sync/language/da/block.block.claro_content.yml
+++ b/config/sync/language/da/block.block.claro_content.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Primært sideindhold'

--- a/config/sync/language/da/block.block.claro_local_actions.yml
+++ b/config/sync/language/da/block.block.claro_local_actions.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Primære administratorhandlinger'

--- a/config/sync/language/da/block.block.claro_messages.yml
+++ b/config/sync/language/da/block.block.claro_messages.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Statusmeddelelser

--- a/config/sync/language/da/block.block.claro_page_title.yml
+++ b/config/sync/language/da/block.block.claro_page_title.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Sidetitel

--- a/config/sync/language/da/block.block.claro_primary_local_tasks.yml
+++ b/config/sync/language/da/block.block.claro_primary_local_tasks.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Primære faneblade'

--- a/config/sync/language/da/block.block.claro_secondary_local_tasks.yml
+++ b/config/sync/language/da/block.block.claro_secondary_local_tasks.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Sekundære faneblade'

--- a/config/sync/language/da/block.block.gin_breadcrumbs.yml
+++ b/config/sync/language/da/block.block.gin_breadcrumbs.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Brødkrummer

--- a/config/sync/language/da/block.block.gin_content.yml
+++ b/config/sync/language/da/block.block.gin_content.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Primært sideindhold'

--- a/config/sync/language/da/block.block.gin_local_actions.yml
+++ b/config/sync/language/da/block.block.gin_local_actions.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Primære administratorhandlinger'

--- a/config/sync/language/da/block.block.gin_messages.yml
+++ b/config/sync/language/da/block.block.gin_messages.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Statusmeddelelser

--- a/config/sync/language/da/block.block.gin_page_title.yml
+++ b/config/sync/language/da/block.block.gin_page_title.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Sidetitel

--- a/config/sync/language/da/block.block.gin_primary_local_tasks.yml
+++ b/config/sync/language/da/block.block.gin_primary_local_tasks.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Primære faneblade'

--- a/config/sync/language/da/block.block.gin_secondary_local_tasks.yml
+++ b/config/sync/language/da/block.block.gin_secondary_local_tasks.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Sekundære faneblade'

--- a/config/sync/language/da/core.date_format.fallback.yml
+++ b/config/sync/language/da/core.date_format.fallback.yml
@@ -1,0 +1,1 @@
+label: Reservedatoformat

--- a/config/sync/language/da/core.date_format.html_date.yml
+++ b/config/sync/language/da/core.date_format.html_date.yml
@@ -1,0 +1,1 @@
+label: 'HTML Date'

--- a/config/sync/language/da/core.date_format.html_datetime.yml
+++ b/config/sync/language/da/core.date_format.html_datetime.yml
@@ -1,0 +1,1 @@
+label: 'HTML Datetime'

--- a/config/sync/language/da/core.date_format.html_month.yml
+++ b/config/sync/language/da/core.date_format.html_month.yml
@@ -1,0 +1,1 @@
+label: 'HTML Month'

--- a/config/sync/language/da/core.date_format.html_time.yml
+++ b/config/sync/language/da/core.date_format.html_time.yml
@@ -1,0 +1,1 @@
+label: 'HTML Time'

--- a/config/sync/language/da/core.date_format.html_week.yml
+++ b/config/sync/language/da/core.date_format.html_week.yml
@@ -1,0 +1,1 @@
+label: 'HTML Week'

--- a/config/sync/language/da/core.date_format.html_year.yml
+++ b/config/sync/language/da/core.date_format.html_year.yml
@@ -1,0 +1,1 @@
+label: 'HTML Year'

--- a/config/sync/language/da/core.date_format.html_yearless_date.yml
+++ b/config/sync/language/da/core.date_format.html_yearless_date.yml
@@ -1,0 +1,1 @@
+label: 'HTML Yearless date'

--- a/config/sync/language/da/core.date_format.long.yml
+++ b/config/sync/language/da/core.date_format.long.yml
@@ -1,0 +1,1 @@
+label: 'Standard lang dato'

--- a/config/sync/language/da/core.date_format.medium.yml
+++ b/config/sync/language/da/core.date_format.medium.yml
@@ -1,0 +1,1 @@
+label: 'Standard mellem dato'

--- a/config/sync/language/da/core.date_format.short.yml
+++ b/config/sync/language/da/core.date_format.short.yml
@@ -1,0 +1,1 @@
+label: 'Standard kort dato'

--- a/config/sync/language/da/core.entity_form_mode.user.register.yml
+++ b/config/sync/language/da/core.entity_form_mode.user.register.yml
@@ -1,0 +1,1 @@
+label: 'Opret konto'

--- a/config/sync/language/da/core.entity_view_mode.node.full.yml
+++ b/config/sync/language/da/core.entity_view_mode.node.full.yml
@@ -1,0 +1,1 @@
+label: 'Fuldt indhold'

--- a/config/sync/language/da/core.entity_view_mode.node.rss.yml
+++ b/config/sync/language/da/core.entity_view_mode.node.rss.yml
@@ -1,0 +1,1 @@
+label: RSS

--- a/config/sync/language/da/core.entity_view_mode.node.search_index.yml
+++ b/config/sync/language/da/core.entity_view_mode.node.search_index.yml
@@ -1,0 +1,1 @@
+label: Søgeindex

--- a/config/sync/language/da/core.entity_view_mode.node.search_result.yml
+++ b/config/sync/language/da/core.entity_view_mode.node.search_result.yml
@@ -1,0 +1,1 @@
+label: 'Søgeresultat med fremhævelse af input'

--- a/config/sync/language/da/core.entity_view_mode.node.teaser.yml
+++ b/config/sync/language/da/core.entity_view_mode.node.teaser.yml
@@ -1,0 +1,1 @@
+label: Smagsprøve

--- a/config/sync/language/da/core.entity_view_mode.user.compact.yml
+++ b/config/sync/language/da/core.entity_view_mode.user.compact.yml
@@ -1,0 +1,1 @@
+label: Kompakt

--- a/config/sync/language/da/core.entity_view_mode.user.full.yml
+++ b/config/sync/language/da/core.entity_view_mode.user.full.yml
@@ -1,0 +1,1 @@
+label: Brugerkonto

--- a/config/sync/language/da/filter.format.plain_text.yml
+++ b/config/sync/language/da/filter.format.plain_text.yml
@@ -1,0 +1,1 @@
+name: 'Ren tekst'

--- a/config/sync/language/da/language.entity.da.yml
+++ b/config/sync/language/da/language.entity.da.yml
@@ -1,0 +1,1 @@
+label: Dansk

--- a/config/sync/language/da/language.entity.en.yml
+++ b/config/sync/language/da/language.entity.en.yml
@@ -1,0 +1,1 @@
+label: Engelsk

--- a/config/sync/language/da/language.entity.und.yml
+++ b/config/sync/language/da/language.entity.und.yml
@@ -1,0 +1,1 @@
+label: 'Ikke angivet'

--- a/config/sync/language/da/language.entity.zxx.yml
+++ b/config/sync/language/da/language.entity.zxx.yml
@@ -1,0 +1,1 @@
+label: 'Ikke relevant'

--- a/config/sync/language/da/system.action.node_delete_action.yml
+++ b/config/sync/language/da/system.action.node_delete_action.yml
@@ -1,0 +1,1 @@
+label: 'Slet indhold'

--- a/config/sync/language/da/system.action.node_make_sticky_action.yml
+++ b/config/sync/language/da/system.action.node_make_sticky_action.yml
@@ -1,0 +1,1 @@
+label: 'Gør indhold klæbrigt'

--- a/config/sync/language/da/system.action.node_make_unsticky_action.yml
+++ b/config/sync/language/da/system.action.node_make_unsticky_action.yml
@@ -1,0 +1,1 @@
+label: 'Fjern klæbrighed'

--- a/config/sync/language/da/system.action.node_promote_action.yml
+++ b/config/sync/language/da/system.action.node_promote_action.yml
@@ -1,0 +1,1 @@
+label: 'Vis indhold på forsiden'

--- a/config/sync/language/da/system.action.node_publish_action.yml
+++ b/config/sync/language/da/system.action.node_publish_action.yml
@@ -1,0 +1,1 @@
+label: 'Udgiv indhold'

--- a/config/sync/language/da/system.action.node_save_action.yml
+++ b/config/sync/language/da/system.action.node_save_action.yml
@@ -1,0 +1,1 @@
+label: 'Gem indhold'

--- a/config/sync/language/da/system.action.node_unpromote_action.yml
+++ b/config/sync/language/da/system.action.node_unpromote_action.yml
@@ -1,0 +1,1 @@
+label: 'Fjern indhold fra forsiden'

--- a/config/sync/language/da/system.action.node_unpublish_action.yml
+++ b/config/sync/language/da/system.action.node_unpublish_action.yml
@@ -1,0 +1,1 @@
+label: 'Afpublicér indhold'

--- a/config/sync/language/da/system.action.user_block_user_action.yml
+++ b/config/sync/language/da/system.action.user_block_user_action.yml
@@ -1,0 +1,1 @@
+label: 'Blokér de(n) valgte bruger(e)'

--- a/config/sync/language/da/system.action.user_cancel_user_action.yml
+++ b/config/sync/language/da/system.action.user_cancel_user_action.yml
@@ -1,0 +1,1 @@
+label: 'Opsig de valgte brugerkonti'

--- a/config/sync/language/da/system.action.user_unblock_user_action.yml
+++ b/config/sync/language/da/system.action.user_unblock_user_action.yml
@@ -1,0 +1,1 @@
+label: 'Fjern blokering af de(n) valgte bruger(e)'

--- a/config/sync/language/da/system.maintenance.yml
+++ b/config/sync/language/da/system.maintenance.yml
@@ -1,0 +1,1 @@
+message: 'Vi er ved at opdatere @site. Vi er snart tilbage. Tak for din tålmodighed.'

--- a/config/sync/language/da/system.menu.account.yml
+++ b/config/sync/language/da/system.menu.account.yml
@@ -1,0 +1,2 @@
+label: Brugerkontomenu
+description: 'Links relateret til den aktive brugerkonto'

--- a/config/sync/language/da/system.menu.admin.yml
+++ b/config/sync/language/da/system.menu.admin.yml
@@ -1,0 +1,2 @@
+label: Administration
+description: 'Links til administrative opgaver'

--- a/config/sync/language/da/system.menu.footer.yml
+++ b/config/sync/language/da/system.menu.footer.yml
@@ -1,0 +1,2 @@
+label: Sidefod
+description: 'Links til informationen om sitet'

--- a/config/sync/language/da/system.menu.main.yml
+++ b/config/sync/language/da/system.menu.main.yml
@@ -1,0 +1,2 @@
+label: 'Primær navigation'
+description: 'Links til sitets sektioner'

--- a/config/sync/language/da/system.menu.tools.yml
+++ b/config/sync/language/da/system.menu.tools.yml
@@ -1,0 +1,2 @@
+label: Værktøjer
+description: 'Bruger værktøjslinks, som typisk tilføjes af moduler'

--- a/config/sync/language/da/user.mail.yml
+++ b/config/sync/language/da/user.mail.yml
@@ -1,0 +1,78 @@
+cancel_confirm:
+  subject: 'Anmodning om opsigelse af konto for [user:display-name] på [site:name]'
+password_reset:
+  subject: 'Ny login-information for [user:display-name] på [site:name]'
+  body: |-
+    [user:display-name],
+
+    Der er lavet en forespørgsel om at nulstille adgangskoden til din konto på [site:name].
+
+    Du kan logge ind nu ved at klikke på linket eller ved at kopiere og indsætte det i din browser:
+
+    [user:one-time-login-url]
+
+    Dette link kan kun bruges til at logge ind én gang, og det sender dig til en side hvor du kan vælge en adgangskode. Linket udløber efter én dag og der sker ikke noget hvis det ikke bruges.
+
+    -- Holdet bag [site:name]
+register_admin_created:
+  subject: 'En administrator har oprettet en konto til dig på [site:name]'
+  body: |-
+    [user:display-name],
+
+    En administrator på [site:name] har oprettet en konto til dig. Du kan logge ind ved at klikke på linket eller ved at kopiere og indsætte det i din browser:
+
+    [user:one-time-login-url]
+
+    Dette link kan kun bruges til at logge ind, og det sender dig til en side hvor du kan vælge en adgangskode.
+
+    Når du har valgt en adgangskode kan du logge ind på [site:login-url] med:
+
+    Brugernavn: [user:name]
+    Adgangskode: Din adgangskode
+
+    --  Holdet bag [site:name]
+register_no_approval_required:
+  subject: 'Kontoinformationer for [user:display-name] på [site:name] (blokeret)'
+  body: |-
+    [user:display-name],
+
+    Tak fordi du har oprettet dig som bruger på [site:name]. Du kan nu logge ind ved at klikke på linket eller ved at kopiere og indsætte det i din browser:
+
+    [user:one-time-login-url]
+
+    Dette link kan kun bruges til at logge ind, og det sender dig til en side hvor du kan vælge en adgangskode.
+
+    Når du har valgt en adgangskode kan du logge ind på [site:login-url] med:
+
+    Brugernavn: [user:name]
+    Adgangskode: Din adgangskode
+
+    --  Holdet bag [site:name]
+register_pending_approval:
+  subject: 'Kontoinformation for [user:display-name] på [site:name] (afventer godkendelse af administrator)'
+  body: |-
+    [bruger:vist navn],
+
+    Tak for din tilmelding på [site:name]. Din ansøgning om en konto afventer i øjeblikket godkendelse. Når den er godkendt, modtager du en anden e-mail med oplysninger om, hvordan du logger ind, angiver din adgangskode og andre detaljer.
+
+    -- [site:name] holdet
+register_pending_approval_admin:
+  subject: 'Kontoinformation for [user:display-name] på [site:name] (afventer godkendelse af administrator)'
+  body: |-
+    [user:display-name] har anmodet om en konto.
+
+    [user:edit-url]
+status_activated:
+  subject: 'Kontoinformationer for [user:display-name] på [site:name] (godkendt)'
+  body: "[user:display-name],\r\n\r\nDin konto på [site:name] er blevet aktiveret.\r\n\r\nDu kan logge ind ved at klikke på følgende link eller ved at kopiere og indsætte det i din browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nLinket kan kun bruges én gang, og det fører dig til en side, hvor du kan vælge din adgangskode.\r\n\r\nNår du har valgt en adgangskode kan du fremover logge ind på [site:login-url] med:\r\n\r\nBrugernavn: [user:account-name]\r\nAdgangskode: Din adgangskode\r\n\r\n--  Holdet bag [site:name]"
+status_blocked:
+  subject: 'Kontoinformationer for [user:display-name] på [site:name] (blokeret)'
+  body: "[user:display-name],\r\n\r\nDin konto på [site:name] er blevet blokeret.\r\n\r\n--  [site:name] team"
+status_canceled:
+  subject: 'Kontoinformationer for [user:display-name] på [site:name] (opsagt)'
+  body: |-
+    [user:display-name],
+
+    Din konto på [site:name] er blevet lukket.
+
+    --  [site:name] holdet

--- a/config/sync/language/da/user.role.anonymous.yml
+++ b/config/sync/language/da/user.role.anonymous.yml
@@ -1,0 +1,1 @@
+label: 'Anonym bruger'

--- a/config/sync/language/da/user.role.authenticated.yml
+++ b/config/sync/language/da/user.role.authenticated.yml
@@ -1,0 +1,1 @@
+label: 'Godkendt bruger'

--- a/config/sync/language/da/user.settings.yml
+++ b/config/sync/language/da/user.settings.yml
@@ -1,0 +1,1 @@
+anonymous: Anonym

--- a/config/sync/language/da/views.view.archive.yml
+++ b/config/sync/language/da/views.view.archive.yml
@@ -1,0 +1,25 @@
+label: Arkiv
+display:
+  default:
+    display_title: Standard
+    display_options:
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+  block_1:
+    display_title: Blok
+  page_1:
+    display_title: Side

--- a/config/sync/language/da/views.view.authmap.yml
+++ b/config/sync/language/da/views.view.authmap.yml
@@ -1,0 +1,34 @@
+display:
+  default:
+    display_options:
+      fields:
+        name:
+          separator: ', '
+        delete_link:
+          label: slet
+          text: slet
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      arguments:
+        provider_field:
+          exception:
+            title: Alle
+  page:
+    display_title: Side
+    display_options:
+      menu:
+        title: Eksterne

--- a/config/sync/language/da/views.view.content.yml
+++ b/config/sync/language/da/views.view.content.yml
@@ -1,0 +1,68 @@
+label: Indhold
+description: 'Find og håndtér indhold.'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      title: Indhold
+      fields:
+        title:
+          label: Titel
+        type:
+          label: Indholdstype
+          separator: ', '
+        name:
+          label: Forfatter
+        status:
+          label: Status
+          settings:
+            format_custom_false: 'Ikke udgivet'
+            format_custom_true: Offentliggjort
+        changed:
+          label: Opdateret
+        langcode:
+          label: Sprog
+          separator: ', '
+        operations:
+          label: Handlinger
+      pager:
+        options:
+          tags:
+            next: 'Næste ›'
+            previous: '‹ Forrige'
+            first: '« Første'
+            last: 'Sidste »'
+      exposed_form:
+        options:
+          submit_button: Filter
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      filters:
+        title:
+          expose:
+            label: Titel
+        type:
+          expose:
+            label: Indholdstype
+        status:
+          expose:
+            label: Status
+          group_info:
+            label: Publiceringsstatus
+            group_items:
+              1:
+                title: Offentliggjort
+              2:
+                title: 'Ikke udgivet'
+        langcode:
+          expose:
+            label: Sprog
+  page_1:
+    display_title: Side
+    display_options:
+      menu:
+        title: Indhold
+      tab_options:
+        title: Indhold

--- a/config/sync/language/da/views.view.content_recent.yml
+++ b/config/sync/language/da/views.view.content_recent.yml
@@ -1,0 +1,17 @@
+display:
+  default:
+    display_title: Standard
+    display_options:
+      fields:
+        changed:
+          separator: ', '
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      use_more_text: Mere
+  block_1:
+    display_title: Blok

--- a/config/sync/language/da/views.view.eca_log.yml
+++ b/config/sync/language/da/views.view.eca_log.yml
@@ -1,0 +1,41 @@
+display:
+  default:
+    display_title: Standard
+    display_options:
+      fields:
+        name:
+          label: Bruger
+          separator: ', '
+        timestamp:
+          label: Tid
+        message:
+          label: Meddelelse
+        variables:
+          label: Symboler
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« Første'
+            last: 'Sidste »'
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      filters:
+        timestamp:
+          expose:
+            label: Fra
+        timestamp_1:
+          expose:
+            label: Til
+  page_1:
+    display_title: Side

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -1,0 +1,79 @@
+label: Filer
+display:
+  default:
+    display_title: Standard
+    display_options:
+      title: Filer
+      fields:
+        filename:
+          label: Navn
+          separator: ', '
+        filemime:
+          label: 'MIME type'
+        filesize:
+          label: Størrelse
+        status:
+          label: Status
+          settings:
+            format_custom_false: Midlertidig
+            format_custom_true: Permanent
+        changed:
+          label: Ændringsdato
+        count:
+          label: 'Brugt i'
+        operations:
+          label: Handlinger
+      pager:
+        options:
+          tags:
+            next: 'Næste ›'
+            previous: '‹ Forrige'
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Filter
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      filters:
+        filename:
+          expose:
+            label: Filnavn
+        filemime:
+          expose:
+            label: 'MIME type'
+        status:
+          expose:
+            label: Status
+  page_1:
+    display_options:
+      menu:
+        title: Filer
+  page_2:
+    display_title: 'File usage'
+    display_options:
+      title: 'File usage'
+      fields:
+        entity_label:
+          label: Entity
+        type:
+          label: Entity-type
+        count:
+          label: 'Brug antal'
+      pager:
+        options:
+          tags:
+            next: 'Næste ›'
+            previous: '‹ Forrige'
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      arguments:
+        fid:
+          exception:
+            title: Alle

--- a/config/sync/language/da/views.view.frontpage.yml
+++ b/config/sync/language/da/views.view.frontpage.yml
@@ -1,0 +1,28 @@
+label: Forside
+description: 'Alt indhold som vises på forsiden.'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      pager:
+        options:
+          tags:
+            next: 'Næste ›'
+            previous: '‹ Forrige'
+            first: '« Første'
+            last: 'Sidste »'
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+  feed_1:
+    display_title: Feed
+  page_1:
+    display_title: Side

--- a/config/sync/language/da/views.view.glossary.yml
+++ b/config/sync/language/da/views.view.glossary.yml
@@ -1,0 +1,29 @@
+display:
+  default:
+    display_title: Standard
+    display_options:
+      fields:
+        title:
+          label: Titel
+        name:
+          label: Forfatter
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+  attachment_1:
+    display_title: Bilag
+  page_1:
+    display_title: Side

--- a/config/sync/language/da/views.view.user_admin_people.yml
+++ b/config/sync/language/da/views.view.user_admin_people.yml
@@ -1,0 +1,71 @@
+label: Personer
+display:
+  default:
+    display_title: Standard
+    display_options:
+      title: Personer
+      fields:
+        user_bulk_form:
+          label: Masseopdatering
+        name:
+          label: Brugernavn
+        status:
+          label: Status
+          settings:
+            format_custom_false: Blokeret
+            format_custom_true: Aktiv
+        roles_target_id:
+          label: Roller
+        created:
+          label: 'Medlem i'
+        access:
+          label: 'Seneste tilgang'
+        operations:
+          label: Handlinger
+        mail:
+          separator: ', '
+      pager:
+        options:
+          tags:
+            next: 'Næste ›'
+            previous: '‹ Forrige'
+            first: '« Første'
+            last: 'Sidste »'
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Filter
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      empty:
+        area_text_custom:
+          content: 'Ingen personer til rådighed.'
+      filters:
+        status:
+          group_info:
+            label: Status
+            group_items:
+              1:
+                title: Aktiv
+              2:
+                title: Blokeret
+        roles_target_id:
+          expose:
+            label: Rolle
+        permission:
+          expose:
+            label: Tilladelse
+      use_more_text: mere
+  page_1:
+    display_title: Side
+    display_options:
+      menu:
+        title: Vis
+      tab_options:
+        title: Personer
+        description: 'Håndtér brugerkonti, roller og tilladelser.'

--- a/config/sync/language/da/views.view.watchdog.yml
+++ b/config/sync/language/da/views.view.watchdog.yml
@@ -1,0 +1,54 @@
+label: Hændelseslog
+description: 'Seneste logmeddelelser'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      title: 'Seneste logmeddelelser'
+      fields:
+        nothing:
+          admin_label: Ikon
+        wid:
+          label: WID
+        severity:
+          label: Grad
+        type:
+          label: Type
+        timestamp:
+          label: Dato
+        message:
+          label: Meddelelse
+        name:
+          label: Bruger
+          separator: ', '
+        link:
+          label: Handlinger
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Filter
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      empty:
+        area:
+          admin_label: 'Ingen logbeskeder til rådighed.'
+          content: 'Ingen logbeskeder til rådighed.'
+      filters:
+        type:
+          expose:
+            label: Type
+        severity:
+          expose:
+            label: Grad
+  page:
+    display_title: Side

--- a/config/sync/language/da/views.view.webform_submissions.yml
+++ b/config/sync/language/da/views.view.webform_submissions.yml
@@ -1,0 +1,134 @@
+label: 'Indsendte webforms'
+display:
+  default:
+    display_options:
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      pager:
+        options:
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« Første'
+            last: 'Sidste »'
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      fields:
+        sid:
+          separator: ', '
+        in_draft:
+          separator: ', '
+        created:
+          label: Oprettet
+          separator: ', '
+        remote_addr:
+          label: IP-adresse
+          separator: ', '
+        view_webform_submission:
+          label: Handlinger
+          text: vis
+      header:
+        result:
+          content: 'Viser @start - @end af @total'
+      arguments:
+        in_draft:
+          exception:
+            title: Alle
+      title: 'Indsendte webforms'
+  embed_administer:
+    display_options:
+      fields:
+        webform_submission_bulk_form:
+          action_title: Handling
+        sid:
+          separator: ', '
+        in_draft:
+          separator: ', '
+        sticky:
+          separator: ', '
+        locked:
+          label: Låst
+          separator: ', '
+        created:
+          label: Oprettet
+          separator: ', '
+        completed:
+          label: Gennemført
+          separator: ', '
+        remote_addr:
+          label: IP-adresse
+          separator: ', '
+        operations:
+          label: Handlinger
+      filters:
+        locked:
+          expose:
+            label: Låst
+  embed_manage:
+    display_options:
+      fields:
+        webform_submission_bulk_form:
+          action_title: Handling
+        sid:
+          separator: ', '
+        in_draft:
+          separator: ', '
+        sticky:
+          separator: ', '
+        locked:
+          label: Låst
+          separator: ', '
+        created:
+          label: Oprettet
+          separator: ', '
+        completed:
+          label: Gennemført
+          separator: ', '
+        remote_addr:
+          label: IP-adresse
+          separator: ', '
+        view_webform_submission:
+          label: Handlinger
+          text: vis
+        edit_webform_submission:
+          label: Handlinger
+          text: redigér
+      filters:
+        locked:
+          expose:
+            label: Låst
+  embed_review:
+    display_options:
+      fields:
+        sid:
+          separator: ', '
+        in_draft:
+          separator: ', '
+        sticky:
+          separator: ', '
+        locked:
+          label: Låst
+          separator: ', '
+        created:
+          label: Oprettet
+          separator: ', '
+        completed:
+          label: Gennemført
+          separator: ', '
+        remote_addr:
+          label: IP-adresse
+          separator: ', '
+        view_webform_submission:
+          label: Handlinger
+          text: vis
+      filters:
+        locked:
+          expose:
+            label: Låst

--- a/config/sync/language/da/views.view.who_s_new.yml
+++ b/config/sync/language/da/views.view.who_s_new.yml
@@ -1,0 +1,14 @@
+display:
+  default:
+    display_title: Standard
+    display_options:
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+  block_1:
+    display_options:
+      block_category: Bruger

--- a/config/sync/language/da/views.view.who_s_online.yml
+++ b/config/sync/language/da/views.view.who_s_online.yml
@@ -1,0 +1,15 @@
+display:
+  default:
+    display_title: Standard
+    display_options:
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      filters:
+        access:
+          expose:
+            label: 'Seneste tilgang'

--- a/config/sync/language/da/webform.settings.yml
+++ b/config/sync/language/da/webform.settings.yml
@@ -1,0 +1,13 @@
+settings:
+  default_submit_button_label: Indsend
+  default_reset_button_label: Gendan
+  default_delete_button_label: Slet
+  default_preview_next_button_label: Gennemse
+  default_preview_label: Gennemse
+  dialog_options:
+    narrow:
+      title: Smal
+    wide:
+      title: Bred
+element:
+  default_more_title: Mere

--- a/config/sync/language/da/webform.webform.contact.yml
+++ b/config/sync/language/da/webform.webform.contact.yml
@@ -1,0 +1,3 @@
+title: Kontakt
+settings:
+  confirmation_message: 'Din besked er blevet sendt.'

--- a/config/sync/language/da/webform.webform_options.days.yml
+++ b/config/sync/language/da/webform.webform_options.days.yml
@@ -1,0 +1,1 @@
+category: 'Dato og tid'

--- a/config/sync/language/da/webform.webform_options.languages.yml
+++ b/config/sync/language/da/webform.webform_options.languages.yml
@@ -1,0 +1,2 @@
+label: Sprog
+category: Sprog

--- a/config/sync/language/da/webform.webform_options.months.yml
+++ b/config/sync/language/da/webform.webform_options.months.yml
@@ -1,0 +1,1 @@
+category: 'Dato og tid'

--- a/config/sync/language/da/webform.webform_options.relationship.yml
+++ b/config/sync/language/da/webform.webform_options.relationship.yml
@@ -1,0 +1,1 @@
+label: Forbindelse

--- a/config/sync/language/da/webform.webform_options.size.yml
+++ b/config/sync/language/da/webform.webform_options.size.yml
@@ -1,0 +1,2 @@
+label: Størrelse
+category: Generelt

--- a/config/sync/language/da/webform.webform_options.time_zones.yml
+++ b/config/sync/language/da/webform.webform_options.time_zones.yml
@@ -1,0 +1,2 @@
+label: Tidszoner
+category: 'Dato og tid'

--- a/config/sync/language/da/webform.webform_options.translations.yml
+++ b/config/sync/language/da/webform.webform_options.translations.yml
@@ -1,0 +1,1 @@
+category: Sprog

--- a/config/sync/language/da/webform.webform_options.yes_no.yml
+++ b/config/sync/language/da/webform.webform_options.yes_no.yml
@@ -1,0 +1,1 @@
+category: Generelt

--- a/config/sync/locale.settings.yml
+++ b/config/sync/locale.settings.yml
@@ -1,0 +1,15 @@
+_core:
+  default_config_hash: cSdYeE-_AQETCNZnl8BMFS9-sVn5--VzAYILkpPBUbM
+cache_strings: true
+translate_english: false
+javascript:
+  directory: languages
+translation:
+  use_source: remote_and_local
+  default_filename: '%project-%version.%language.po'
+  default_server_pattern: 'https://ftp.drupal.org/files/translations/%core/%project/%project-%version.%language.po'
+  overwrite_customized: false
+  overwrite_not_customized: true
+  update_interval_days: 0
+  path: sites/default/files/translations
+  import_enabled: true

--- a/web/modules/custom/aabenforms_core/aabenforms_core.info.yml
+++ b/web/modules/custom/aabenforms_core/aabenforms_core.info.yml
@@ -9,3 +9,6 @@ dependencies:
   - drupal:key
   - drupal:encrypt
   - drupal:real_aes
+
+'interface translation project': aabenforms_core
+'interface translation server pattern': 'modules/custom/aabenforms_core/translations/%project.%language.po'

--- a/web/modules/custom/aabenforms_core/translations/aabenforms_core.da.po
+++ b/web/modules/custom/aabenforms_core/translations/aabenforms_core.da.po
@@ -1,0 +1,85 @@
+# Danish translations for aabenforms_core.
+# Covers the admin dashboard shell and its activity panel.
+msgid ""
+msgstr ""
+"Project-Id-Version: aabenforms_core\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Workflow automation backend for Danish municipalities."
+msgstr "Backend til automatisering af arbejdsgange i danske kommuner."
+
+msgid "Evidence traces"
+msgstr "Evidensspor"
+
+msgid "Readiness board"
+msgstr "Parathedsoversigt"
+
+msgid "New workflow"
+msgstr "Ny arbejdsgang"
+
+msgid "Send test Digital Post"
+msgstr "Send test-Digital Post"
+
+msgid "Open ECA modeller"
+msgstr "Åbn ECA-modellering"
+
+msgid "View submissions"
+msgstr "Vis indsendelser"
+
+msgid "Recent activity"
+msgstr "Seneste aktivitet"
+
+msgid "All"
+msgstr "Alle"
+
+msgid "Audit"
+msgstr "Audit"
+
+msgid "Errors"
+msgstr "Fejl"
+
+msgid "No events yet."
+msgstr "Ingen hændelser endnu."
+
+msgid "View activity"
+msgstr "Vis aktivitet"
+
+msgid "Audit Log"
+msgstr "Auditlog"
+
+msgid "events (24h)"
+msgstr "hændelser (24 t)"
+
+msgid "Failures (24h)"
+msgstr "Fejl (24 t)"
+
+msgid "Mock Services"
+msgstr "Mock-tjenester"
+
+msgid "Running"
+msgstr "Kører"
+
+msgid "Down"
+msgstr "Nede"
+
+msgid "Degraded"
+msgstr "Forringet"
+
+msgid "Unavailable"
+msgstr "Utilgængelig"
+
+msgid "Mock in prod"
+msgstr "Mock i produktion"
+
+msgid "Live test"
+msgstr "Livetest"
+
+msgid "(no subject)"
+msgstr "(intet emne)"
+
+msgid "Not set"
+msgstr "Ikke angivet"

--- a/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.info.yml
+++ b/web/modules/custom/aabenforms_digital_post/aabenforms_digital_post.info.yml
@@ -8,3 +8,6 @@ dependencies:
   - aabenforms_core
 
 configure: aabenforms_digital_post.settings
+
+'interface translation project': aabenforms_digital_post
+'interface translation server pattern': 'modules/custom/aabenforms_digital_post/translations/%project.%language.po'

--- a/web/modules/custom/aabenforms_digital_post/translations/aabenforms_digital_post.da.po
+++ b/web/modules/custom/aabenforms_digital_post/translations/aabenforms_digital_post.da.po
@@ -1,0 +1,42 @@
+# Danish translations for aabenforms_digital_post (dashboard card).
+msgid ""
+msgstr ""
+"Project-Id-Version: aabenforms_digital_post\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Sender CVR"
+msgstr "Afsender-CVR"
+
+msgid "Sent (24h)"
+msgstr "Sendt (24 t)"
+
+msgid "Fake DB"
+msgstr "Fake DB"
+
+msgid "Digital Post queue"
+msgstr "Digital Post-kø"
+
+msgid "In queue"
+msgstr "I kø"
+
+msgid "Sent"
+msgstr "Sendt"
+
+msgid "Manage queue"
+msgstr "Administrér kø"
+
+msgid "Clear"
+msgstr "Tom"
+
+msgid "Pending"
+msgstr "Afventer"
+
+msgid "@n in flight"
+msgstr "@n undervejs"
+
+msgid "@n need attention"
+msgstr "@n kræver opmærksomhed"

--- a/web/modules/custom/aabenforms_mitid/aabenforms_mitid.info.yml
+++ b/web/modules/custom/aabenforms_mitid/aabenforms_mitid.info.yml
@@ -9,3 +9,6 @@ dependencies:
   - drupal:openid_connect
   - aabenforms_core:aabenforms_core
   - aabenforms_webform:aabenforms_webform
+
+'interface translation project': aabenforms_mitid
+'interface translation server pattern': 'modules/custom/aabenforms_mitid/translations/%project.%language.po'

--- a/web/modules/custom/aabenforms_mitid/translations/aabenforms_mitid.da.po
+++ b/web/modules/custom/aabenforms_mitid/translations/aabenforms_mitid.da.po
@@ -1,0 +1,18 @@
+# Danish translations for aabenforms_mitid (dashboard card).
+msgid ""
+msgstr ""
+"Project-Id-Version: aabenforms_mitid\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Provider"
+msgstr "Udbyder"
+
+msgid "Logins (24h)"
+msgstr "Logins (24 t)"
+
+msgid "Configure"
+msgstr "Indstil"

--- a/web/modules/custom/aabenforms_webform/aabenforms_webform.info.yml
+++ b/web/modules/custom/aabenforms_webform/aabenforms_webform.info.yml
@@ -8,3 +8,6 @@ php: ^8.3
 dependencies:
   - drupal:webform
   - aabenforms_core:aabenforms_core
+
+'interface translation project': aabenforms_webform
+'interface translation server pattern': 'modules/custom/aabenforms_webform/translations/%project.%language.po'

--- a/web/modules/custom/aabenforms_webform/translations/aabenforms_webform.da.po
+++ b/web/modules/custom/aabenforms_webform/translations/aabenforms_webform.da.po
@@ -1,0 +1,21 @@
+# Danish translations for aabenforms_webform (dashboard card).
+msgid ""
+msgstr ""
+"Project-Id-Version: aabenforms_webform\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Webforms"
+msgstr "Webformularer"
+
+msgid "webforms"
+msgstr "webformularer"
+
+msgid "Submissions (7d)"
+msgstr "Indsendelser (7 d)"
+
+msgid "Browse webforms"
+msgstr "Se webformularer"

--- a/web/modules/custom/aabenforms_workflows/aabenforms_workflows.info.yml
+++ b/web/modules/custom/aabenforms_workflows/aabenforms_workflows.info.yml
@@ -12,3 +12,6 @@ dependencies:
   - modeler_api:modeler_api
   - bpmn_io:bpmn_io
   - modeler:modeler
+
+'interface translation project': aabenforms_workflows
+'interface translation server pattern': 'modules/custom/aabenforms_workflows/translations/%project.%language.po'

--- a/web/modules/custom/aabenforms_workflows/translations/aabenforms_workflows.da.po
+++ b/web/modules/custom/aabenforms_workflows/translations/aabenforms_workflows.da.po
@@ -1,0 +1,332 @@
+# Danish translations for aabenforms_workflows.
+# Covers the workflow wizard, template browser, flow overview and the
+# Workflows dashboard card - the flow-builder surfaces a kommune admin sees.
+msgid ""
+msgstr ""
+"Project-Id-Version: aabenforms_workflows\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Step 1: Select a Workflow Template"
+msgstr "Trin 1: Vælg en arbejdsgangsskabelon"
+
+msgid "Step 2: Flow Preview"
+msgstr "Trin 2: Forhåndsvisning af flow"
+
+msgid "Step 3: Configure Webform Integration"
+msgstr "Trin 3: Opsæt webformular"
+
+msgid "Step 4: Configure Actions"
+msgstr "Trin 4: Opsæt handlinger"
+
+msgid "Step 5: Data Visibility (Optional)"
+msgstr "Trin 5: Datasynlighed (valgfrit)"
+
+msgid "Step 6: Preview and Activate"
+msgstr "Trin 6: Gennemse og aktivér"
+
+msgid "Select Template"
+msgstr "Vælg skabelon"
+
+msgid "Flow Preview"
+msgstr "Forhåndsvisning"
+
+msgid "Configure Webform"
+msgstr "Opsæt webformular"
+
+msgid "Configure Actions"
+msgstr "Opsæt handlinger"
+
+msgid "Data Visibility"
+msgstr "Datasynlighed"
+
+msgid "Preview & Activate"
+msgstr "Gennemse og aktivér"
+
+msgid "Available Templates"
+msgstr "Tilgængelige skabeloner"
+
+msgid "Choose a pre-built workflow template that matches your needs. Each template is designed for common municipality use cases."
+msgstr "Vælg en færdigbygget arbejdsgangsskabelon, der passer til jeres behov. Hver skabelon er designet til almindelige kommunale opgaver."
+
+msgid "Next"
+msgstr "Næste"
+
+msgid "Back"
+msgstr "Tilbage"
+
+msgid "Cancel"
+msgstr "Annullér"
+
+msgid "Create Workflow"
+msgstr "Opret arbejdsgang"
+
+msgid "- Select webform -"
+msgstr "- Vælg webformular -"
+
+msgid "Select Webform"
+msgstr "Vælg webformular"
+
+msgid "Which webform should trigger this workflow?"
+msgstr "Hvilken webformular skal starte denne arbejdsgang?"
+
+msgid "Connect this workflow to a webform and map the form fields to workflow variables."
+msgstr "Forbind arbejdsgangen til en webformular, og knyt formularfelterne til arbejdsgangens variabler."
+
+msgid "Select a webform to configure field mappings."
+msgstr "Vælg en webformular for at opsætte feltkoblinger."
+
+msgid "Workflow Settings"
+msgstr "Indstillinger for arbejdsgang"
+
+msgid "Action Configuration"
+msgstr "Opsætning af handlinger"
+
+msgid "Customize email templates, approval pages, and notification settings for each workflow action."
+msgstr "Tilpas e-mailskabeloner, godkendelsessider og notifikationer for hver handling i arbejdsgangen."
+
+msgid "Configure which data is visible to each party involved in the workflow. This ensures GDPR compliance."
+msgstr "Vælg hvilke oplysninger hver part i arbejdsgangen kan se. Det understøtter efterlevelse af GDPR."
+
+msgid "Note: CPR numbers and other sensitive data are always encrypted per GDPR requirements."
+msgstr "Bemærk: CPR-numre og andre følsomme oplysninger krypteres altid i overensstemmelse med GDPR."
+
+msgid "Full transparency - All parties see all data"
+msgstr "Fuld gennemsigtighed - alle parter ser alle oplysninger"
+
+msgid "Restricted - Each party sees only relevant data"
+msgstr "Begrænset - hver part ser kun relevante oplysninger"
+
+msgid "Visibility Mode"
+msgstr "Synlighedstilstand"
+
+msgid "This template does not require data visibility configuration."
+msgstr "Denne skabelon kræver ikke opsætning af datasynlighed."
+
+msgid "Review your workflow configuration and activate it."
+msgstr "Gennemse opsætningen af arbejdsgangen, og aktivér den."
+
+msgid "Workflow Name"
+msgstr "Navn på arbejdsgang"
+
+msgid "Give this workflow a descriptive name"
+msgstr "Giv arbejdsgangen et sigende navn"
+
+msgid "Configuration Summary"
+msgstr "Opsummering"
+
+msgid "Workflow Steps"
+msgstr "Arbejdsgangens trin"
+
+msgid "Activate workflow immediately"
+msgstr "Aktivér arbejdsgangen med det samme"
+
+msgid "If unchecked, workflow will be created but not active."
+msgstr "Hvis feltet ikke er markeret, oprettes arbejdsgangen uden at være aktiv."
+
+msgid "Workflow \"@label\" has been created successfully!"
+msgstr "Arbejdsgangen \"@label\" er oprettet!"
+
+msgid "Failed to create workflow: @message"
+msgstr "Arbejdsgangen kunne ikke oprettes: @message"
+
+msgid "Could not determine which template to instantiate. Please start the wizard again from the template browser."
+msgstr "Det kunne ikke afgøres, hvilken skabelon der skulle bruges. Start guiden igen fra skabelonoversigten."
+
+msgid "Template Preview"
+msgstr "Forhåndsvisning af skabelon"
+
+msgid "Step @num: @name"
+msgstr "Trin @num: @name"
+
+msgid "Template not found."
+msgstr "Skabelonen blev ikke fundet."
+
+msgid "This is your workflow as it will run - generated from the live ECA flow. Branch labels show the gating condition (for example MitID = verified)."
+msgstr "Sådan kører arbejdsgangen - genereret fra det aktive ECA-flow. Grenetiketterne viser betingelsen (fx MitID = verificeret)."
+
+msgid "<strong>Template:</strong> @name"
+msgstr "<strong>Skabelon:</strong> @name"
+
+msgid "<strong>Webform:</strong> @form"
+msgstr "<strong>Webformular:</strong> @form"
+
+msgid "Active Workflows"
+msgstr "Aktive arbejdsgange"
+
+msgid "Workflow Templates"
+msgstr "Arbejdsgangsskabeloner"
+
+msgid "Use This Template"
+msgstr "Brug denne skabelon"
+
+msgid "No workflow templates available."
+msgstr "Ingen arbejdsgangsskabeloner tilgængelige."
+
+msgid "No workflows created yet. Use the templates below to create your first workflow."
+msgstr "Der er ikke oprettet arbejdsgange endnu. Brug skabelonerne nedenfor til at oprette den første."
+
+msgid "Create new approval workflows from pre-built templates designed for Danish municipalities. No technical knowledge required."
+msgstr "Opret nye godkendelsesarbejdsgange fra færdigbyggede skabeloner designet til danske kommuner. Ingen teknisk viden nødvendig."
+
+msgid "View Form"
+msgstr "Vis formular"
+
+msgid "Edit"
+msgstr "Redigér"
+
+msgid "Delete"
+msgstr "Slet"
+
+msgid "Status"
+msgstr "Status"
+
+msgid "Active"
+msgstr "Aktiv"
+
+msgid "Inactive"
+msgstr "Inaktiv"
+
+msgid "Created"
+msgstr "Oprettet"
+
+msgid "Template"
+msgstr "Skabelon"
+
+msgid "Webform"
+msgstr "Webformular"
+
+msgid "Operations"
+msgstr "Handlinger"
+
+msgid "Are you sure you want to delete the workflow instance %workflow?"
+msgstr "Er du sikker på, at du vil slette arbejdsgangen %workflow?"
+
+msgid "This will delete the workflow configuration and all associated ECA rules. This action cannot be undone."
+msgstr "Dette sletter arbejdsgangens opsætning og alle tilhørende ECA-regler. Handlingen kan ikke fortrydes."
+
+msgid "Delete Workflow"
+msgstr "Slet arbejdsgang"
+
+msgid "Workflow instance %workflow has been deleted."
+msgstr "Arbejdsgangen %workflow er slettet."
+
+msgid "Failed to delete workflow instance %workflow."
+msgstr "Arbejdsgangen %workflow kunne ikke slettes."
+
+msgid "No workflow instances found."
+msgstr "Ingen arbejdsgange fundet."
+
+msgid "Workflows"
+msgstr "Arbejdsgange"
+
+msgid "active workflows"
+msgstr "aktive arbejdsgange"
+
+msgid "Built with the wizard"
+msgstr "Bygget med guiden"
+
+msgid "Templates available"
+msgstr "Skabeloner til rådighed"
+
+msgid "Browse templates"
+msgstr "Se skabeloner"
+
+msgid "Flow overview"
+msgstr "Flowoversigt"
+
+msgid "Flows grouped by the journey they belong to. Stages run top to bottom: intake, event-driven steps, decision. The raw model list remains at <a href=\":url\">ECA models</a>."
+msgstr "Flows grupperet efter det forløb, de hører til. Trinnene læses oppefra og ned: modtagelse, hændelsesdrevne trin, afgørelse. Den rå modelliste findes fortsat under <a href=\":url\">ECA-modeller</a>."
+
+msgid "@enabled enabled of @total flows in @journeys journeys."
+msgstr "@enabled aktiveret af @total flows i @journeys forløb."
+
+msgid "@label (@count flows)"
+msgstr "@label (@count flows)"
+
+msgid "@label (@count)"
+msgstr "@label (@count)"
+
+msgid "Event-driven steps without a journey"
+msgstr "Hændelsesdrevne trin uden forløb"
+
+msgid "Scheduled (cron)"
+msgstr "Planlagt (cron)"
+
+msgid "Other"
+msgstr "Øvrige"
+
+msgid "On submission (@webform)"
+msgstr "Ved indsendelse (@webform)"
+
+msgid "On update (@webform)"
+msgstr "Ved opdatering (@webform)"
+
+msgid "Event: @event"
+msgstr "Hændelse: @event"
+
+msgid "Cron: @frequency"
+msgstr "Cron: @frequency"
+
+msgid "Wizard"
+msgstr "Guide"
+
+msgid "Hand-authored"
+msgstr "Håndbygget"
+
+msgid "Enabled"
+msgstr "Aktiveret"
+
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+msgid "Flow"
+msgstr "Flow"
+
+msgid "Machine name"
+msgstr "Maskinnavn"
+
+msgid "Trigger"
+msgstr "Udløser"
+
+msgid "Source"
+msgstr "Kilde"
+
+msgid "Graph"
+msgstr "Graf"
+
+msgid "No flows."
+msgstr "Ingen flows."
+
+msgid "Elections"
+msgstr "Valg"
+
+msgid "Total elections"
+msgstr "Valg i alt"
+
+msgid "Browse elections"
+msgstr "Se valg"
+
+msgid "Voting open"
+msgstr "Afstemning åben"
+
+msgid "Awaiting publish"
+msgstr "Afventer offentliggørelse"
+
+msgid "Published"
+msgstr "Offentliggjort"
+
+msgid "Latest"
+msgstr "Seneste"
+
+msgid "Create Workflow from Template"
+msgstr "Opret arbejdsgang fra skabelon"
+
+msgid "Create and manage approval workflows from templates"
+msgstr "Opret og administrér godkendelsesarbejdsgange fra skabeloner"
+
+msgid "All ECA flows grouped by citizen journey"
+msgstr "Alle ECA-flows grupperet efter borgerforløb"


### PR DESCRIPTION
Part of #198 (items 1 and 2 of the four; leaves the issue open for the BPMN template metadata and the workflow.steps language sweep).

## What lands
- `language` + `locale` enabled, Danish added. **Site default stays English**; admins opt into Danish per user via the account-administration-pages negotiation method.
- `da.po` in each of the five demo-visible modules (~140 strings): wizard, template browser, flow overview, dashboard shell + cards. Strings from #201/#202 are included so coverage is complete once the stack merges.
- Official Danish core/contrib packs imported (7k+ strings) - toolbar, menus, buttons all Danish.
- Config export: `language.entity.da`, negotiation, and the da config-translation collection (82 files).

## Verified (Playwright, admin with da preference)
Wizard fully Danish: route title "Opret arbejdsgang fra skabelon", "Trin 1: Vælg en arbejdsgangsskabelon", progress "Vælg skabelon / Forhåndsvisning / Opsæt webformular / Opsæt handlinger / Datasynlighed / Gennemse og aktivér". Dashboard: Arbejdsgange, Webformularer, Digital Post-kø, Auditlog, Valg, Mock-tjenester. An admin without the preference still sees English.

## Deploy notes
After `drush cim`: `drush locale:check && drush locale:update && drush cr`. Fallback per module: `drush locale:import da modules/custom/<m>/translations/<m>.da.po --type=customized --override=all`.

## Still open on #198
Template names/descriptions bypass t() (BPMN documentation text) and citizen-facing `workflow.steps` descriptions mix da/en per flow config - both need their own pass.